### PR TITLE
Fixes for bundler file parsing

### DIFF
--- a/pkg/lockfile/extract.go
+++ b/pkg/lockfile/extract.go
@@ -77,7 +77,7 @@ func ExtractDeps(f DepFile, extractAs string, enabledParsers map[string]bool) (L
 			for _, matcher := range matchers {
 				matchError := matchWithFile(f, packages, matcher)
 				if matchError != nil {
-					_, _ = fmt.Fprintf(os.Stderr, "there was an error matching the source file: %s\n", matchError.Error())
+					_, _ = fmt.Fprintf(os.Stderr, "there was an error matching the source file %s: %s\n", f.Path(), matchError.Error())
 				}
 			}
 		}

--- a/pkg/lockfile/extractor.go
+++ b/pkg/lockfile/extractor.go
@@ -115,7 +115,7 @@ func ExtractFromFile(pathToLockfile string, extractor Extractor) ([]PackageDetai
 			for _, matcher := range matchers {
 				matchError := matchWithFile(f, packages, matcher)
 				if matchError != nil {
-					_, _ = fmt.Fprintf(os.Stderr, "there was an error matching the source file: %s\n", matchError.Error())
+					_, _ = fmt.Fprintf(os.Stderr, "there was an error matching the source file %s: %s\n", pathToLockfile, matchError.Error())
 				}
 			}
 		}

--- a/pkg/lockfile/fixtures/bundler/platform-specific/Gemfile
+++ b/pkg/lockfile/fixtures/bundler/platform-specific/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'zeitwerk', '2.6.0'
+
+# Only installed in jruby platform
+platform :jruby do
+  gem 'tzinfo-data'
+end

--- a/pkg/lockfile/fixtures/bundler/platform-specific/Gemfile.lock
+++ b/pkg/lockfile/fixtures/bundler/platform-specific/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    zeitwerk (2.6.0)
+
+PLATFORMS
+  aarch64-linux
+  ruby
+
+DEPENDENCIES
+  tzinfo-data
+  zeitwerk (= 2.6.0)
+
+BUNDLED WITH
+   2.5.11

--- a/pkg/lockfile/match-gemspec.go
+++ b/pkg/lockfile/match-gemspec.go
@@ -1,7 +1,6 @@
 package lockfile
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +37,8 @@ func (matcher GemspecFileMatcher) GetSourceFile(lockfile DepFile) (DepFile, erro
 		}
 	}
 
-	return nil, errors.New("no " + gemspecFileSuffix + " file found")
+	// .gemspec are optional, Gemfile.lock sometimes has no .gemspec and that is fine
+	return nil, nil
 }
 
 func (matcher GemspecFileMatcher) Match(sourceFile DepFile, packages []PackageDetails) error {

--- a/pkg/lockfile/match-gemspec_test.go
+++ b/pkg/lockfile/match-gemspec_test.go
@@ -24,7 +24,7 @@ func TestGemspecFileMatcher_GetSourceFile_FileDoesNotExist(t *testing.T) {
 
 	sourceFile, err := gemspecFileMatcher.GetSourceFile(lockFile)
 	assert.Nil(t, sourceFile)
-	assert.Error(t, err, "no .gemspec file found")
+	assert.NoError(t, err)
 }
 
 func TestGemspecFileMatcher_GetSourceFile(t *testing.T) {

--- a/pkg/lockfile/matcher-helpers_test.go
+++ b/pkg/lockfile/matcher-helpers_test.go
@@ -38,8 +38,8 @@ type FailingMatcher struct {
 	Error error
 }
 
-func (m FailingMatcher) GetSourceFile(_ lockfile.DepFile) (lockfile.DepFile, error) {
-	return nil, nil
+func (m FailingMatcher) GetSourceFile(f lockfile.DepFile) (lockfile.DepFile, error) {
+	return f, nil
 }
 
 func (m FailingMatcher) Match(_ lockfile.DepFile, _ []lockfile.PackageDetails) error {

--- a/pkg/lockfile/matcher.go
+++ b/pkg/lockfile/matcher.go
@@ -7,9 +7,12 @@ type Matcher interface {
 
 func matchWithFile(lockfile DepFile, packages []PackageDetails, matcher Matcher) error {
 	sourceFile, err := matcher.GetSourceFile(lockfile)
-
 	if err != nil {
 		return err
+	}
+
+	if sourceFile == nil {
+		return nil
 	}
 
 	return matcher.Match(sourceFile, packages)

--- a/pkg/lockfile/parse-gemfile-lock.go
+++ b/pkg/lockfile/parse-gemfile-lock.go
@@ -81,13 +81,27 @@ func (parser *gemfileLockfileParser) addDependency(name string, version string) 
 	}
 
 	// find the package that exists already from parsing the `GEM` section
-	// and set it as a direct dep
-
+	// if not found, add it as a direct dep if found just set it as a direct dep
+	found := false
 	for i, dep := range parser.dependencies {
 		if dep.Name == name {
 			parser.dependencies[i].IsDirect = true
-			return
+			found = true
+
+			break
 		}
+	}
+
+	if !found {
+		parser.dependencies = append(parser.dependencies, PackageDetails{
+			Name:           name,
+			Version:        version,
+			PackageManager: models.Bundler,
+			Ecosystem:      BundlerEcosystem,
+			CompareAs:      BundlerEcosystem,
+			Commit:         parser.currentGemCommit,
+			IsDirect:       true,
+		})
 	}
 }
 

--- a/pkg/lockfile/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/parse-gemfile-lock_test.go
@@ -906,3 +906,31 @@ func TestParseGemfileLock_HasGitGem(t *testing.T) {
 		},
 	})
 }
+
+func TestParseGemfileLock_PlatformSpecificDependencyIsParsed(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/platform-specific/Gemfile.lock")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "zeitwerk",
+			Version:        "2.6.0",
+			PackageManager: models.Bundler,
+			Ecosystem:      lockfile.BundlerEcosystem,
+			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
+		},
+		{
+			Name:           "tzinfo-data",
+			Version:        "",
+			PackageManager: models.Bundler,
+			Ecosystem:      lockfile.BundlerEcosystem,
+			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
+		},
+	})
+}


### PR DESCRIPTION
<!--- * 
Notes:
- Jira ticket ID needs to be in PR Title.
- All PRs must have proper test coverage for the change they introduce. Even when solving an incident: You don’t want an incident to escalate!
* --->

## 🎯 Motivation 
<!--- * Why did we add this change. * --->

User reported issue fails to run scanner on projects where some dependencies are platform specific and the `Gemfile.lock` was generated for a different platform which only contains a subset of the dependencies.


## 📎 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | N/A


## 📋 Summary
<!--- * What did we change and How is it solving the Why. * --->

- Port of https://github.com/DataDog/osv-scanner/pull/167
- Allow scanning without returning an error of projects with just `Gemfile.lock` and `Gemfile`, which do not contain the optional `*.gemspec`
- Read all dependencies from `Gemfile.lock` even the platform specific ones that might not be installed in the platform where the `Gemfile.lock` was generated but might be downloaded in other platforms.

## 🧪 Testing
<!--- * Describe how you tested your work. * --->
- [X] New tests were added for new logic.
- [X] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.


## ✅ Staging validation
- [X] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.


## 🔙 Recovery
Notes for on-call - **select only one**:
- [X] The change can be rolled back.
- [ ] Do not roll back. Why?:


<!--- * Read 'logs-backend/.github/PULL_REQUEST_TEMPLATE/README.md' for usage details. * -->
