### PR TITLE
[BACKPORT FROM OSV] Stop reporting name and version location on external parent pom.xml files

### DIFF
--- a/pkg/lockfile/fixtures/maven/with-external-parent.xml
+++ b/pkg/lockfile/fixtures/maven/with-external-parent.xml
@@ -1,0 +1,15 @@
+<project>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-dependencies</artifactId>
+    <version>2.7.3</version>
+  </parent>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-amqp</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -351,9 +351,15 @@ func (e MavenLockExtractor) mergeLockfiles(childLockfile *MavenLockFile, parentL
 
 func (e MavenLockExtractor) enrichDependencies(path string, dependencies []MavenLockDependency) MavenLockDependencyHolder {
 	result := make([]MavenLockDependency, len(dependencies))
+	// We don't want to have location kept if it has been found outside the repository
+	shouldEnrich := !strings.HasPrefix(path, "https")
 	for index, dependency := range dependencies {
-		if len(dependency.SourceFile) == 0 {
+		if len(dependency.SourceFile) == 0 && shouldEnrich {
 			dependency.SourceFile = path
+		} else if !shouldEnrich {
+			dependency.FilePosition = models.FilePosition{}
+			dependency.Version.FilePosition = models.FilePosition{}
+			dependency.ArtifactID.FilePosition = models.FilePosition{}
 		}
 		result[index] = dependency
 	}
@@ -362,9 +368,13 @@ func (e MavenLockExtractor) enrichDependencies(path string, dependencies []Maven
 }
 
 func (e MavenLockExtractor) enrichProperties(path string, properties map[string]MavenLockProperty) MavenLockProperties {
+	shouldEnrich := !strings.HasPrefix(path, "https")
 	for key, property := range properties {
-		if len(property.SourceFile) == 0 {
+		if len(property.SourceFile) == 0 && shouldEnrich {
 			property.SourceFile = path
+		} else if !shouldEnrich {
+			property.Property.FilePosition = models.FilePosition{}
+			property.SourceFile = ""
 		}
 		properties[key] = property
 	}

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -268,6 +268,42 @@ func TestParseMavenLock_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseMavenLock_WithExternalParent(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/maven/with-external-parent.xml"))
+	packages, err := lockfile.ParseMavenLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "org.apache.activemq:activemq-amqp",
+			Version:        "5.16.5",
+			PackageManager: models.Maven,
+			Ecosystem:      lockfile.MavenEcosystem,
+			CompareAs:      lockfile.MavenEcosystem,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 10, End: 13},
+				Column:   models.Position{Start: 5, End: 18},
+				Filename: path,
+			},
+			VersionLocation: &models.FilePosition{},
+			NameLocation: &models.FilePosition{
+				Line:     models.Position{Start: 12, End: 12},
+				Column:   models.Position{Start: 19, End: 32},
+				Filename: path,
+			},
+			IsDirect: true,
+		},
+	})
+}
+
 func TestParseMavenLock_OnePackageWithMultipleVersionVariable(t *testing.T) {
 	t.Parallel()
 	dir, err := os.Getwd()
@@ -1638,8 +1674,6 @@ func TestParseMavenLock_SpringRemote(t *testing.T) {
 	packages, err := lockfile.ParseMavenLock(path)
 	require.NoError(t, err)
 
-	remotePom := "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/3.4.0/spring-boot-dependencies-3.4.0.pom"
-
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "org.springframework.boot:spring-boot-starter-test",
@@ -1657,13 +1691,9 @@ func TestParseMavenLock_SpringRemote(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 40},
 				Filename: path,
 			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1811, End: 1811},
-				Column:   models.Position{Start: 18, End: 23},
-				Filename: remotePom,
-			},
-			DepGroups: []string{"test"},
-			IsDirect:  true,
+			VersionLocation: &models.FilePosition{},
+			DepGroups:       []string{"test"},
+			IsDirect:        true,
 		},
 		{
 			Name:           "org.springframework.boot:spring-boot-starter-web",
@@ -1681,12 +1711,8 @@ func TestParseMavenLock_SpringRemote(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 39},
 				Filename: path,
 			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1836, End: 1836},
-				Column:   models.Position{Start: 18, End: 23},
-				Filename: remotePom,
-			},
-			IsDirect: true,
+			VersionLocation: &models.FilePosition{},
+			IsDirect:        true,
 		},
 	})
 }


### PR DESCRIPTION
The entire PR come from https://github.com/DataDog/osv-scanner/pull/169

## Context

When the scanner encounter a pom.xml file, it starts reading it recursively (a pom.xml file can have a parent pom.xml).  A parent pom can be defined either in the repository or outside the repository.

When the parent pom is outside the repository, it is declared as a parent artifact, which can either be a public or private one. Usually, we do not read external resources from the scanner, but to be able to resolve some springboot versions (which are defined using maven `dependencyManagement` tag in a dedicated public library) we previously added a fallback downloading a pom.xml from Maven Central to integrate it as if it was in the current repository.

## What is this PR doing ?

Until this PR, we were reporting the location of name and versions defined in any parent pom, even if they was from a public library. This have an effect on the product as the filepath of a public library : 
1. Is an URL
2. Is by definition not related to the repository itself

This PR removes all location information on anything scanned outside of the repository.
