### PR TITLE
Update PR comment if it exists

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -141,8 +141,7 @@ jobs:
         with:
           name: main.breakdown
           path: main.breakdown # as specified via `breakdown-file-name`
-          if-no-files-found:
-            error
+          if-no-files-found: error
       # Post coverage report as comment (update existing or create new)
       - name: post coverage report
         if: ${{github.event_name == 'pull_request'}}


### PR DESCRIPTION
## What problem are you trying to solve?
The PR coverage comment is recreating a new comment each time a new commit is checked

## What is your solution?
- Add a title to identify the comment about coverage
- Updating the comment if it exists