### PR TITLE
[K9VULN-5213] Make --version output to stdout and not stderr

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -15,13 +15,13 @@ No package sources found, --help for usage information.
 ---
 
 [TestRun/#01 - 1]
+datadog-sbom-generator version: set at build time, see .goreleaser.yml ldflags section
+commit: set at build time, see .goreleaser.yml ldflags section
+built at: set at build time, see .goreleaser.yml ldflags section
 
 ---
 
 [TestRun/#01 - 2]
-datadog-sbom-generator version: set at build time, see .goreleaser.yml ldflags section
-commit: set at build time, see .goreleaser.yml ldflags section
-built at: set at build time, see .goreleaser.yml ldflags section
 
 ---
 

--- a/cmd/datadog-sbom-generator/main.go
+++ b/cmd/datadog-sbom-generator/main.go
@@ -23,8 +23,8 @@ var (
 func run(args []string, stdout, stderr io.Writer) int {
 	var r reporter.Reporter
 	cli.VersionPrinter = func(ctx *cli.Context) {
-		// Use the app Writer and ErrWriter since they will be the writers to keep parallel tests consistent
-		r = reporter.NewJSONReporter(ctx.App.Writer, ctx.App.ErrWriter, reporter.InfoLevel)
+		// Use the app Writer and Writer since they will be the writers to keep parallel tests consistent
+		r = reporter.NewJSONReporter(ctx.App.Writer, ctx.App.Writer, reporter.InfoLevel)
 		r.Infof("datadog-sbom-generator version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date)
 	}
 


### PR DESCRIPTION
## What problem are you trying to solve?

`datadog-sbom-generator --version` was outputting to `stderr` and not `stdout`

## What is your solution?

Update the output writter

## Alternatives considered
N/A

## What the reviewer should know
You can try it yourself here:
```
datadog-sbom-generator --version > out.txt 2> err.txt
```
and check to which file we write :) 