### PR TITLE
Defend against regex failure

### DIFF
--- a/internal/json/utils.go
+++ b/internal/json/utils.go
@@ -49,7 +49,9 @@ func ExtractPackageIndexes(pkgName, targetedVersion, content string) []int {
 	} else {
 		versionRegex = cachedregexp.QuoteMeta(targetedVersion)
 	}
-	pkgMatcher := cachedregexp.MustCompile(`"(?P<pkgName>` + pkgName + `)\"\s*:\s*\"(?P<version>` + versionRegex + `)"`)
+	pkgNameRegex := cachedregexp.QuoteMeta(pkgName)
+
+	pkgMatcher := cachedregexp.MustCompile(`"(?P<pkgName>` + pkgNameRegex + `)\"\s*:\s*\"(?P<version>` + versionRegex + `)"`)
 	result := pkgMatcher.FindAllStringSubmatchIndex(content, -1)
 
 	if len(result) == 0 || len(result[0]) < 6 {


### PR DESCRIPTION
## What problem are you trying to solve?

Backports the change [here](https://github.com/DataDog/osv-scanner/pull/171) that was made in the scanner