### PR TITLE
[K9VULN-5215] Fix inconsistent dev dependency classification

### DIFF
--- a/pkg/models/package_metadata.go
+++ b/pkg/models/package_metadata.go
@@ -17,7 +17,7 @@ func (metadata PackageMetadata) Merge(other PackageMetadata) PackageMetadata {
 		return metadata
 	}
 	_, isDevDependency := metadata[IsDevDependencyMetadata]
-	_, otherIsDevDependency := other[IsDirectDependencyMetadata]
+	_, otherIsDevDependency := other[IsDevDependencyMetadata]
 
 	for key, value := range other {
 		if _, exists := metadata[key]; !exists {

--- a/pkg/models/package_metadata_test.go
+++ b/pkg/models/package_metadata_test.go
@@ -1,0 +1,42 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackageMetadata_MergeDevDepndency(t *testing.T) {
+	t.Parallel()
+
+	t.Run("both dev dependencies, keep property", func(t *testing.T) {
+		t.Parallel()
+		metadata := PackageMetadata{
+			PackageManagerMetadata:  "npm",
+			IsDevDependencyMetadata: "true",
+		}
+		other := PackageMetadata{
+			PackageManagerMetadata:  "npm",
+			IsDevDependencyMetadata: "true",
+		}
+		result := metadata.Merge(other)
+
+		_, isDevDep := result[IsDevDependencyMetadata]
+		assert.True(t, isDevDep)
+	})
+
+	t.Run("one is dev other is not, remove property", func(t *testing.T) {
+		t.Parallel()
+		metadata := PackageMetadata{
+			PackageManagerMetadata:  "npm",
+			IsDevDependencyMetadata: "true",
+		}
+		other := PackageMetadata{
+			PackageManagerMetadata: "npm",
+		}
+		result := metadata.Merge(other)
+
+		_, isDevDep := result[IsDevDependencyMetadata]
+		assert.False(t, isDevDep)
+	})
+}

--- a/pkg/models/package_metadata_test.go
+++ b/pkg/models/package_metadata_test.go
@@ -6,17 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPackageMetadata_MergeDevDepndency(t *testing.T) {
+func TestPackageMetadata_MergeDevDependency(t *testing.T) {
 	t.Parallel()
 
 	t.Run("both dev dependencies, keep property", func(t *testing.T) {
 		t.Parallel()
 		metadata := PackageMetadata{
-			PackageManagerMetadata:  "npm",
+			PackageManagerMetadata:  string(NPM),
 			IsDevDependencyMetadata: "true",
 		}
 		other := PackageMetadata{
-			PackageManagerMetadata:  "npm",
+			PackageManagerMetadata:  string(NPM),
 			IsDevDependencyMetadata: "true",
 		}
 		result := metadata.Merge(other)
@@ -25,14 +25,29 @@ func TestPackageMetadata_MergeDevDepndency(t *testing.T) {
 		assert.True(t, isDevDep)
 	})
 
-	t.Run("one is dev other is not, remove property", func(t *testing.T) {
+	t.Run("existing package is dev and incoming package is not, remove property", func(t *testing.T) {
 		t.Parallel()
 		metadata := PackageMetadata{
-			PackageManagerMetadata:  "npm",
+			PackageManagerMetadata:  string(NPM),
 			IsDevDependencyMetadata: "true",
 		}
 		other := PackageMetadata{
-			PackageManagerMetadata: "npm",
+			PackageManagerMetadata: string(NPM),
+		}
+		result := metadata.Merge(other)
+
+		_, isDevDep := result[IsDevDependencyMetadata]
+		assert.False(t, isDevDep)
+	})
+
+	t.Run("incoming package is dev and existing package is not, remove property", func(t *testing.T) {
+		t.Parallel()
+		metadata := PackageMetadata{
+			PackageManagerMetadata: string(NPM),
+		}
+		other := PackageMetadata{
+			PackageManagerMetadata:  string(NPM),
+			IsDevDependencyMetadata: "true",
 		}
 		result := metadata.Merge(other)
 


### PR DESCRIPTION
## What problem are you trying to solve?

We have seen issues in which we see packages reported with `is-dev` being set to true when we would not expect that to be the case - you can see examples in the linked Jira ticket.

## What is your solution?

- In the scanner we have a merging mechanism to handle when we have two packages that are the same, one being a direct dependency and one being a dev dependency (introduced to the scanner in this [PR](https://github.com/DataDog/osv-scanner/pull/128)).
- For marking dependencies as with `is-dev` set to true, if one of the two is not tagged with `is-dev` we keep the production priority 
- The fixes a bug in the merge logic in which we were comparing against the `is-dev` value rather than `is-direct` 
