### PR TITLE
[K9VULN-5150] Add generation tool to metadata.tools

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -4,7 +4,19 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "version": 1
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  }
 }
 
 ---
@@ -30,7 +42,19 @@ built at: set at build time, see .goreleaser.yml ldflags section
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "version": 1
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  }
 }
 
 ---
@@ -46,6 +70,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -92,6 +128,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -171,6 +219,18 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -254,6 +314,18 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -292,6 +364,18 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -388,6 +472,18 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -441,6 +537,18 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -470,6 +578,18 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/ansi-html@0.0.1",
@@ -499,6 +619,18 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -539,6 +671,18 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -568,6 +712,18 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -656,6 +812,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -1317,6 +1485,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/%40eslint%2Feslintrc@2.1.4",
@@ -3079,6 +3259,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/%40eslint%2Feslintrc@2.1.4",
@@ -4841,6 +5033,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/%40eslint%2Feslintrc@2.1.4",
@@ -6603,6 +6807,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/%40eslint%2Feslintrc@2.1.4",
@@ -8365,6 +8581,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -8419,6 +8647,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -8448,6 +8688,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:composer/sentry/sdk@2.0.4",
@@ -8478,6 +8730,18 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "libs/pom.xml",
@@ -8603,7 +8867,19 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "version": 1
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  }
 }
 
 ---
@@ -8619,6 +8895,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "maven-spring/pom.xml",
@@ -13492,6 +13780,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "maven-spring/pom.xml",
@@ -18297,6 +18597,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "maven-spring/pom.xml",
@@ -23102,6 +23414,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "libs/pom.xml",
@@ -23211,6 +23535,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -23860,6 +24196,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -24522,6 +24870,18 @@ No package sources found, --help for usage information.
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
   "components": [
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",

--- a/cmd/datadog-sbom-generator/scan/main.go
+++ b/cmd/datadog-sbom-generator/scan/main.go
@@ -115,7 +115,7 @@ func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, 
 		return r, err
 	}
 
-	if errPrint := r.PrintResult(&vulnResult); errPrint != nil {
+	if errPrint := r.PrintResult(context, &vulnResult); errPrint != nil {
 		return r, fmt.Errorf("failed to write output: %w", errPrint)
 	}
 

--- a/internal/output/__snapshots__/cyclonedx_test.snap
+++ b/internal/output/__snapshots__/cyclonedx_test.snap
@@ -12,7 +12,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -34,7 +34,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -56,7 +56,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -103,7 +103,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -125,7 +125,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -156,7 +156,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -187,7 +187,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -218,7 +218,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -294,7 +294,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -370,7 +370,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -414,7 +414,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -458,7 +458,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -502,7 +502,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -553,7 +553,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -651,7 +651,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -749,7 +749,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -801,7 +801,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -877,7 +877,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -975,7 +975,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1073,7 +1073,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1095,7 +1095,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1117,7 +1117,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1139,7 +1139,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1170,7 +1170,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1225,7 +1225,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1269,7 +1269,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1313,7 +1313,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1357,7 +1357,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1401,7 +1401,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1462,7 +1462,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1523,7 +1523,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1572,7 +1572,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }
@@ -1623,7 +1623,7 @@
           "type": "application",
           "group": "datadog",
           "name": "datadog-sbom-generator",
-          "version": "0.62.1"
+          "version": "1.0.1"
         }
       ]
     }

--- a/internal/output/cyclonedx.go
+++ b/internal/output/cyclonedx.go
@@ -12,15 +12,15 @@ import (
 )
 
 // This method creates a CycloneDX SBOM and returns it. Error being returned here are from components being filtered during PURL grouping
-func CreateCycloneDXBOM(vulnResult *models.VulnerabilityResults) (*cyclonedx.BOM, error) {
+func CreateCycloneDXBOM(tool sbom.Tool, vulnResult *models.VulnerabilityResults) (*cyclonedx.BOM, error) {
 	resultsByPurl, errs := purl.Group(vulnResult.Results)
 
-	return sbom.BuildCycloneDXBom(resultsByPurl, vulnResult.Artifacts), errors.Join(errs...)
+	return sbom.BuildCycloneDXBom(tool, resultsByPurl, vulnResult.Artifacts), errors.Join(errs...)
 }
 
 // PrintCycloneDXResults writes results to the provided writer in CycloneDX format
-func PrintCycloneDXResults(vulnResult *models.VulnerabilityResults, outputWriter io.Writer) error {
-	bom, errs := CreateCycloneDXBOM(vulnResult)
+func PrintCycloneDXResults(tool sbom.Tool, vulnResult *models.VulnerabilityResults, outputWriter io.Writer) error {
+	bom, errs := CreateCycloneDXBOM(tool, vulnResult)
 	encoder := cyclonedx.NewBOMEncoder(outputWriter, cyclonedx.BOMFileFormatJSON)
 	encoder.SetPretty(testing.Testing())
 

--- a/internal/output/cyclonedx_test.go
+++ b/internal/output/cyclonedx_test.go
@@ -5,8 +5,14 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/internal/output/sbom"
 	"github.com/DataDog/datadog-sbom-generator/internal/testutility"
 )
+
+var defaultTool = sbom.Tool{
+	Name:    "datadog-sbom-generator",
+	Version: "1.0.1",
+}
 
 func TestPrintCycloneDX15Results_WithDependencies(t *testing.T) {
 	t.Parallel()
@@ -15,7 +21,7 @@ func TestPrintCycloneDX15Results_WithDependencies(t *testing.T) {
 		t.Helper()
 
 		outputWriter := &bytes.Buffer{}
-		err := output.PrintCycloneDXResults(args.vulnResult, outputWriter)
+		err := output.PrintCycloneDXResults(defaultTool, args.vulnResult, outputWriter)
 
 		if err != nil {
 			t.Errorf("%v", err)
@@ -32,7 +38,7 @@ func TestPrintCycloneDX15Results_WithVulnerabilities(t *testing.T) {
 		t.Helper()
 
 		outputWriter := &bytes.Buffer{}
-		err := output.PrintCycloneDXResults(args.vulnResult, outputWriter)
+		err := output.PrintCycloneDXResults(defaultTool, args.vulnResult, outputWriter)
 
 		if err != nil {
 			t.Errorf("%v", err)
@@ -49,7 +55,7 @@ func TestPrintCycloneDX15Results_WithMixedIssues(t *testing.T) {
 		t.Helper()
 
 		outputWriter := &bytes.Buffer{}
-		err := output.PrintCycloneDXResults(args.vulnResult, outputWriter)
+		err := output.PrintCycloneDXResults(defaultTool, args.vulnResult, outputWriter)
 
 		if err != nil {
 			t.Errorf("%v", err)

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -15,7 +15,12 @@ import (
 
 type PackageProcessingHook = func(component *cyclonedx.Component, details models.PackageVulns)
 
-func BuildCycloneDXBom(uniquePackages map[string]models.PackageVulns, artifacts []models.ScannedArtifact) *cyclonedx.BOM {
+type Tool struct {
+	Name    string
+	Version string
+}
+
+func BuildCycloneDXBom(tool Tool, uniquePackages map[string]models.PackageVulns, artifacts []models.ScannedArtifact) *cyclonedx.BOM {
 	bom := cyclonedx.NewBOM()
 	bom.JSONSchema = cycloneDx15Schema
 	bom.SpecVersion = cyclonedx.SpecVersion1_5
@@ -57,7 +62,9 @@ func BuildCycloneDXBom(uniquePackages map[string]models.PackageVulns, artifacts 
 		return strings.Compare(a.Ref, b.Ref)
 	})
 
-	bom.Metadata = buildMetadataComponent()
+	metadata := buildMetadataComponent(tool)
+
+	bom.Metadata = metadata
 	bom.Components = &components
 	bom.Dependencies = &dependencies
 	bom.Vulnerabilities = &bomVulnerabilities
@@ -89,15 +96,15 @@ func addLocations(component *cyclonedx.Component, details models.PackageVulns) {
 	}
 }
 
-func buildMetadataComponent() *cyclonedx.Metadata {
+func buildMetadataComponent(tool Tool) *cyclonedx.Metadata {
 	return &cyclonedx.Metadata{
 		Tools: &cyclonedx.ToolsChoice{
 			Components: &[]cyclonedx.Component{
 				{
 					Type:    cyclonedx.ComponentTypeApplication,
 					Group:   "datadog",
-					Name:    "datadog-sbom-generator",
-					Version: "0.62.1",
+					Name:    tool.Name,
+					Version: tool.Version,
 				},
 			},
 		},

--- a/pkg/reporter/cyclonedx.go
+++ b/pkg/reporter/cyclonedx.go
@@ -5,7 +5,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/DataDog/datadog-sbom-generator/internal/output/sbom"
+	"github.com/urfave/cli/v2"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/output"
 
@@ -55,8 +56,9 @@ func (r *CycloneDXReporter) Verbosef(format string, a ...any) {
 	}
 }
 
-func (r *CycloneDXReporter) PrintResult(vulnerabilityResults *models.VulnerabilityResults) error {
-	errs := output.PrintCycloneDXResults(vulnerabilityResults, r.stdout)
+func (r *CycloneDXReporter) PrintResult(context *cli.Context, vulnerabilityResults *models.VulnerabilityResults) error {
+	tool := sbom.Tool{Name: context.App.Name, Version: context.App.Version}
+	errs := output.PrintCycloneDXResults(tool, vulnerabilityResults, r.stdout)
 	if errs != nil {
 		for _, err := range strings.Split(errs.Error(), "\n") {
 			r.Warnf("Failed to parse package URL: %v", err)
@@ -64,10 +66,4 @@ func (r *CycloneDXReporter) PrintResult(vulnerabilityResults *models.Vulnerabili
 	}
 
 	return nil
-}
-
-// BuildCycloneDXBOM is only intended to be used when datadog-sbom-generator is used as a library as opposed to the CLI,
-// it has been written here to avoid being in an internal package which triggers linting issues
-func BuildCycloneDXBOM(vulnerabilityResults *models.VulnerabilityResults) (*cyclonedx.BOM, error) {
-	return output.CreateCycloneDXBOM(vulnerabilityResults)
 }

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/DataDog/datadog-sbom-generator/internal/output"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -53,6 +55,6 @@ func (r *JSONReporter) Verbosef(format string, a ...any) {
 	}
 }
 
-func (r *JSONReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
+func (r *JSONReporter) PrintResult(context *cli.Context, vulnResult *models.VulnerabilityResults) error {
 	return output.PrintJSONResults(vulnResult, r.stdout)
 }

--- a/pkg/reporter/mock_reporter.go
+++ b/pkg/reporter/mock_reporter.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	models "github.com/DataDog/datadog-sbom-generator/pkg/models"
+	v2 "github.com/urfave/cli/v2"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -83,17 +84,17 @@ func (mr *MockReporterMockRecorder) Infof(format interface{}, a ...interface{}) 
 }
 
 // PrintResult mocks base method.
-func (m *MockReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
+func (m *MockReporter) PrintResult(context *v2.Context, vulnResult *models.VulnerabilityResults) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrintResult", vulnResult)
+	ret := m.ctrl.Call(m, "PrintResult", context, vulnResult)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PrintResult indicates an expected call of PrintResult.
-func (mr *MockReporterMockRecorder) PrintResult(vulnResult interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) PrintResult(context, vulnResult interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrintResult", reflect.TypeOf((*MockReporter)(nil).PrintResult), vulnResult)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrintResult", reflect.TypeOf((*MockReporter)(nil).PrintResult), context, vulnResult)
 }
 
 // Verbosef mocks base method.

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -2,6 +2,7 @@ package reporter
 
 import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/urfave/cli/v2"
 )
 
 // Reporter provides printing operations for vulnerability results and for runtime information (depending on the verbosity
@@ -31,5 +32,5 @@ type Reporter interface {
 	Verbosef(format string, a ...any)
 	// PrintResult prints the models.VulnerabilityResults per the logic of the
 	// actual reporter
-	PrintResult(vulnResult *models.VulnerabilityResults) error
+	PrintResult(context *cli.Context, vulnResult *models.VulnerabilityResults) error
 }

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -2,6 +2,7 @@ package reporter
 
 import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/urfave/cli/v2"
 )
 
 type VoidReporter struct {
@@ -25,6 +26,6 @@ func (r *VoidReporter) Infof(msg string, a ...any) {
 func (r *VoidReporter) Verbosef(msg string, a ...any) {
 }
 
-func (r *VoidReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
+func (r *VoidReporter) PrintResult(context *cli.Context, vulnResult *models.VulnerabilityResults) error {
 	return nil
 }


### PR DESCRIPTION
## What problem are you trying to solve?
We would like sboms to include the version with which they were generated. 
This will facilitate our understandability/debuggability if customers reports issues with the sbom generator 

## What is your solution?
Following CycloneDX documentation, we are adding support for `tool`, as described [here](https://cyclonedx.org/docs/1.5/json/#tab-pane_metadata_tools_oneOf_i0) 

## Alternatives considered
N/A

## What the reviewer should know
We are adding the generated sbom the tool version as:
```
"metadata": {
  "tools": {
    "components": [
      {
        "type": "application",
        "group": "datadog",
        "name": "datadog-sbom-generator",
        "version": "1.0.1"
      }
    ]
  }
}
``` 