### PR TITLE
[K9VULN-5672] Parse maven exclusions

### DIFF
--- a/internal/output/__snapshots__/cyclonedx_test.snap
+++ b/internal/output/__snapshots__/cyclonedx_test.snap
@@ -205,6 +205,51 @@
 
 ---
 
+[TestPrintCycloneDX15Results_WithDependencies/one_source_with_one_package,_two_exclusions - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "1.0.1"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:maven/org.apache.maven/maven-artifact@1.2.1",
+      "type": "library",
+      "name": "org.apache.maven:maven-artifact",
+      "version": "1.2.1",
+      "purl": "pkg:maven/org.apache.maven/maven-artifact@1.2.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:exclusion",
+          "value": "org.example:example-artifact1"
+        },
+        {
+          "name": "datadog-sbom-generator:exclusion",
+          "value": "org.example:*"
+        },
+        {
+          "name": "osv-scanner:is-dev",
+          "value": "true"
+        }
+      ]
+    }
+  ]
+}
+
+---
+
 [TestPrintCycloneDX15Results_WithMixedIssues/multiple_sources_with_a_mixed_count_of_packages,_some_called_vulnerabilities_and_license_violations - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",

--- a/internal/output/helpers_test.go
+++ b/internal/output/helpers_test.go
@@ -1463,6 +1463,32 @@ func testOutputWithArtifacts(t *testing.T, run outputTestRunner) {
 				},
 			},
 		},
+		{
+			name: "one source with one package, two exclusions",
+			args: outputTestCaseArgs{
+				vulnResult: &models.VulnerabilityResults{
+					Artifacts: make([]models.ScannedArtifact, 0),
+					Results: []models.PackageSource{
+						{
+							Source: models.SourceInfo{Path: "path/to/my/first/pom.xml"},
+							Packages: []models.PackageVulns{
+								{
+									Package: models.PackageInfo{
+										Name:      "org.apache.maven:maven-artifact",
+										Version:   "1.2.1",
+										Ecosystem: "Maven",
+									},
+									Metadata: models.PackageMetadata{
+										models.IsDevDependencyMetadata: "true",
+										models.ExclusionMetadata:       "org.example:example-artifact1,org.example:*",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -124,6 +124,14 @@ func buildProperties(metadatas models.PackageMetadata) []cyclonedx.Property {
 				Name:  "datadog-sbom-generator:" + string(metadataType),
 				Value: value,
 			})
+		} else if metadataType == models.ExclusionMetadata {
+			props := strings.Split(value, ",")
+			for _, prop := range props {
+				properties = append(properties, cyclonedx.Property{
+					Name:  "datadog-sbom-generator:" + string(metadataType),
+					Value: prop,
+				})
+			}
 		} else {
 			properties = append(properties, cyclonedx.Property{
 				Name:  "osv-scanner:" + string(metadataType),

--- a/pkg/lockfile/fixtures/maven/one-package-two-exclusions.xml
+++ b/pkg/lockfile/fixtures/maven/one-package-two-exclusions.xml
@@ -1,0 +1,23 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>1.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.example</groupId>
+          <artifactId>not-wanted</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.example</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/helpers_test.go
+++ b/pkg/lockfile/helpers_test.go
@@ -50,18 +50,24 @@ func packageToString(pkg lockfile.PackageDetails) string {
 		groups = "<no groups>"
 	}
 
-	return fmt.Sprintf("%s@%s (%s, %s, %s, %s, %t)", pkg.Name, pkg.Version, pkg.Ecosystem, commit, groups, pkg.PackageManager, pkg.IsDirect)
+	exclusions := strings.Join(pkg.Exclusions, ", ")
+
+	if exclusions == "" {
+		exclusions = "<no exclusions>"
+	}
+
+	return fmt.Sprintf("%s@%s (%s, %s, %s, %s, %t, %s)", pkg.Name, pkg.Version, pkg.Ecosystem, commit, groups, pkg.PackageManager, pkg.IsDirect, exclusions)
 }
 
-func hasPackage(t *testing.T, packages []lockfile.PackageDetails, pkg lockfile.PackageDetails, ignoreLocations bool) bool {
+func hasPackage(t *testing.T, expectedPkgs []lockfile.PackageDetails, currentPkg lockfile.PackageDetails, ignoreLocations bool) bool {
 	t.Helper()
 
-	for _, details := range packages {
+	for _, expectedPkg := range expectedPkgs {
 		var ignore []string
 		if ignoreLocations {
 			ignore = []string{"BlockLocation", "NameLocation", "VersionLocation"}
 		}
-		if cmp.Equal(details, pkg, cmpopts.IgnoreFields(lockfile.PackageDetails{}, ignore...)) {
+		if cmp.Equal(expectedPkg, currentPkg, cmpopts.IgnoreFields(lockfile.PackageDetails{}, ignore...)) {
 			return true
 		}
 	}
@@ -69,15 +75,15 @@ func hasPackage(t *testing.T, packages []lockfile.PackageDetails, pkg lockfile.P
 	return false
 }
 
-func innerExpectPackage(t *testing.T, packages []lockfile.PackageDetails, pkg lockfile.PackageDetails, ignoreLocations bool) {
+func innerExpectPackage(t *testing.T, expectedPkgs []lockfile.PackageDetails, currentPkg lockfile.PackageDetails, ignoreLocations bool) {
 	t.Helper()
 
-	if !hasPackage(t, packages, pkg, ignoreLocations) {
+	if !hasPackage(t, expectedPkgs, currentPkg, ignoreLocations) {
 		t.Errorf(
 			"Expected packages to include %s@%s (%s), but it did not",
-			pkg.Name,
-			pkg.Version,
-			pkg.Ecosystem,
+			currentPkg.Name,
+			currentPkg.Version,
+			currentPkg.Ecosystem,
 		)
 	}
 }

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -544,9 +544,12 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 			versionPosition.Filename = lockPackage.SourceFile
 		}
 
-		exclusions := []string{}
-		for _, exclusion := range lockPackage.Exclusions {
-			exclusions = append(exclusions, exclusion.GroupID.Value+":"+exclusion.ArtifactID.Value)
+		var exclusions []string
+		if len(lockPackage.Exclusions) > 0 {
+			exclusions = make([]string, 0, len(lockPackage.Exclusions))
+			for _, exclusion := range lockPackage.Exclusions {
+				exclusions = append(exclusions, exclusion.GroupID.Value+":"+exclusion.ArtifactID.Value)
+			}
 		}
 
 		pkgDetails := PackageDetails{

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -81,6 +81,7 @@ type MavenLockDependency struct {
 	ArtifactID models.StringWithPosition `xml:"artifactId"`
 	Version    models.StringWithPosition `xml:"version"`
 	Scope      string                    `xml:"scope"`
+	Exclusions []MavenLockExclusion      `xml:"exclusions>exclusion"`
 	SourceFile string
 	models.FilePosition
 }
@@ -91,6 +92,12 @@ type MavenLockParent struct {
 	GroupID      string   `xml:"groupId"`
 	ArtifactID   string   `xml:"artifactId"`
 	Version      string   `xml:"version"`
+}
+
+type MavenLockExclusion struct {
+	XMLName    xml.Name                  `xml:"exclusion"`
+	GroupID    models.StringWithPosition `xml:"groupId"`
+	ArtifactID models.StringWithPosition `xml:"artifactId"`
 }
 
 type MavenLockDependencyHolder struct {
@@ -537,6 +544,11 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 			versionPosition.Filename = lockPackage.SourceFile
 		}
 
+		exclusions := []string{}
+		for _, exclusion := range lockPackage.Exclusions {
+			exclusions = append(exclusions, exclusion.GroupID.Value+":"+exclusion.ArtifactID.Value)
+		}
+
 		pkgDetails := PackageDetails{
 			Name:            finalName,
 			Version:         resolvedVersion,
@@ -546,6 +558,7 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 			VersionLocation: &versionPosition,
 			PackageManager:  models.Maven,
 			IsDirect:        true,
+			Exclusions:      exclusions,
 		}
 		if scope := strings.TrimSpace(lockPackage.Scope); scope != "" && scope != "compile" {
 			// Only append non-default scope (compile is the default scope).

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -1665,3 +1665,45 @@ func TestParseMavenLock_SpringRemote(t *testing.T) {
 		},
 	})
 }
+
+func TestParseMavenLock_TwoExclusions(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/maven/one-package-two-exclusions.xml"))
+	packages, err := lockfile.ParseMavenLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "org.apache.maven:maven-artifact",
+			Version:        "1.0.0",
+			PackageManager: models.Maven,
+			Ecosystem:      models.EcosystemMaven,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 7, End: 21},
+				Column:   models.Position{Start: 5, End: 18},
+				Filename: path,
+			},
+			NameLocation: &models.FilePosition{
+				Line:     models.Position{Start: 9, End: 9},
+				Column:   models.Position{Start: 19, End: 33},
+				Filename: path,
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 10, End: 10},
+				Column:   models.Position{Start: 16, End: 21},
+				Filename: path,
+			},
+			IsDirect: true,
+			Exclusions: []string{
+				"com.example:not-wanted", "com.example:*",
+			},
+		},
+	})
+}

--- a/pkg/lockfile/types.go
+++ b/pkg/lockfile/types.go
@@ -19,6 +19,7 @@ type PackageDetails struct {
 	PackageManager  models.PackageManager `json:"packageManager,omitempty"`
 	IsDirect        bool                  `json:"isDirect,omitempty"`
 	Dependencies    []*PackageDetails     `json:"dependencies,omitempty"`
+	Exclusions      []string              `json:"exclusions,omitempty"`
 }
 
 type Ecosystem string

--- a/pkg/models/package_metadata.go
+++ b/pkg/models/package_metadata.go
@@ -8,6 +8,7 @@ const (
 	PackageManagerMetadata     PackageMetadataType = "package-manager"
 	IsDirectDependencyMetadata PackageMetadataType = "is-direct"
 	IsDevDependencyMetadata    PackageMetadataType = "is-dev"
+	ExclusionMetadata          PackageMetadataType = "exclusion"
 )
 
 type PackageMetadata map[PackageMetadataType]string

--- a/pkg/scanner/vulnerability_result.go
+++ b/pkg/scanner/vulnerability_result.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 
@@ -24,6 +25,9 @@ func exportMetadata(rawPkg lockfile.PackageDetails, reachabilityAnalysisResults 
 	}
 	if rawPkg.Ecosystem.IsDevGroup(rawPkg.DepGroups) {
 		metadata[models.IsDevDependencyMetadata] = strconv.FormatBool(true)
+	}
+	if len(rawPkg.Exclusions) > 0 {
+		metadata[models.ExclusionMetadata] = strings.Join(rawPkg.Exclusions, ",")
 	}
 	if reachabilityAnalysisResults != nil {
 		if !rawPkg.IsDirect && len(reachabilityAnalysisResults.ReachableVulnerabilities) > 0 {

--- a/pkg/scanner/vulnerability_result_test.go
+++ b/pkg/scanner/vulnerability_result_test.go
@@ -52,3 +52,104 @@ func Test_groupBySource_OutputDeterministicOfInputOrder(t *testing.T) {
 	// Results should be identical regardless of input order
 	assert.Equal(t, result1, result2)
 }
+
+// Test cases for exportMetadata function
+func Test_exportMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Mock reachability analysis results
+	mockReachabilityResults := &models.ReachabilityAnalysisResults{
+		ReachableVulnerabilities: []models.ReachableVulnerability{
+			{
+				AdvisoryID: "ADV-123",
+				ReachableSymbolLocations: []models.ReachableSymbolLocation{
+					{
+						Symbol: "foo",
+						PackageLocation: models.PackageLocation{
+							Filename:    "pom.xml",
+							LineStart:   0,
+							LineEnd:     0,
+							ColumnStart: 0,
+							ColumnEnd:   0,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test cases
+	testCases := []struct {
+		name                 string
+		rawPkg               lockfile.PackageDetails
+		reachabilityAnalysis *models.ReachabilityAnalysisResults
+		expectedMetadata     map[models.PackageMetadataType]string
+	}{
+		{
+			name: "Valid package manager and direct dependency",
+			rawPkg: lockfile.PackageDetails{
+				PackageManager: models.NPM,
+				IsDirect:       true,
+			},
+			reachabilityAnalysis: nil,
+			expectedMetadata: map[models.PackageMetadataType]string{
+				models.PackageManagerMetadata:     "NPM",
+				models.IsDirectDependencyMetadata: "true",
+			},
+		},
+		{
+			name: "Package with exclusions",
+			rawPkg: lockfile.PackageDetails{
+				Exclusions: []string{"exclusion1", "exclusion2"},
+			},
+			reachabilityAnalysis: nil,
+			expectedMetadata: map[models.PackageMetadataType]string{
+				models.ExclusionMetadata: "exclusion1,exclusion2",
+			},
+		},
+		{
+			name: "Transitive package with reachable vulnerabilities",
+			rawPkg: lockfile.PackageDetails{
+				PURL:     "pkg:maven/org.example/pkg1@1.0.0",
+				IsDirect: true,
+			},
+			reachabilityAnalysis: mockReachabilityResults,
+			expectedMetadata: map[models.PackageMetadataType]string{
+				models.IsDirectDependencyMetadata:                           "true",
+				models.ReachableSymbolLocationMetadata.WithValue("ADV-123"): `[{"file_name":"pom.xml","line_start":0,"line_end":0,"column_start":0,"column_end":0,"symbol":"foo"}]`,
+			},
+		},
+		{
+			name: "Drop reachable vulnerabilities when not direct",
+			rawPkg: lockfile.PackageDetails{
+				PURL:     "pkg:maven/org.example/pkg1@1.0.0",
+				IsDirect: false,
+			},
+			reachabilityAnalysis: mockReachabilityResults,
+			expectedMetadata:     map[models.PackageMetadataType]string{},
+		},
+		{
+			name: "Package with dev group",
+			rawPkg: lockfile.PackageDetails{
+				Ecosystem: models.EcosystemNPM,
+				DepGroups: []string{"dev"},
+			},
+			reachabilityAnalysis: nil,
+			expectedMetadata: map[models.PackageMetadataType]string{
+				models.IsDevDependencyMetadata: "true",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Call the function
+			metadata := exportMetadata(tc.rawPkg, tc.reachabilityAnalysis)
+
+			// Validate metadata
+			assert.Equal(t, tc.expectedMetadata, metadata)
+		})
+	}
+}


### PR DESCRIPTION
## What problem are you trying to solve?

Our current scans Maven projects by analyzing `pom.xml` files and resolving transitive dependencies down the road. However, it does not currently support the Maven `<exclusions>` mechanism ([doc](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html)), which allows projects to intentionally omit specific transitive dependencies.
As a result, our SCA scanning includes dependencies that are explicitly excluded by the project, leading to inaccurate or misleading outputs. 

## What is your solution?
To ensure our SBOM generator faithfully reflects the Maven project’s effective dependency set, we need to support and honor exclusions specified in `pom.xml` files during both parsing and post-processing phases.

This PR takes care of the first part, reporting `exclusions` in the sbom `properties` field of a `component`.

Example:
```xml
// pom.xml
<dependency>
  <groupId>aero.tav.tams</groupId>
  <artifactId>integration-api-app</artifactId>
  <exclusions>
    <exclusion>
      <artifactId>spring-boot-devtools</artifactId> // new exclusion
      <groupId>org.springframework.boot</groupId> // new exclusion
    </exclusion>
    <exclusion>
      <groupId>org.mapstruct</groupId> // new exclusion
      <artifactId>mapstruct</artifactId> // new exclusion
    </exclusion>
  </exclusions>
  <version>${tams-integration-api.version}</version>
</dependency>
```
would report library as:
```json
{
    "bom-ref": "pkg:maven/aero.tav.tams/integration-api-app@2.13.0.Spring-Boot-3.0.9",
    "type": "library",
    "name": "aero.tav.tams:integration-api-app",
    "version": "2.13.0.Spring-Boot-3.0.9",
    "purl": "pkg:maven/aero.tav.tams/integration-api-app@2.13.0.Spring-Boot-3.0.9",
    "properties": [
        {
            "name": "datadog-sbom-generator:exclusion", // new exclusion
            "value": "org.springframework.boot:spring-boot-devtools" // new exclusion
        },
        {
            "name": "datadog-sbom-generator:exclusion", // new exclusion
            "value": "org.mapstruct:mapstruct" // new exclusion
        },
        {
            "name": "osv-scanner:is-direct",
            "value": "true"
        },
        {
            "name": "osv-scanner:package-manager",
            "value": "Maven"
        }
    ]
}
```