### PR TITLE
[K9VULN-5123] Make result order deterministic

### DIFF
--- a/pkg/scanner/vulnerability_result.go
+++ b/pkg/scanner/vulnerability_result.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"log"
+	"sort"
 	"strconv"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
@@ -92,6 +93,10 @@ func groupBySource(r reporter.Reporter, packages []lockfile.PackageDetails, arti
 			Packages: packages,
 		})
 	}
+
+	sort.Slice(output.Results, func(i, j int) bool {
+		return output.Results[i].Source.Path < output.Results[j].Source.Path
+	})
 
 	return output
 }

--- a/pkg/scanner/vulnerability_result_test.go
+++ b/pkg/scanner/vulnerability_result_test.go
@@ -1,0 +1,54 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_groupBySource_OutputDeterministicOfInputOrder(t *testing.T) {
+	t.Parallel()
+
+	packages1 := []lockfile.PackageDetails{
+		{
+			Name:      "lodash",
+			Version:   "4.17.21",
+			Source:    models.SourceInfo{Path: "z-package-lock.json"},
+			Ecosystem: "npm",
+			PURL:      "pkg:npm/lodash@4.17.21",
+		},
+		{
+			Name:      "react",
+			Version:   "17.0.2",
+			Source:    models.SourceInfo{Path: "a-yarn.lock"},
+			Ecosystem: "npm",
+			PURL:      "pkg:npm/react@17.0.2",
+		},
+	}
+
+	packages2 := []lockfile.PackageDetails{
+		{
+			Name:      "react",
+			Version:   "17.0.2",
+			Source:    models.SourceInfo{Path: "a-yarn.lock"},
+			Ecosystem: "npm",
+			PURL:      "pkg:npm/react@17.0.2",
+		},
+		{
+			Name:      "lodash",
+			Version:   "4.17.21",
+			Source:    models.SourceInfo{Path: "z-package-lock.json"},
+			Ecosystem: "npm",
+			PURL:      "pkg:npm/lodash@4.17.21",
+		},
+	}
+
+	result1 := groupBySource(&reporter.VoidReporter{}, packages1, []models.ScannedArtifact{}, models.ReachabilityAnalysis{})
+	result2 := groupBySource(&reporter.VoidReporter{}, packages2, []models.ScannedArtifact{}, models.ReachabilityAnalysis{})
+
+	// Results should be identical regardless of input order
+	assert.Equal(t, result1, result2)
+}


### PR DESCRIPTION
## What problem are you trying to solve?

- We have seen discrepancies in results when scanning the same repo.  Specifically this happens when the same package is present in different lockfiles (in this case npm and yarn lockfiles) 
   - As a result the relevant libraries have the same PURL which is what we key in on
- We have deduplication logic for packages with the same PURL, but the results we pass in are not ordered as iterating through a map in go is not ordered
  - In this case the package manager we see first will be maintained, but this can vary between runs

## What is your solution?
We should order our results so that things are deterministic - this will also help comparing sboms side by side

## Alternatives considered
- Making custom weights to see which package manager should take precedent - I figured this would be arbitrary and hard to describe our rationale as to what we prioritize 
- No longer key in on PURL's and pass information about both instances we see (one per package manager) - I figured this is out of scope and would require a much larger discussion as this would have a non significant effect on our backend 

## What the reviewer should know
- This logic is also being done in the upstream osv-scanner we originally forked, you can see the PR [here](https://github.com/google/osv-scanner/pull/220)
- We should lets this run in staging to determine this has no discernable impact on performance
