### PR TITLE
Adding attribution to osv-scanner

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,3 +2,10 @@ Datadog datadog-sbom-generator
 Copyright 2025-Present Datadog, Inc.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+Portions of this product are derived from the osv-scanner project, originally developed by Google.
+Copyright 2022 Google LLC.
+
+The original project is available at: https://github.com/google/osv-scanner
+
+This usage does not imply endorsement by Google or affiliation with the original project.

--- a/README.md
+++ b/README.md
@@ -124,3 +124,8 @@ This tool only supports enriching information from the following package manager
 ## License
 
 The Datadog version of datadog-sbom-generator is licensed under the [Apache License, Version 2.0](LICENSE).
+
+## Acknowledgement
+
+This project builds upon portions of the osv-scanner project originally developed by Google and released under the Apache License 2.0.
+We thank the original authors for their foundational work.


### PR DESCRIPTION
## Summary
This PR adds proper attribution to the [osv-scanner](https://github.com/google/osv-scanner) project developed by Google, which served as an initial foundation for parts of this repository.

Although we have fully decoupled our codebase from the original fork and removed unused components, we continue to reuse and build upon select parts of the original implementation. As osv-scanner is licensed under Apache License 2.0, we are including appropriate acknowledgments as per the license requirements.