### PR TITLE
Use `DataDog` instead of `datadog` as the module name

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"slices"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/osvscanner"
+	"github.com/DataDog/datadog-sbom-generator/pkg/osvscanner"
 
-	"github.com/datadog/datadog-sbom-generator/cmd/osv-scanner/scan"
-	"github.com/datadog/datadog-sbom-generator/internal/version"
-	"github.com/datadog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/cmd/osv-scanner/scan"
+	"github.com/DataDog/datadog-sbom-generator/internal/version"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/osv-scanner/scan/main.go
+++ b/cmd/osv-scanner/scan/main.go
@@ -8,10 +8,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/osvscanner"
-	"github.com/datadog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/pkg/osvscanner"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 	"golang.org/x/term"
 
 	"github.com/urfave/cli/v2"

--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 	"github.com/go-git/go-git/v5"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/datadog/datadog-sbom-generator
+module github.com/DataDog/datadog-sbom-generator
 
 go 1.22
 

--- a/internal/customgitignore/dir_test.go
+++ b/internal/customgitignore/dir_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/customgitignore"
+	"github.com/DataDog/datadog-sbom-generator/internal/customgitignore"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"

--- a/internal/json/utils.go
+++ b/internal/json/utils.go
@@ -3,7 +3,7 @@ package json
 import (
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 /*

--- a/internal/output/cyclonedx.go
+++ b/internal/output/cyclonedx.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
-	"github.com/datadog/datadog-sbom-generator/internal/output/sbom"
-	"github.com/datadog/datadog-sbom-generator/internal/utility/purl"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/output/sbom"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/purl"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 // This method creates a CycloneDX SBOM and returns it. Error being returned here are from components being filtered during PURL grouping

--- a/internal/output/cyclonedx_test.go
+++ b/internal/output/cyclonedx_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/output"
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 )
 
 func TestPrintCycloneDX15Results_WithDependencies(t *testing.T) {

--- a/internal/output/form_test.go
+++ b/internal/output/form_test.go
@@ -3,7 +3,7 @@ package output_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
 )
 
 func TestForm(t *testing.T) {

--- a/internal/output/helpers_test.go
+++ b/internal/output/helpers_test.go
@@ -3,7 +3,7 @@ package output_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type outputTestCaseArgs struct {

--- a/internal/output/machinejson.go
+++ b/internal/output/machinejson.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 // PrintJSONResults writes results to the provided writer in JSON format

--- a/internal/output/machinejson_test.go
+++ b/internal/output/machinejson_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/output"
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 )
 
 func TestPrintJSONResults_WithVulnerabilities(t *testing.T) {

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/purl"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/purl"
 
 	"golang.org/x/exp/maps"
 
 	"github.com/CycloneDX/cyclonedx-go"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type PackageProcessingHook = func(component *cyclonedx.Component, details models.PackageVulns)

--- a/internal/output/sbom/models.go
+++ b/internal/output/sbom/models.go
@@ -1,7 +1,7 @@
 package sbom
 
 import (
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/CycloneDX/cyclonedx-go"
 )

--- a/internal/output/testmain_test.go
+++ b/internal/output/testmain_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/semantic/compare_test.go
+++ b/internal/semantic/compare_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/semantic"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/semantic"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func expectedResult(t *testing.T, comparator string) int {

--- a/internal/semantic/parse.go
+++ b/internal/semantic/parse.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 var ErrUnsupportedEcosystem = errors.New("unsupported ecosystem")

--- a/internal/semantic/parse_test.go
+++ b/internal/semantic/parse_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/semantic"
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/semantic"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func TestParse(t *testing.T) {

--- a/internal/semantic/version-alpine.go
+++ b/internal/semantic/version-alpine.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 type alpineNumberComponent struct {

--- a/internal/semantic/version-maven.go
+++ b/internal/semantic/version-maven.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 type mavenVersionToken struct {

--- a/internal/semantic/version-packagist.go
+++ b/internal/semantic/version-packagist.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 func canonicalizePackagistVersion(v string) string {

--- a/internal/semantic/version-pypi.go
+++ b/internal/semantic/version-pypi.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 type PyPIVersion struct {

--- a/internal/semantic/version-semver-like.go
+++ b/internal/semantic/version-semver-like.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 // SemverLikeVersion is a version that is _like_ a version as defined by the

--- a/internal/testutility/normalize.go
+++ b/internal/testutility/normalize.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 // Attempts to normalize any file paths in the given `output` so that they can

--- a/internal/utility/fileposition/column.go
+++ b/internal/utility/fileposition/column.go
@@ -1,7 +1,7 @@
 package fileposition
 
 import (
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 var wordRe = cachedregexp.MustCompile(`[^\s\r\n]+`)

--- a/internal/utility/fileposition/fileposition.go
+++ b/internal/utility/fileposition/fileposition.go
@@ -1,6 +1,6 @@
 package fileposition
 
-import "github.com/datadog/datadog-sbom-generator/pkg/models"
+import "github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 func IsFilePositionExtractedSuccessfully(filePosition models.FilePosition) bool {
 	return filePosition.Line.Start > 0 && filePosition.Line.End > 0 && filePosition.Column.Start > 0 && filePosition.Column.End > 0 && filePosition.Filename != ""

--- a/internal/utility/fileposition/json.go
+++ b/internal/utility/fileposition/json.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 var shouldDebugInJSON bool

--- a/internal/utility/fileposition/json_test.go
+++ b/internal/utility/fileposition/json_test.go
@@ -3,7 +3,7 @@ package fileposition
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/utility/fileposition/string.go
+++ b/internal/utility/fileposition/string.go
@@ -4,9 +4,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func BytesToLines(data []byte) []string {

--- a/internal/utility/fileposition/string_test.go
+++ b/internal/utility/fileposition/string_test.go
@@ -3,7 +3,7 @@ package fileposition
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/utility/fileposition/toml.go
+++ b/internal/utility/fileposition/toml.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 var shouldDebugInTOML bool

--- a/internal/utility/fileposition/toml_test.go
+++ b/internal/utility/fileposition/toml_test.go
@@ -3,7 +3,7 @@ package fileposition
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/utility/location/location.go
+++ b/internal/utility/location/location.go
@@ -1,8 +1,8 @@
 package location
 
 import (
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func NewPackageLocations(block models.FilePosition, name *models.FilePosition, version *models.FilePosition) models.PackageLocations {

--- a/internal/utility/purl/composer.go
+++ b/internal/utility/purl/composer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func FromComposer(packageInfo models.PackageInfo) (namespace string, name string, err error) {

--- a/internal/utility/purl/composer_test.go
+++ b/internal/utility/purl/composer_test.go
@@ -3,9 +3,9 @@ package purl_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/purl"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/purl"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func TestComposerExtraction_shouldExtractPackages(t *testing.T) {

--- a/internal/utility/purl/golang.go
+++ b/internal/utility/purl/golang.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func FromGo(packageInfo models.PackageInfo) (namespace string, name string, err error) {

--- a/internal/utility/purl/golang_test.go
+++ b/internal/utility/purl/golang_test.go
@@ -3,9 +3,9 @@ package purl_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/purl"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/purl"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func TestGolangExtraction_shouldExtractPackages(t *testing.T) {

--- a/internal/utility/purl/maven.go
+++ b/internal/utility/purl/maven.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func FromMaven(packageInfo models.PackageInfo) (namespace string, name string, err error) {

--- a/internal/utility/purl/maven_test.go
+++ b/internal/utility/purl/maven_test.go
@@ -3,9 +3,9 @@ package purl_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/purl"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/purl"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func TestMavenExtraction_shouldExtractPackages(t *testing.T) {

--- a/internal/utility/purl/package_grouper.go
+++ b/internal/utility/purl/package_grouper.go
@@ -3,7 +3,7 @@ package purl
 import (
 	"slices"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 // Group takes a list of packages, and group them in a map using their PURL

--- a/internal/utility/purl/package_grouper_test.go
+++ b/internal/utility/purl/package_grouper_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/purl"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/purl"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {

--- a/internal/utility/purl/purl.go
+++ b/internal/utility/purl/purl.go
@@ -3,7 +3,7 @@ package purl
 import (
 	"fmt"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/package-url/packageurl-go"
 )

--- a/internal/utility/results/results.go
+++ b/internal/utility/results/results.go
@@ -3,7 +3,7 @@ package results
 import (
 	"fmt"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 // Number of characters to display a git commit

--- a/pkg/lockfile/apk-installed.go
+++ b/pkg/lockfile/apk-installed.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 const AlpineEcosystem Ecosystem = "Alpine"

--- a/pkg/lockfile/apk-installed_test.go
+++ b/pkg/lockfile/apk-installed_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseApkInstalled_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/csv.go
+++ b/pkg/lockfile/csv.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 var errCSVRecordNotEnoughFields = errors.New("not enough fields (expected at least four)")

--- a/pkg/lockfile/csv_test.go
+++ b/pkg/lockfile/csv_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestFromCSVRows(t *testing.T) {

--- a/pkg/lockfile/devgroup_test.go
+++ b/pkg/lockfile/devgroup_test.go
@@ -3,7 +3,7 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/dpkg-status.go
+++ b/pkg/lockfile/dpkg-status.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 const DebianEcosystem Ecosystem = "Debian"

--- a/pkg/lockfile/dpkg-status_test.go
+++ b/pkg/lockfile/dpkg-status_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseDpkgStatus_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/ecosystems_test.go
+++ b/pkg/lockfile/ecosystems_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func numberOfLockfileParsers(t *testing.T) int {

--- a/pkg/lockfile/extract_test.go
+++ b/pkg/lockfile/extract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 type TestDepFile struct {

--- a/pkg/lockfile/extractor.go
+++ b/pkg/lockfile/extractor.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"

--- a/pkg/lockfile/go-binary.go
+++ b/pkg/lockfile/go-binary.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type GoBinaryExtractor struct{}

--- a/pkg/lockfile/go-binary_test.go
+++ b/pkg/lockfile/go-binary_test.go
@@ -3,9 +3,9 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestGoBinaryExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/helpers_test.go
+++ b/pkg/lockfile/helpers_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/datadog/datadog-sbom-generator/internal/output"
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func expectErrContaining(t *testing.T, err error, str string) {

--- a/pkg/lockfile/match-build-gradle.go
+++ b/pkg/lockfile/match-build-gradle.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type BuildGradleMatcher struct{}

--- a/pkg/lockfile/match-build-gradle_test.go
+++ b/pkg/lockfile/match-build-gradle_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/match-composer.go
+++ b/pkg/lockfile/match-composer.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"path/filepath"
 
-	jsonUtils "github.com/datadog/datadog-sbom-generator/internal/json"
+	jsonUtils "github.com/DataDog/datadog-sbom-generator/internal/json"
 )
 
 const composerFilename = "composer.json"

--- a/pkg/lockfile/match-composer_test.go
+++ b/pkg/lockfile/match-composer_test.go
@@ -6,11 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/match-gemfile.go
+++ b/pkg/lockfile/match-gemfile.go
@@ -3,7 +3,7 @@ package lockfile
 import (
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 const gemfileFilename = "Gemfile"

--- a/pkg/lockfile/match-gemfile_test.go
+++ b/pkg/lockfile/match-gemfile_test.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/match-gemspec.go
+++ b/pkg/lockfile/match-gemspec.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 const gemspecFileSuffix = ".gemspec"

--- a/pkg/lockfile/match-gemspec_test.go
+++ b/pkg/lockfile/match-gemspec_test.go
@@ -5,10 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/match-nuget-csproj.go
+++ b/pkg/lockfile/match-nuget-csproj.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"path/filepath"
 	"strings"

--- a/pkg/lockfile/match-nuget-csproj_test.go
+++ b/pkg/lockfile/match-nuget-csproj_test.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/match-package-json.go
+++ b/pkg/lockfile/match-package-json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	jsonUtils "github.com/datadog/datadog-sbom-generator/internal/json"
+	jsonUtils "github.com/DataDog/datadog-sbom-generator/internal/json"
 )
 
 const (

--- a/pkg/lockfile/match-package-json_test.go
+++ b/pkg/lockfile/match-package-json_test.go
@@ -6,11 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/match-pipfile.go
+++ b/pkg/lockfile/match-pipfile.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type PipfileMatcher struct{}

--- a/pkg/lockfile/match-pipfile_test.go
+++ b/pkg/lockfile/match-pipfile_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/match-pyproject-toml_test.go
+++ b/pkg/lockfile/match-pyproject-toml_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/matcher-dependency-map.go
+++ b/pkg/lockfile/matcher-dependency-map.go
@@ -3,7 +3,7 @@ package lockfile
 import (
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"golang.org/x/exp/maps"
 )
 

--- a/pkg/lockfile/matcher-dependency-map_test.go
+++ b/pkg/lockfile/matcher-dependency-map_test.go
@@ -3,7 +3,7 @@ package lockfile
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/matcher-helpers_test.go
+++ b/pkg/lockfile/matcher-helpers_test.go
@@ -1,7 +1,7 @@
 package lockfile_test
 
 import (
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func MockAllMatchers() {

--- a/pkg/lockfile/node-modules-npm-v1_test.go
+++ b/pkg/lockfile/node-modules-npm-v1_test.go
@@ -3,9 +3,9 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestNodeModulesExtractor_Extract_npm_v1_InvalidJson(t *testing.T) {

--- a/pkg/lockfile/node-modules-npm-v2_test.go
+++ b/pkg/lockfile/node-modules-npm-v2_test.go
@@ -3,9 +3,9 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestNodeModulesExtractor_Extract_npm_v2_InvalidJson(t *testing.T) {

--- a/pkg/lockfile/node-modules_test.go
+++ b/pkg/lockfile/node-modules_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func createTestDir(t *testing.T) (string, func()) {

--- a/pkg/lockfile/osv-vuln-result_test.go
+++ b/pkg/lockfile/osv-vuln-result_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseOSVScannerResults_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/osv-vuln-results.go
+++ b/pkg/lockfile/osv-vuln-results.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func ParseOSVScannerResults(pathToLockfile string) ([]PackageDetails, error) {

--- a/pkg/lockfile/parse-cargo-lock.go
+++ b/pkg/lockfile/parse-cargo-lock.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/BurntSushi/toml"
 )

--- a/pkg/lockfile/parse-cargo-lock_test.go
+++ b/pkg/lockfile/parse-cargo-lock_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestCargoLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-composer-lock.go
+++ b/pkg/lockfile/parse-composer-lock.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type ComposerPackage struct {

--- a/pkg/lockfile/parse-composer-lock_test.go
+++ b/pkg/lockfile/parse-composer-lock_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestComposerLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-conan-lock-v1-revisions_test.go
+++ b/pkg/lockfile/parse-conan-lock-v1-revisions_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseConanLock_v1_revisions_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/parse-conan-lock-v1_test.go
+++ b/pkg/lockfile/parse-conan-lock-v1_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseConanLock_v1_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/parse-conan-lock-v2_test.go
+++ b/pkg/lockfile/parse-conan-lock-v2_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseConanLock_v2_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/parse-conan-lock.go
+++ b/pkg/lockfile/parse-conan-lock.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type ConanReference struct {

--- a/pkg/lockfile/parse-conan-lock_test.go
+++ b/pkg/lockfile/parse-conan-lock_test.go
@@ -3,7 +3,7 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestConanLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-gemfile-lock.go
+++ b/pkg/lockfile/parse-gemfile-lock.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 const BundlerEcosystem Ecosystem = "RubyGems"

--- a/pkg/lockfile/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/parse-gemfile-lock_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestGemfileLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -7,14 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"golang.org/x/exp/maps"
 
 	"golang.org/x/mod/module"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"golang.org/x/mod/modfile"
 )

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestGoLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-gradle-lock.go
+++ b/pkg/lockfile/parse-gradle-lock.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 const (

--- a/pkg/lockfile/parse-gradle-lock_test.go
+++ b/pkg/lockfile/parse-gradle-lock_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestGradleLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-gradle-verification-metadata.go
+++ b/pkg/lockfile/parse-gradle-verification-metadata.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type GradleVerificationMetadataFile struct {

--- a/pkg/lockfile/parse-gradle-verification-metadata_test.go
+++ b/pkg/lockfile/parse-gradle-verification-metadata_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestGradleVerificationMetadataExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -16,11 +16,11 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/filereader"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/filereader"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 const MavenCentral = "https://repo.maven.apache.org/maven2"

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestMavenLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-mix-lock.go
+++ b/pkg/lockfile/parse-mix-lock.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 const MixEcosystem Ecosystem = "Hex"

--- a/pkg/lockfile/parse-mix-lock_test.go
+++ b/pkg/lockfile/parse-mix-lock_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestMixLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseNpmLock_v1_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseNpmLock_v2_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -13,9 +13,9 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type NpmLockDependency struct {

--- a/pkg/lockfile/parse-npm-lock_test.go
+++ b/pkg/lockfile/parse-npm-lock_test.go
@@ -3,7 +3,7 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestNpmLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-nuget-lock-v1_test.go
+++ b/pkg/lockfile/parse-nuget-lock-v1_test.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"golang.org/x/exp/maps"
 )

--- a/pkg/lockfile/parse-nuget-lock_test.go
+++ b/pkg/lockfile/parse-nuget-lock_test.go
@@ -3,7 +3,7 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestNuGetLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-pdm-lock.go
+++ b/pkg/lockfile/parse-pdm-lock.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/BurntSushi/toml"
 )

--- a/pkg/lockfile/parse-pdm-lock_test.go
+++ b/pkg/lockfile/parse-pdm-lock_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestPdmExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-pipenv-lock.go
+++ b/pkg/lockfile/parse-pipenv-lock.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"golang.org/x/exp/maps"
 )

--- a/pkg/lockfile/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/parse-pipenv-lock_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestPipenvLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-pnpm-lock-v9_test.go
+++ b/pkg/lockfile/parse-pnpm-lock-v9_test.go
@@ -3,9 +3,9 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParsePnpmLock_v9_NoPackages(t *testing.T) {

--- a/pkg/lockfile/parse-pnpm-v9-lock.go
+++ b/pkg/lockfile/parse-pnpm-v9-lock.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/lockfile/parse-poetry-lock.go
+++ b/pkg/lockfile/parse-poetry-lock.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/BurntSushi/toml"
 )

--- a/pkg/lockfile/parse-poetry-lock_test.go
+++ b/pkg/lockfile/parse-poetry-lock_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestPoetryLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-pubspec-lock.go
+++ b/pkg/lockfile/parse-pubspec-lock.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/lockfile/parse-pubspec-lock_test.go
+++ b/pkg/lockfile/parse-pubspec-lock_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestPubspecLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-renv-lock.go
+++ b/pkg/lockfile/parse-renv-lock.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type RenvPackage struct {

--- a/pkg/lockfile/parse-renv-lock_test.go
+++ b/pkg/lockfile/parse-renv-lock_test.go
@@ -4,9 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseRenvLock_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 	"golang.org/x/exp/maps"
 )
 

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestRequirementsTxtExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v1_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseYarnLock_v1_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v2_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestParseYarnLock_v2_FileDoesNotExist(t *testing.T) {

--- a/pkg/lockfile/parse-yarn-lock.go
+++ b/pkg/lockfile/parse-yarn-lock.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 )
 
 const YarnEcosystem = NpmEcosystem

--- a/pkg/lockfile/parse-yarn-lock_test.go
+++ b/pkg/lockfile/parse-yarn-lock_test.go
@@ -3,7 +3,7 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestYarnLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"golang.org/x/exp/maps"
 )

--- a/pkg/lockfile/parse_test.go
+++ b/pkg/lockfile/parse_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/output"
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func expectNumberOfParsersCalled(t *testing.T, numberOfParsersCalled int) {

--- a/pkg/lockfile/pnpm-legacy-lock.go
+++ b/pkg/lockfile/pnpm-legacy-lock.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
-	"github.com/datadog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/lockfile/pnpm-legacy-lock_test.go
+++ b/pkg/lockfile/pnpm-legacy-lock_test.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 )
 
 func TestPnpmLockExtractor_ShouldExtract(t *testing.T) {

--- a/pkg/lockfile/testmain_test.go
+++ b/pkg/lockfile/testmain_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/testutility"
+	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/lockfile/tree-sitter_test.go
+++ b/pkg/lockfile/tree-sitter_test.go
@@ -3,7 +3,7 @@ package lockfile_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lockfile/types.go
+++ b/pkg/lockfile/types.go
@@ -3,7 +3,7 @@ package lockfile
 import (
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type PackageDetails struct {

--- a/pkg/models/purl_to_package_test.go
+++ b/pkg/models/purl_to_package_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func TestPURLToPackage(t *testing.T) {

--- a/pkg/models/vulnerabilities_test.go
+++ b/pkg/models/vulnerabilities_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 func TestVulnerabilities_MarshalJSON(t *testing.T) {

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -8,14 +8,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/datadog-sbom-generator/internal/customgitignore"
-	"github.com/datadog/datadog-sbom-generator/internal/output"
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
-	"github.com/datadog/datadog-sbom-generator/internal/utility/purl"
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
-	"github.com/datadog/datadog-sbom-generator/pkg/reachability"
-	"github.com/datadog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/internal/customgitignore"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/purl"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reachability"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 )

--- a/pkg/osvscanner/osvscanner_test.go
+++ b/pkg/osvscanner/osvscanner_test.go
@@ -3,7 +3,7 @@ package osvscanner
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -4,12 +4,12 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
-	"github.com/datadog/datadog-sbom-generator/internal/utility/location"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
-	"github.com/datadog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/location"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 func exportMetadata(rawPkg lockfile.PackageDetails, reachabilityAnalysisResults *models.ReachabilityAnalysisResults) map[models.PackageMetadataType]string {

--- a/pkg/reachability/codefile/java.go
+++ b/pkg/reachability/codefile/java.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/datadog/datadog-sbom-generator/internal/utility/fileposition"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	treesitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_java "github.com/tree-sitter/tree-sitter-java/bindings/go"

--- a/pkg/reachability/codefile/java_test.go
+++ b/pkg/reachability/codefile/java_test.go
@@ -3,7 +3,7 @@ package codefile
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/reachability/reachability.go
+++ b/pkg/reachability/reachability.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/datadog/datadog-sbom-generator/internal/http"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
-	"github.com/datadog/datadog-sbom-generator/pkg/reachability/codefile"
+	"github.com/DataDog/datadog-sbom-generator/internal/http"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reachability/codefile"
 )
 
 // PerformReachabilityAnalysis performs a reachability analysis on the given PURLs.

--- a/pkg/reachability/utils.go
+++ b/pkg/reachability/utils.go
@@ -1,8 +1,8 @@
 package reachability
 
 import (
-	"github.com/datadog/datadog-sbom-generator/internal/http"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/http"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 // getAdvisoriesToCheckPerLanguage returns a map of language to advisories with symbols to check.

--- a/pkg/reachability/utils_test.go
+++ b/pkg/reachability/utils_test.go
@@ -3,8 +3,8 @@ package reachability
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/internal/http"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/http"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/reporter/cyclonedx.go
+++ b/pkg/reporter/cyclonedx.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/CycloneDX/cyclonedx-go"
 
-	"github.com/datadog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type CycloneDXReporter struct {

--- a/pkg/reporter/cyclonedx_test.go
+++ b/pkg/reporter/cyclonedx_test.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
-	"github.com/datadog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 func TestCycloneDXReporter_Errorf(t *testing.T) {

--- a/pkg/reporter/format.go
+++ b/pkg/reporter/format.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 var format = []string{"json", "cyclonedx-1-4", "cyclonedx-1-5"}

--- a/pkg/reporter/format_test.go
+++ b/pkg/reporter/format_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/datadog/datadog-sbom-generator/internal/output"
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 // JSONReporter prints vulnerability results in JSON format to stdout. Runtime information

--- a/pkg/reporter/json_reporter_test.go
+++ b/pkg/reporter/json_reporter_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 func TestJSONReporter_Errorf(t *testing.T) {

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -1,7 +1,7 @@
 package reporter
 
 import (
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 // Reporter provides printing operations for vulnerability results and for runtime information (depending on the verbosity

--- a/pkg/reporter/verbosity_test.go
+++ b/pkg/reporter/verbosity_test.go
@@ -3,7 +3,7 @@ package reporter_test
 import (
 	"testing"
 
-	"github.com/datadog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 func TestParseVerbosityLevel_GivenValidLevels(t *testing.T) {

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -1,7 +1,7 @@
 package reporter
 
 import (
-	"github.com/datadog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
 type VoidReporter struct {


### PR DESCRIPTION
## What problem are you trying to solve?

When trying to dogfood this repository internally, I ran `go get github.com/datadog/datadog-sbom-generator` which results in a `404 Not Found`. When I switch to using `go get github.com/DataDog/datadog-sbom-generator` I get the following error message:

```
 module declares its path as: github.com/datadog/datadog-sbom-generator
         but was required as: github.com/DataDog/datadog-sbom-generator
```

## What is your solution?

While the repo is still private (and maybe after as well -- TBD) the module name needs to match the repo URL.