### PR TITLE
[K9VULN-6217] Avoid reporting duplicate location file for a same package

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -513,6 +513,321 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
 
 ---
 
+[TestRun/nested_requirements_files - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:pypi/black@25.1.0",
+      "type": "library",
+      "name": "black",
+      "version": "25.1.0",
+      "purl": "pkg:pypi/black@25.1.0",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":10,/"line_end/":10,/"column_start/":1,/"column_end/":14},/"name/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":10,/"line_end/":10,/"column_start/":1,/"column_end/":6},/"version/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":10,/"line_end/":10,/"column_start/":8,/"column_end/":14}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/dirty-equals@0.8.0",
+      "type": "library",
+      "name": "dirty-equals",
+      "version": "0.8.0",
+      "purl": "pkg:pypi/dirty-equals@0.8.0",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":21},/"name/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":13},/"version/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":5,/"line_end/":5,/"column_start/":16,/"column_end/":21}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/inline-snapshot@0.19.3",
+      "type": "library",
+      "name": "inline-snapshot",
+      "version": "0.19.3",
+      "purl": "pkg:pypi/inline-snapshot@0.19.3",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":24},/"name/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":16},/"version/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":12,/"line_end/":12,/"column_start/":18,/"column_end/":24}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/jieba@0.42.1",
+      "type": "library",
+      "name": "jieba",
+      "version": "0.42.1",
+      "purl": "pkg:pypi/jieba@0.42.1",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":8,/"line_end/":8,/"column_start/":1,/"column_end/":14},/"name/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":8,/"line_end/":8,/"column_start/":1,/"column_end/":6},/"version/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":8,/"line_end/":8,/"column_start/":8,/"column_end/":14}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/markdown-include-variants@0.0.4",
+      "type": "library",
+      "name": "markdown-include-variants",
+      "version": "0.0.4",
+      "purl": "pkg:pypi/markdown-include-variants@0.0.4",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":33},/"name/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26},/"version/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":12,/"line_end/":12,/"column_start/":28,/"column_end/":33}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/mkdocs-macros-plugin@1.3.7",
+      "type": "library",
+      "name": "mkdocs-macros-plugin",
+      "version": "1.3.7",
+      "purl": "pkg:pypi/mkdocs-macros-plugin@1.3.7",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":11,/"line_end/":11,/"column_start/":1,/"column_end/":28},/"name/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":11,/"line_end/":11,/"column_start/":1,/"column_end/":21},/"version/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":11,/"line_end/":11,/"column_start/":23,/"column_end/":28}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/mkdocs-material@9.6.1",
+      "type": "library",
+      "name": "mkdocs-material",
+      "version": "9.6.1",
+      "purl": "pkg:pypi/mkdocs-material@9.6.1",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":2,/"line_end/":2,/"column_start/":1,/"column_end/":23},/"name/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":2,/"line_end/":2,/"column_start/":1,/"column_end/":16},/"version/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":2,/"line_end/":2,/"column_start/":18,/"column_end/":23}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/mypy@1.8.0",
+      "type": "library",
+      "name": "mypy",
+      "version": "1.8.0",
+      "purl": "pkg:pypi/mypy@1.8.0",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":13},/"name/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":5},/"version/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":4,/"line_end/":4,/"column_start/":8,/"column_end/":13}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/playwright",
+      "type": "library",
+      "name": "playwright",
+      "purl": "pkg:pypi/playwright",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements.txt/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":11},/"name/":{/"file_name/":/"requirements.txt/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":11}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/pyjwt@2.8.0",
+      "type": "library",
+      "name": "pyjwt",
+      "version": "2.8.0",
+      "purl": "pkg:pypi/pyjwt@2.8.0",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":9,/"line_end/":9,/"column_start/":1,/"column_end/":13},/"name/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":9,/"line_end/":9,/"column_start/":1,/"column_end/":6},/"version/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":9,/"line_end/":9,/"column_start/":8,/"column_end/":13}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/sqlmodel@0.0.23",
+      "type": "library",
+      "name": "sqlmodel",
+      "version": "0.0.23",
+      "purl": "pkg:pypi/sqlmodel@0.0.23",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":17},/"name/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":9},/"version/":{/"file_name/":/"requirements-tests.txt/",/"line_start/":6,/"line_end/":6,/"column_start/":11,/"column_end/":17}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/typer@0.12.5",
+      "type": "library",
+      "name": "typer",
+      "version": "0.12.5",
+      "purl": "pkg:pypi/typer@0.12.5",
+      "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "osv-scanner:package-manager",
+          "value": "Requirements"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":16},/"name/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":6},/"version/":{/"file_name/":/"requirements-docs.txt/",/"line_start/":5,/"line_end/":5,/"column_start/":10,/"column_end/":16}}"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+---
+
+[TestRun/nested_requirements_files - 2]
+
+---
+
 [TestRun/not_lockfile - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",

--- a/cmd/datadog-sbom-generator/fixtures/locks-requirements/requirements-docs.txt
+++ b/cmd/datadog-sbom-generator/fixtures/locks-requirements/requirements-docs.txt
@@ -1,0 +1,12 @@
+-e .
+mkdocs-material==9.6.1
+mdx-include >=1.4.1,<2.0.0
+mkdocs-redirects>=1.2.1,<1.3.0
+typer == 0.12.5
+pyyaml >=5.3.1,<7.0.0
+# For Material for MkDocs, Chinese search
+jieba==0.42.1
+# For griffe, it formats with black
+black==25.1.0
+mkdocs-macros-plugin==1.3.7
+markdown-include-variants==0.0.4

--- a/cmd/datadog-sbom-generator/fixtures/locks-requirements/requirements-tests.txt
+++ b/cmd/datadog-sbom-generator/fixtures/locks-requirements/requirements-tests.txt
@@ -1,0 +1,12 @@
+-e .[all]
+pytest >=7.1.3,<9.0.0
+coverage[toml] >= 6.5.0,< 8.0
+mypy ==1.8.0
+dirty-equals ==0.8.0
+sqlmodel==0.0.23
+flask >=1.1.2,<4.0.0
+anyio[trio] >=3.2.1,<5.0.0
+PyJWT==2.8.0
+pyyaml >=5.3.1,<7.0.0
+passlib[bcrypt] >=1.7.2,<2.0.0
+inline-snapshot==0.19.3

--- a/cmd/datadog-sbom-generator/fixtures/locks-requirements/requirements.txt
+++ b/cmd/datadog-sbom-generator/fixtures/locks-requirements/requirements.txt
@@ -1,0 +1,6 @@
+-e .[all]
+-r requirements-tests.txt
+-r requirements-docs.txt
+pre-commit >=2.17.0,<5.0.0
+# For generating screenshots
+playwright

--- a/cmd/datadog-sbom-generator/main_test.go
+++ b/cmd/datadog-sbom-generator/main_test.go
@@ -205,6 +205,12 @@ func TestRun(t *testing.T) {
 			args: []string{"", "./fixtures/locks-one-with-nested"},
 			exit: 0,
 		},
+		// requirements files are referencing each other
+		{
+			name: "nested requirements files",
+			args: []string{"", "./fixtures/locks-requirements"},
+			exit: 0,
+		},
 		// .gitignored files
 		{
 			name: "",

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -75,6 +75,12 @@ func BuildCycloneDXBom(tool Tool, uniquePackages map[string]models.PackageVulns,
 func addLocations(component *cyclonedx.Component, details models.PackageVulns) {
 	occurrences := make([]cyclonedx.EvidenceOccurrence, 0)
 
+	// Track unique jsonLocation values
+	// If lock files are self referencing each other,
+	// we might have been traversing the same file more than once.
+	// Causing multiple identical locations to be reported.
+	seenLocations := make(map[string]struct{})
+
 	for _, packageLocations := range details.Locations {
 		cleanedLocation := packageLocations.Clean()
 
@@ -86,10 +92,14 @@ func addLocations(component *cyclonedx.Component, details models.PackageVulns) {
 		if err != nil {
 			continue
 		}
+		if _, exists := seenLocations[jsonLocation]; exists {
+			continue // Skip duplicate jsonLocation
+		}
 		occurrence := cyclonedx.EvidenceOccurrence{
 			Location: jsonLocation,
 		}
 		occurrences = append(occurrences, occurrence)
+		seenLocations[jsonLocation] = struct{}{}
 	}
 	if len(occurrences) > 0 {
 		component.Evidence = &cyclonedx.Evidence{Occurrences: &occurrences}


### PR DESCRIPTION
## What problem are you trying to solve?
Fixed an issue where the same package location was being reported multiple times in the SBOM output

## What is your solution?
Added deduplication logic to track unique jsonLocation values when processing package locations. This prevents duplicate occurrences when lock files reference each other, causing the same file to be traversed multiple times 


## Alternatives considered

## What the reviewer should know
When parsing "lockfiles" that reference each other (e.g., `requirements.txt` includes `-r requirements-tests.txt` and `-r requirements-docs.txt`), the SBOM generator would traverse the same files multiple times. This caused identical package locations to be reported as separate occurrences in the final SBOM output, creating noise.
As each parser could implement self referencing differently, I'm going with the approach of fixing it in the reporting of the location. And not having to manage the self referencing of files. 
