### PR TITLE
[K9VULN-1327] Optimize workspace package.json parsing performance

### DIFF
--- a/pkg/lockfile/match-package-json.go
+++ b/pkg/lockfile/match-package-json.go
@@ -53,7 +53,7 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 	var parsed map[string]interface{}
 	unmarshallErr := json.Unmarshal(data, &parsed)
 	if unmarshallErr != nil {
-		log.Printf("could not unmarshal %s", packageJSONContent)
+		log.Printf("could not unmarshal %s, received error of %s", packageJSONContent, unmarshallErr)
 	}
 
 	dependencyNames := make(map[string]bool)


### PR DESCRIPTION
## 🚀 Motivation 
Large monorepos with many workspaces experience significant performance bottlenecks with the advent of workspace support in the generator.  Specifically for repos such as `web-ui` scans now take over 2 minutes,  leading to timeouts and errors in the SCA cwp runner.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [K9VULN-1327](https://datadoghq.atlassian.net/browse/K9VULN-1327)

## 📝 Summary
When parsing the dependencies in a `package.json` file we check all of the entries in the projects lock file against it.  This worked in our prior paradigm when we expected only one `package.json` file at the root, and as such could expect to find all the packages from the lockfile there.

With the advent of having multiple `package.json` files through workspace support this prior assumption is not true and leads to a lot of unnecessary computation.  Typically with workspaces a `package.json` file would only contain a small subset of the lockfile entries, so processing all of them is wasteful.  

This change makes it so that per package.json file:
    - We still iterate over every entry in the lockfile
    - But now we will skip processing if we find the lockfile entry is not in the particular set of dependencies we are processing 

## 🧪 Testing
- [X] Benchmark results prove that performance is the same or better.
     - Performance improvement: ~70% reduction in execution time (150s -> 46s) on the web-ui monorepo.
- [X] Diffed outputs before and after change to verify the output was the same
     - [before-optimization.json](https://github.com/user-attachments/files/21798781/before-optimization.json)
     - [after-optimization.json](https://github.com/user-attachments/files/21798783/after-optimization.json)

<img width="872" height="230" alt="Screenshot 2025-08-15 at 11 32 25 AM" src="https://github.com/user-attachments/assets/9d111de8-1996-4021-b4f9-b56aa7c96ee1" />

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:

[K9VULN-1327]: https://datadoghq.atlassian.net/browse/K9VULN-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ