### PR TITLE
[K9VULN-5997] Fail scanning without provided path

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -1,28 +1,10 @@
 
 [TestRun/#00 - 1]
-{
-  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
-  "version": 1,
-  "metadata": {
-    "tools": {
-      "components": [
-        {
-          "type": "application",
-          "group": "datadog",
-          "name": "datadog-sbom-generator",
-          "version": "set at build time, see .goreleaser.yml ldflags section"
-        }
-      ]
-    }
-  }
-}
 
 ---
 
 [TestRun/#00 - 2]
-No package sources found, --help for usage information.
+no directory paths provided to scan
 
 ---
 
@@ -350,7 +332,7 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
 ---
 
 [TestRun/Scan_locks-many_with_exclusion - 2]
-Scanning dir ./fixtures/locks-many
+Scanning directory './fixtures/locks-many', resolved absolute path '<rootdir>/fixtures/locks-many'
 Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
 Skipping <rootdir>/fixtures/locks-many/composer.lock with exclusion rule: *composer.lock
 Skipping <rootdir>/fixtures/locks-many/package-lock.json with exclusion rule: *package-lock.json
@@ -706,7 +688,7 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
 
 ---
 
-[TestRun/verbosity_level_=_info - 1]
+[TestRun/verbosity_level_=_verbose - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
@@ -743,8 +725,8 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
 
 ---
 
-[TestRun/verbosity_level_=_info - 2]
-Scanning dir ./fixtures/locks-many/composer.lock
+[TestRun/verbosity_level_=_verbose - 2]
+Scanning directory './fixtures/locks-many/composer.lock', resolved absolute path '<rootdir>/fixtures/locks-many/composer.lock'
 Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 [reachability] Reachability analysis is disabled
 ---

--- a/cmd/datadog-sbom-generator/main_test.go
+++ b/cmd/datadog-sbom-generator/main_test.go
@@ -157,7 +157,7 @@ func TestRun(t *testing.T) {
 		{
 			name: "",
 			args: []string{""},
-			exit: 0,
+			exit: 127,
 		},
 		{
 			name: "",
@@ -240,13 +240,13 @@ func TestRun(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name: "verbosity level = info",
-			args: []string{"", "--verbosity", "info", "./fixtures/locks-many/composer.lock"},
+			name: "verbosity level = verbose",
+			args: []string{"", "--verbosity", "verbose", "./fixtures/locks-many/composer.lock"},
 			exit: 0,
 		},
 		{
 			name: "Scan locks-many with exclusion",
-			args: []string{"", "--verbosity", "info", "--exclude", "*composer.lock,*yarn.lock,*package-lock.json", "./fixtures/locks-many"},
+			args: []string{"", "--verbosity", "verbose", "--exclude", "*composer.lock,*yarn.lock,*package-lock.json", "./fixtures/locks-many"},
 			exit: 0,
 		},
 	}

--- a/pkg/scanner/datadog_sbom_generator.go
+++ b/pkg/scanner/datadog_sbom_generator.go
@@ -36,6 +36,9 @@ type DDEnvVars struct {
 	JwtToken string
 }
 
+// NoDirectoryPathsFoundErr for when no directory paths are provided to scan.
+var NoDirectoryPathsFoundErr = errors.New("no directory paths provided to scan")
+
 // NoPackagesFoundErr for when no packages are found during a scan.
 //
 //nolint:errname,stylecheck // Would require version major bump to change
@@ -184,7 +187,7 @@ func scanLockfile(r reporter.Reporter, path string, enabledParsers map[string]bo
 		return nil, nil, err
 	}
 
-	r.Infof(
+	r.Verbosef(
 		"Scanned %s file and found %d %s\n",
 		path,
 		len(parsedLockfile.Packages),
@@ -219,6 +222,10 @@ func initializeEnabledParsers(enabledParsers []string) map[string]bool {
 
 // DoScan Perform datadog-sbom-generator scan action, with optional reporter to output information
 func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityResults, error) {
+	if len(actions.DirectoryPaths) == 0 {
+		return models.VulnerabilityResults{}, NoDirectoryPathsFoundErr
+	}
+
 	enabledParsers := initializeEnabledParsers(actions.EnableParsers)
 
 	if r == nil {
@@ -233,7 +240,11 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	}
 
 	for _, dir := range actions.DirectoryPaths {
-		r.Infof("Scanning dir %s\n", dir)
+		absolutePath := dir
+		if absPath, err := filepath.Abs(dir); err == nil {
+			absolutePath = absPath
+		}
+		r.Infof("Scanning directory '%s', resolved absolute path '%s'\n", dir, absolutePath)
 		pkgs, artifacts, err := scanDir(r, dir, actions.Recursive, !actions.NoIgnore, enabledParsers, actions.ExcludePaths)
 		if err != nil {
 			return models.VulnerabilityResults{}, err

--- a/pkg/scanner/datadog_sbom_generator.go
+++ b/pkg/scanner/datadog_sbom_generator.go
@@ -37,6 +37,8 @@ type DDEnvVars struct {
 }
 
 // NoDirectoryPathsFoundErr for when no directory paths are provided to scan.
+//
+//nolint:errname,stylecheck // Would require version major bump to change
 var NoDirectoryPathsFoundErr = errors.New("no directory paths provided to scan")
 
 // NoPackagesFoundErr for when no packages are found during a scan.

--- a/pkg/scanner/datadog_sbom_generator_test.go
+++ b/pkg/scanner/datadog_sbom_generator_test.go
@@ -53,6 +53,7 @@ func Test_scanDir(t *testing.T) {
 
 	mockReporter := reporter.NewMockReporter(ctrl)
 	mockReporter.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+	mockReporter.EXPECT().Verbosef(gomock.Any(), gomock.Any()).AnyTimes()
 	mockReporter.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
 
 	// Call scanDir without exclusion


### PR DESCRIPTION
## What problem are you trying to solve?
Some customers failed to see that they did not provide any paths to scan… This went all the way to an actual customer call which could have been easily avoided. 

The default behavior when scanning without paths is to return that there is nothing found.

<img width="586" alt="Screenshot 2025-06-23 at 16 21 54" src="https://github.com/user-attachments/assets/6e937a23-d74b-4349-a0fe-6bacfc29e6d0" />

## What is your solution?
Fail to scan when there is no path provided

<img width="1117" alt="Screenshot 2025-06-23 at 16 21 42" src="https://github.com/user-attachments/assets/71c2ba66-322d-4081-b433-464fb44cff68" />

## Alternatives considered
Not failing but doing a default to `current_dir`, which I'd rather not do, as I want customers to proactivitely select what they will scan

## What the reviewer should know
