### PR TITLE
Export lockfile locations in SBOM output

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -161,15 +161,15 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "properties": [
         {
           "name": "datadog-sbom-generator:lockfile-filepath",
-          "value": "subdir/Gemfile.lock"
-        },
-        {
-          "name": "datadog-sbom-generator:lockfile-filepath",
           "value": "Gemfile.lock"
         },
         {
           "name": "datadog-sbom-generator:lockfile-filepath",
           "value": "ignored/Gemfile.lock"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "subdir/Gemfile.lock"
         },
         {
           "name": "osv-scanner:is-direct",
@@ -900,11 +900,11 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "properties": [
         {
           "name": "datadog-sbom-generator:lockfile-filepath",
-          "value": "requirements.txt"
+          "value": "requirements-tests.txt"
         },
         {
           "name": "datadog-sbom-generator:lockfile-filepath",
-          "value": "requirements-tests.txt"
+          "value": "requirements.txt"
         },
         {
           "name": "osv-scanner:is-direct",
@@ -964,11 +964,11 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "properties": [
         {
           "name": "datadog-sbom-generator:lockfile-filepath",
-          "value": "requirements.txt"
+          "value": "requirements-docs.txt"
         },
         {
           "name": "datadog-sbom-generator:lockfile-filepath",
-          "value": "requirements-docs.txt"
+          "value": "requirements.txt"
         },
         {
           "name": "osv-scanner:is-direct",

--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -73,6 +73,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/ast@2.4.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -89,6 +93,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "subdir/yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -131,6 +139,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer.lock"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "subdir/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -143,6 +159,18 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.4.2",
       "purl": "pkg:gem/ast@2.4.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "subdir/Gemfile.lock"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "ignored/Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -160,6 +188,18 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "ignored/yarn.lock"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "subdir/yarn.lock"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -222,6 +262,10 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -234,6 +278,10 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
       "version": "2.4.2",
       "purl": "pkg:gem/ast@2.4.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -252,6 +300,10 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
       "purl": "pkg:npm/ansi-html@0.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -264,6 +316,10 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -317,6 +373,10 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
       "purl": "pkg:gem/ast@2.4.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -367,6 +427,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "purl": "pkg:gem/ast@2.4.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -383,6 +447,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -475,6 +543,10 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nested/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -487,6 +559,10 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -540,6 +616,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "purl": "pkg:pypi/black@25.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-docs.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -563,6 +647,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "version": "0.8.0",
       "purl": "pkg:pypi/dirty-equals@0.8.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-tests.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -588,6 +680,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "purl": "pkg:pypi/inline-snapshot@0.19.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-tests.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -611,6 +711,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "version": "0.42.1",
       "purl": "pkg:pypi/jieba@0.42.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-docs.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -636,6 +744,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "purl": "pkg:pypi/markdown-include-variants@0.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-docs.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -659,6 +775,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "version": "1.3.7",
       "purl": "pkg:pypi/mkdocs-macros-plugin@1.3.7",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-docs.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -684,6 +808,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "purl": "pkg:pypi/mkdocs-material@9.6.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-docs.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -708,6 +840,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "purl": "pkg:pypi/mypy@1.8.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-tests.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -730,6 +870,10 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "name": "playwright",
       "purl": "pkg:pypi/playwright",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -755,6 +899,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "purl": "pkg:pypi/pyjwt@2.8.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-tests.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -779,6 +931,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "purl": "pkg:pypi/sqlmodel@0.0.23",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-tests.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -802,6 +962,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "version": "0.12.5",
       "purl": "pkg:pypi/typer@0.12.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-docs.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -882,6 +1050,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -923,6 +1095,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ansi-html@0.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -963,6 +1139,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -1016,6 +1196,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -1056,6 +1240,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.4",
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -1157,6 +1345,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1169,6 +1361,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.12.1",
       "purl": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1183,6 +1379,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1195,6 +1395,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.5",
       "purl": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1209,6 +1413,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1221,6 +1429,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "7.0.15",
       "purl": "pkg:npm/%40types%2Fjson-schema@7.0.15",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1235,6 +1447,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fsemver@7.5.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1247,6 +1463,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1261,6 +1481,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1273,6 +1497,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1287,6 +1515,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1299,6 +1531,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1313,6 +1549,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1325,6 +1565,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1339,6 +1583,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/array-union@2.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1352,6 +1600,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/braces@3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1364,6 +1616,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.5.2",
       "purl": "pkg:npm/debug@2.5.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -1382,6 +1638,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/debug@4.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1394,6 +1654,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.1",
       "purl": "pkg:npm/dir-glob@3.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1408,6 +1672,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint-scope@5.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1420,6 +1688,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.4.3",
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1434,6 +1706,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esrecurse@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1446,6 +1722,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.3.0",
       "purl": "pkg:npm/estraverse@4.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1460,6 +1740,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/estraverse@5.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1472,6 +1756,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.3.3",
       "purl": "pkg:npm/fast-glob@3.3.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1486,6 +1774,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fastq@1.18.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1498,6 +1790,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "7.1.1",
       "purl": "pkg:npm/fill-range@7.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1512,6 +1808,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob-parent@5.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1524,6 +1824,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "11.1.0",
       "purl": "pkg:npm/globby@11.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1538,6 +1842,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/graphemer@1.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1550,6 +1858,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.2",
       "purl": "pkg:npm/ignore@5.3.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1564,6 +1876,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-extglob@2.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1576,6 +1892,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.3",
       "purl": "pkg:npm/is-glob@4.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1590,6 +1910,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-number@7.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1602,6 +1926,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.1",
       "purl": "pkg:npm/merge2@1.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1616,6 +1944,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/micromatch@4.0.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1628,6 +1960,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.7.2",
       "purl": "pkg:npm/ms@0.7.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -1646,6 +1982,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1658,6 +1998,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/natural-compare-lite@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1672,6 +2016,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-type@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1684,6 +2032,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.3.1",
       "purl": "pkg:npm/picomatch@2.3.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1698,6 +2050,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1710,6 +2066,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.4",
       "purl": "pkg:npm/reusify@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1724,6 +2084,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/run-parallel@1.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1736,6 +2100,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "7.6.3",
       "purl": "pkg:npm/semver@7.6.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1750,6 +2118,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/slash@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1762,6 +2134,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.0.1",
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1776,6 +2152,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/tslib@1.14.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1788,6 +2168,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.21.0",
       "purl": "pkg:npm/tsutils@3.21.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1830,6 +2214,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint%2Feslintrc@2.1.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1842,6 +2230,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "8.57.1",
       "purl": "pkg:npm/%40eslint%2Fjs@8.57.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1856,6 +2248,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1868,6 +2264,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.12.1",
       "purl": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1882,6 +2282,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1894,6 +2298,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1908,6 +2316,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1920,6 +2332,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.1.5",
       "purl": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1934,6 +2350,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1946,6 +2366,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.8",
       "purl": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -1960,6 +2384,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fjson-schema@7.0.15",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1973,6 +2401,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fsemver@7.5.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -1985,6 +2417,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -2010,6 +2446,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fparser@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2022,6 +2462,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2036,6 +2480,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2048,6 +2496,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2062,6 +2514,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2074,6 +2530,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2088,6 +2548,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2100,6 +2564,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.1",
       "purl": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2114,6 +2582,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/acorn-jsx@5.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2126,6 +2598,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "8.14.0",
       "purl": "pkg:npm/acorn@8.14.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2140,6 +2616,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ajv@6.12.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2152,6 +2632,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.0.1",
       "purl": "pkg:npm/ansi-regex@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2166,6 +2650,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ansi-styles@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2178,6 +2666,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.1",
       "purl": "pkg:npm/argparse@2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2192,6 +2684,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/array-union@2.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2204,6 +2700,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2218,6 +2718,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/brace-expansion@1.1.11",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2230,6 +2734,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.3",
       "purl": "pkg:npm/braces@3.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2244,6 +2752,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/callsites@3.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2256,6 +2768,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.1.2",
       "purl": "pkg:npm/chalk@4.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2270,6 +2786,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/color-convert@2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2282,6 +2802,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.1.4",
       "purl": "pkg:npm/color-name@1.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2296,6 +2820,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/concat-map@0.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2309,6 +2837,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/cross-spawn@7.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2321,6 +2853,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.5.2",
       "purl": "pkg:npm/debug@2.5.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -2350,6 +2886,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/debug@4.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2362,6 +2902,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.4",
       "purl": "pkg:npm/deep-is@0.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2376,6 +2920,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/dir-glob@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2388,6 +2936,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.0",
       "purl": "pkg:npm/doctrine@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2402,6 +2954,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/escape-string-regexp@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2414,6 +2970,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.1.1",
       "purl": "pkg:npm/eslint-scope@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2428,6 +2988,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint-scope@7.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2440,6 +3004,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.4.3",
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2454,6 +3022,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint@8.57.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2466,6 +3038,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "9.6.1",
       "purl": "pkg:npm/espree@9.6.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2480,6 +3056,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esquery@1.6.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2492,6 +3072,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.3.0",
       "purl": "pkg:npm/esrecurse@4.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2506,6 +3090,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/estraverse@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2518,6 +3106,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.0",
       "purl": "pkg:npm/estraverse@5.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2532,6 +3124,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esutils@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2544,6 +3140,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.3",
       "purl": "pkg:npm/fast-deep-equal@3.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2558,6 +3158,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fast-glob@3.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2570,6 +3174,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.1.0",
       "purl": "pkg:npm/fast-json-stable-stringify@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2584,6 +3192,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fast-levenshtein@2.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2596,6 +3208,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.18.0",
       "purl": "pkg:npm/fastq@1.18.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2610,6 +3226,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/file-entry-cache@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2622,6 +3242,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "7.1.1",
       "purl": "pkg:npm/fill-range@7.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2636,6 +3260,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/find-up@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2648,6 +3276,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.2.0",
       "purl": "pkg:npm/flat-cache@3.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2662,6 +3294,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/flatted@3.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2674,6 +3310,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.0",
       "purl": "pkg:npm/fs.realpath@1.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2688,6 +3328,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob-parent@5.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2700,6 +3344,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.2",
       "purl": "pkg:npm/glob-parent@6.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2714,6 +3362,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob@7.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2726,6 +3378,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "13.24.0",
       "purl": "pkg:npm/globals@13.24.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2740,6 +3396,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/globby@11.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2752,6 +3412,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/graphemer@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2766,6 +3430,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/has-flag@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2778,6 +3446,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.2",
       "purl": "pkg:npm/ignore@5.3.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2792,6 +3464,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/import-fresh@3.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2804,6 +3480,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.4",
       "purl": "pkg:npm/imurmurhash@0.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2818,6 +3498,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/inflight@1.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2830,6 +3514,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.4",
       "purl": "pkg:npm/inherits@2.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2844,6 +3532,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-extglob@2.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2856,6 +3548,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.3",
       "purl": "pkg:npm/is-glob@4.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2870,6 +3566,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-number@7.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2882,6 +3582,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.3",
       "purl": "pkg:npm/is-path-inside@3.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2896,6 +3600,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/isexe@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2908,6 +3616,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.1.0",
       "purl": "pkg:npm/js-yaml@4.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2922,6 +3634,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/json-buffer@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2934,6 +3650,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.4.1",
       "purl": "pkg:npm/json-schema-traverse@0.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2948,6 +3668,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2960,6 +3684,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.5.4",
       "purl": "pkg:npm/keyv@4.5.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -2974,6 +3702,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/levn@0.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -2986,6 +3718,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.0",
       "purl": "pkg:npm/locate-path@6.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3000,6 +3736,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/lodash.merge@4.6.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3012,6 +3752,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.1",
       "purl": "pkg:npm/merge2@1.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3026,6 +3770,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/micromatch@4.0.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3039,6 +3787,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/minimatch@3.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3051,6 +3803,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.7.2",
       "purl": "pkg:npm/ms@0.7.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -3069,6 +3825,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3081,6 +3841,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/natural-compare-lite@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3095,6 +3859,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/natural-compare@1.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3107,6 +3875,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/once@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3121,6 +3893,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/optionator@0.9.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3133,6 +3909,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.0",
       "purl": "pkg:npm/p-limit@3.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3147,6 +3927,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/p-locate@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3159,6 +3943,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/parent-module@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3173,6 +3961,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-exists@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3185,6 +3977,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/path-is-absolute@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3199,6 +3995,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-key@3.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3211,6 +4011,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.0",
       "purl": "pkg:npm/path-type@4.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3225,6 +4029,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/picomatch@2.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3237,6 +4045,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.1",
       "purl": "pkg:npm/prelude-ls@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3251,6 +4063,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/punycode@2.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3263,6 +4079,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.3",
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3277,6 +4097,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/resolve-from@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3289,6 +4113,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.4",
       "purl": "pkg:npm/reusify@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3303,6 +4131,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/rimraf@3.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3315,6 +4147,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.0",
       "purl": "pkg:npm/run-parallel@1.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3329,6 +4165,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/semver@7.6.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3341,6 +4181,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.0",
       "purl": "pkg:npm/shebang-command@2.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3355,6 +4199,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/shebang-regex@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3367,6 +4215,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.0",
       "purl": "pkg:npm/slash@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3381,6 +4233,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/strip-ansi@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3393,6 +4249,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.1",
       "purl": "pkg:npm/strip-json-comments@3.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3407,6 +4267,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/supports-color@7.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3419,6 +4283,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.2.0",
       "purl": "pkg:npm/text-table@0.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3433,6 +4301,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3445,6 +4317,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.14.1",
       "purl": "pkg:npm/tslib@1.14.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3459,6 +4335,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/tsutils@3.21.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3471,6 +4351,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.4.0",
       "purl": "pkg:npm/type-check@0.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3485,6 +4369,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/type-fest@0.20.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3497,6 +4385,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.7.3",
       "purl": "pkg:npm/typescript@5.7.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3511,6 +4403,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/uri-js@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3523,6 +4419,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.2",
       "purl": "pkg:npm/which@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3537,6 +4437,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/word-wrap@1.2.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3550,6 +4454,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3562,6 +4470,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.0",
       "purl": "pkg:npm/yocto-queue@0.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3604,6 +4516,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint%2Feslintrc@2.1.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3616,6 +4532,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "8.57.1",
       "purl": "pkg:npm/%40eslint%2Fjs@8.57.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3630,6 +4550,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3642,6 +4566,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.12.1",
       "purl": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3656,6 +4584,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3668,6 +4600,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3682,6 +4618,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3694,6 +4634,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.1.5",
       "purl": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3708,6 +4652,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3720,6 +4668,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.8",
       "purl": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3734,6 +4686,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fjson-schema@7.0.15",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3747,6 +4703,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fsemver@7.5.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3759,6 +4719,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -3784,6 +4748,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fparser@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3796,6 +4764,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3810,6 +4782,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3822,6 +4798,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3836,6 +4816,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3848,6 +4832,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3862,6 +4850,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3874,6 +4866,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.1",
       "purl": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3888,6 +4884,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/acorn-jsx@5.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3900,6 +4900,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "8.14.0",
       "purl": "pkg:npm/acorn@8.14.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3914,6 +4918,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ajv@6.12.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3926,6 +4934,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.0.1",
       "purl": "pkg:npm/ansi-regex@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3940,6 +4952,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ansi-styles@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3952,6 +4968,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.1",
       "purl": "pkg:npm/argparse@2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3966,6 +4986,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/array-union@2.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -3978,6 +5002,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -3992,6 +5020,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/brace-expansion@1.1.11",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4004,6 +5036,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.3",
       "purl": "pkg:npm/braces@3.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4018,6 +5054,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/callsites@3.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4030,6 +5070,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.1.2",
       "purl": "pkg:npm/chalk@4.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4044,6 +5088,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/color-convert@2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4056,6 +5104,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.1.4",
       "purl": "pkg:npm/color-name@1.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4070,6 +5122,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/concat-map@0.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4083,6 +5139,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/cross-spawn@7.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4095,6 +5155,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.5.2",
       "purl": "pkg:npm/debug@2.5.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -4124,6 +5188,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/debug@4.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4136,6 +5204,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.4",
       "purl": "pkg:npm/deep-is@0.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4150,6 +5222,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/dir-glob@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4162,6 +5238,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.0",
       "purl": "pkg:npm/doctrine@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4176,6 +5256,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/escape-string-regexp@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4188,6 +5272,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.1.1",
       "purl": "pkg:npm/eslint-scope@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4202,6 +5290,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint-scope@7.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4214,6 +5306,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.4.3",
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4228,6 +5324,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint@8.57.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4240,6 +5340,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "9.6.1",
       "purl": "pkg:npm/espree@9.6.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4254,6 +5358,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esquery@1.6.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4266,6 +5374,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.3.0",
       "purl": "pkg:npm/esrecurse@4.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4280,6 +5392,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/estraverse@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4292,6 +5408,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.0",
       "purl": "pkg:npm/estraverse@5.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4306,6 +5426,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esutils@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4318,6 +5442,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.3",
       "purl": "pkg:npm/fast-deep-equal@3.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4332,6 +5460,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fast-glob@3.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4344,6 +5476,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.1.0",
       "purl": "pkg:npm/fast-json-stable-stringify@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4358,6 +5494,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fast-levenshtein@2.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4370,6 +5510,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.18.0",
       "purl": "pkg:npm/fastq@1.18.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4384,6 +5528,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/file-entry-cache@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4396,6 +5544,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "7.1.1",
       "purl": "pkg:npm/fill-range@7.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4410,6 +5562,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/find-up@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4422,6 +5578,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.2.0",
       "purl": "pkg:npm/flat-cache@3.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4436,6 +5596,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/flatted@3.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4448,6 +5612,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.0",
       "purl": "pkg:npm/fs.realpath@1.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4462,6 +5630,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob-parent@5.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4474,6 +5646,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.2",
       "purl": "pkg:npm/glob-parent@6.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4488,6 +5664,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob@7.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4500,6 +5680,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "13.24.0",
       "purl": "pkg:npm/globals@13.24.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4514,6 +5698,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/globby@11.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4526,6 +5714,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/graphemer@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4540,6 +5732,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/has-flag@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4552,6 +5748,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.2",
       "purl": "pkg:npm/ignore@5.3.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4566,6 +5766,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/import-fresh@3.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4578,6 +5782,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.4",
       "purl": "pkg:npm/imurmurhash@0.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4592,6 +5800,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/inflight@1.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4604,6 +5816,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.4",
       "purl": "pkg:npm/inherits@2.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4618,6 +5834,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-extglob@2.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4630,6 +5850,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.3",
       "purl": "pkg:npm/is-glob@4.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4644,6 +5868,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-number@7.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4656,6 +5884,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.3",
       "purl": "pkg:npm/is-path-inside@3.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4670,6 +5902,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/isexe@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4682,6 +5918,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.1.0",
       "purl": "pkg:npm/js-yaml@4.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4696,6 +5936,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/json-buffer@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4708,6 +5952,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.4.1",
       "purl": "pkg:npm/json-schema-traverse@0.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4722,6 +5970,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4734,6 +5986,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.5.4",
       "purl": "pkg:npm/keyv@4.5.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4748,6 +6004,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/levn@0.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4760,6 +6020,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.0",
       "purl": "pkg:npm/locate-path@6.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4774,6 +6038,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/lodash.merge@4.6.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4786,6 +6054,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.1",
       "purl": "pkg:npm/merge2@1.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4800,6 +6072,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/micromatch@4.0.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4813,6 +6089,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/minimatch@3.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4825,6 +6105,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.7.2",
       "purl": "pkg:npm/ms@0.7.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -4843,6 +6127,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4855,6 +6143,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/natural-compare-lite@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4869,6 +6161,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/natural-compare@1.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4881,6 +6177,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/once@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4895,6 +6195,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/optionator@0.9.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4907,6 +6211,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.0",
       "purl": "pkg:npm/p-limit@3.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4921,6 +6229,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/p-locate@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4933,6 +6245,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/parent-module@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4947,6 +6263,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-exists@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4959,6 +6279,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/path-is-absolute@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4973,6 +6297,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-key@3.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -4985,6 +6313,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.0",
       "purl": "pkg:npm/path-type@4.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -4999,6 +6331,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/picomatch@2.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5011,6 +6347,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.1",
       "purl": "pkg:npm/prelude-ls@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5025,6 +6365,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/punycode@2.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5037,6 +6381,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.3",
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5051,6 +6399,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/resolve-from@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5063,6 +6415,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.4",
       "purl": "pkg:npm/reusify@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5077,6 +6433,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/rimraf@3.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5089,6 +6449,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.0",
       "purl": "pkg:npm/run-parallel@1.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5103,6 +6467,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/semver@7.6.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5115,6 +6483,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.0",
       "purl": "pkg:npm/shebang-command@2.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5129,6 +6501,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/shebang-regex@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5141,6 +6517,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.0",
       "purl": "pkg:npm/slash@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5155,6 +6535,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/strip-ansi@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5167,6 +6551,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.1",
       "purl": "pkg:npm/strip-json-comments@3.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5181,6 +6569,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/supports-color@7.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5193,6 +6585,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.2.0",
       "purl": "pkg:npm/text-table@0.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5207,6 +6603,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5219,6 +6619,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.14.1",
       "purl": "pkg:npm/tslib@1.14.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5233,6 +6637,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/tsutils@3.21.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5245,6 +6653,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.4.0",
       "purl": "pkg:npm/type-check@0.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5259,6 +6671,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/type-fest@0.20.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5271,6 +6687,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.7.3",
       "purl": "pkg:npm/typescript@5.7.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5285,6 +6705,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/uri-js@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5297,6 +6721,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.2",
       "purl": "pkg:npm/which@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5311,6 +6739,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/word-wrap@1.2.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5324,6 +6756,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5336,6 +6772,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.0",
       "purl": "pkg:npm/yocto-queue@0.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5378,6 +6818,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint%2Feslintrc@2.1.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5390,6 +6834,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "8.57.1",
       "purl": "pkg:npm/%40eslint%2Fjs@8.57.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5404,6 +6852,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5416,6 +6868,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.12.1",
       "purl": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5430,6 +6886,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5442,6 +6902,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5456,6 +6920,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5468,6 +6936,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.1.5",
       "purl": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5482,6 +6954,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5494,6 +6970,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.8",
       "purl": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5508,6 +6988,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fjson-schema@7.0.15",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5521,6 +7005,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fsemver@7.5.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5533,6 +7021,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -5558,6 +7050,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fparser@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5570,6 +7066,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5584,6 +7084,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5596,6 +7100,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5610,6 +7118,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5622,6 +7134,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5636,6 +7152,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5648,6 +7168,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.1",
       "purl": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5662,6 +7186,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/acorn-jsx@5.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5674,6 +7202,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "8.14.0",
       "purl": "pkg:npm/acorn@8.14.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5688,6 +7220,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ajv@6.12.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5700,6 +7236,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.0.1",
       "purl": "pkg:npm/ansi-regex@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5714,6 +7254,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ansi-styles@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5726,6 +7270,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.1",
       "purl": "pkg:npm/argparse@2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5740,6 +7288,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/array-union@2.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5752,6 +7304,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5766,6 +7322,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/brace-expansion@1.1.11",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5778,6 +7338,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.3",
       "purl": "pkg:npm/braces@3.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5792,6 +7356,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/callsites@3.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5804,6 +7372,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.1.2",
       "purl": "pkg:npm/chalk@4.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5818,6 +7390,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/color-convert@2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5830,6 +7406,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.1.4",
       "purl": "pkg:npm/color-name@1.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5844,6 +7424,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/concat-map@0.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5857,6 +7441,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/cross-spawn@7.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5869,6 +7457,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.5.2",
       "purl": "pkg:npm/debug@2.5.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -5898,6 +7490,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/debug@4.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5910,6 +7506,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.4",
       "purl": "pkg:npm/deep-is@0.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5924,6 +7524,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/dir-glob@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5936,6 +7540,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.0",
       "purl": "pkg:npm/doctrine@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5950,6 +7558,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/escape-string-regexp@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5962,6 +7574,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.1.1",
       "purl": "pkg:npm/eslint-scope@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -5976,6 +7592,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint-scope@7.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -5988,6 +7608,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.4.3",
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6002,6 +7626,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint@8.57.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6014,6 +7642,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "9.6.1",
       "purl": "pkg:npm/espree@9.6.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6028,6 +7660,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esquery@1.6.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6040,6 +7676,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.3.0",
       "purl": "pkg:npm/esrecurse@4.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6054,6 +7694,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/estraverse@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6066,6 +7710,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.0",
       "purl": "pkg:npm/estraverse@5.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6080,6 +7728,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esutils@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6092,6 +7744,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.3",
       "purl": "pkg:npm/fast-deep-equal@3.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6106,6 +7762,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fast-glob@3.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6118,6 +7778,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.1.0",
       "purl": "pkg:npm/fast-json-stable-stringify@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6132,6 +7796,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fast-levenshtein@2.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6144,6 +7812,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.18.0",
       "purl": "pkg:npm/fastq@1.18.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6158,6 +7830,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/file-entry-cache@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6170,6 +7846,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "7.1.1",
       "purl": "pkg:npm/fill-range@7.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6184,6 +7864,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/find-up@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6196,6 +7880,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.2.0",
       "purl": "pkg:npm/flat-cache@3.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6210,6 +7898,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/flatted@3.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6222,6 +7914,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.0",
       "purl": "pkg:npm/fs.realpath@1.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6236,6 +7932,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob-parent@5.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6248,6 +7948,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.2",
       "purl": "pkg:npm/glob-parent@6.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6262,6 +7966,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob@7.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6274,6 +7982,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "13.24.0",
       "purl": "pkg:npm/globals@13.24.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6288,6 +8000,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/globby@11.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6300,6 +8016,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/graphemer@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6314,6 +8034,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/has-flag@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6326,6 +8050,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.2",
       "purl": "pkg:npm/ignore@5.3.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6340,6 +8068,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/import-fresh@3.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6352,6 +8084,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.4",
       "purl": "pkg:npm/imurmurhash@0.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6366,6 +8102,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/inflight@1.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6378,6 +8118,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.4",
       "purl": "pkg:npm/inherits@2.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6392,6 +8136,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-extglob@2.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6404,6 +8152,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.3",
       "purl": "pkg:npm/is-glob@4.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6418,6 +8170,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-number@7.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6430,6 +8186,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.3",
       "purl": "pkg:npm/is-path-inside@3.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6444,6 +8204,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/isexe@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6456,6 +8220,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.1.0",
       "purl": "pkg:npm/js-yaml@4.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6470,6 +8238,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/json-buffer@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6482,6 +8254,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.4.1",
       "purl": "pkg:npm/json-schema-traverse@0.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6496,6 +8272,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6508,6 +8288,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.5.4",
       "purl": "pkg:npm/keyv@4.5.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6522,6 +8306,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/levn@0.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6534,6 +8322,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.0",
       "purl": "pkg:npm/locate-path@6.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6548,6 +8340,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/lodash.merge@4.6.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6560,6 +8356,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.1",
       "purl": "pkg:npm/merge2@1.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6574,6 +8374,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/micromatch@4.0.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6587,6 +8391,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/minimatch@3.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6599,6 +8407,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.7.2",
       "purl": "pkg:npm/ms@0.7.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -6617,6 +8429,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6629,6 +8445,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/natural-compare-lite@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6643,6 +8463,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/natural-compare@1.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6655,6 +8479,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/once@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6669,6 +8497,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/optionator@0.9.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6681,6 +8513,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.0",
       "purl": "pkg:npm/p-limit@3.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6695,6 +8531,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/p-locate@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6707,6 +8547,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/parent-module@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6721,6 +8565,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-exists@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6733,6 +8581,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/path-is-absolute@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6747,6 +8599,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-key@3.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6759,6 +8615,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.0",
       "purl": "pkg:npm/path-type@4.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6773,6 +8633,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/picomatch@2.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6785,6 +8649,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.1",
       "purl": "pkg:npm/prelude-ls@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6799,6 +8667,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/punycode@2.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6811,6 +8683,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.3",
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6825,6 +8701,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/resolve-from@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6837,6 +8717,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.4",
       "purl": "pkg:npm/reusify@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6851,6 +8735,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/rimraf@3.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6863,6 +8751,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.0",
       "purl": "pkg:npm/run-parallel@1.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6877,6 +8769,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/semver@7.6.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6889,6 +8785,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.0",
       "purl": "pkg:npm/shebang-command@2.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6903,6 +8803,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/shebang-regex@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6915,6 +8819,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.0",
       "purl": "pkg:npm/slash@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6929,6 +8837,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/strip-ansi@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6941,6 +8853,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.1",
       "purl": "pkg:npm/strip-json-comments@3.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6955,6 +8871,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/supports-color@7.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6967,6 +8887,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.2.0",
       "purl": "pkg:npm/text-table@0.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -6981,6 +8905,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -6993,6 +8921,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.14.1",
       "purl": "pkg:npm/tslib@1.14.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7007,6 +8939,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/tsutils@3.21.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7019,6 +8955,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.4.0",
       "purl": "pkg:npm/type-check@0.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7033,6 +8973,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/type-fest@0.20.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7045,6 +8989,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.7.3",
       "purl": "pkg:npm/typescript@5.7.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7059,6 +9007,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/uri-js@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7071,6 +9023,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.2",
       "purl": "pkg:npm/which@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7085,6 +9041,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/word-wrap@1.2.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7098,6 +9058,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7110,6 +9074,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.0",
       "purl": "pkg:npm/yocto-queue@0.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7152,6 +9120,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint%2Feslintrc@2.1.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7164,6 +9136,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "8.57.1",
       "purl": "pkg:npm/%40eslint%2Fjs@8.57.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7178,6 +9154,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7190,6 +9170,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.12.1",
       "purl": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7204,6 +9188,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7216,6 +9204,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7230,6 +9222,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7242,6 +9238,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.1.5",
       "purl": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7256,6 +9256,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7268,6 +9272,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.8",
       "purl": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7282,6 +9290,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fjson-schema@7.0.15",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7295,6 +9307,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40types%2Fsemver@7.5.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7307,6 +9323,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -7332,6 +9352,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fparser@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7344,6 +9368,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7358,6 +9386,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7370,6 +9402,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7384,6 +9420,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7396,6 +9436,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7410,6 +9454,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7422,6 +9470,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.1",
       "purl": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7436,6 +9488,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/acorn-jsx@5.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7448,6 +9504,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "8.14.0",
       "purl": "pkg:npm/acorn@8.14.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7462,6 +9522,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ajv@6.12.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7474,6 +9538,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.0.1",
       "purl": "pkg:npm/ansi-regex@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7488,6 +9556,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ansi-styles@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7500,6 +9572,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.1",
       "purl": "pkg:npm/argparse@2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7514,6 +9590,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/array-union@2.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7526,6 +9606,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7540,6 +9624,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/brace-expansion@1.1.11",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7552,6 +9640,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.3",
       "purl": "pkg:npm/braces@3.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7566,6 +9658,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/callsites@3.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7578,6 +9674,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.1.2",
       "purl": "pkg:npm/chalk@4.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7592,6 +9692,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/color-convert@2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7604,6 +9708,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.1.4",
       "purl": "pkg:npm/color-name@1.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7618,6 +9726,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/concat-map@0.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7631,6 +9743,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/cross-spawn@7.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7643,6 +9759,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.5.2",
       "purl": "pkg:npm/debug@2.5.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -7672,6 +9792,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/debug@4.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7684,6 +9808,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.4",
       "purl": "pkg:npm/deep-is@0.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7698,6 +9826,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/dir-glob@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7710,6 +9842,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.0",
       "purl": "pkg:npm/doctrine@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7724,6 +9860,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/escape-string-regexp@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7736,6 +9876,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.1.1",
       "purl": "pkg:npm/eslint-scope@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7750,6 +9894,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint-scope@7.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7762,6 +9910,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.4.3",
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7776,6 +9928,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/eslint@8.57.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7788,6 +9944,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "9.6.1",
       "purl": "pkg:npm/espree@9.6.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7802,6 +9962,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esquery@1.6.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7814,6 +9978,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.3.0",
       "purl": "pkg:npm/esrecurse@4.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7828,6 +9996,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/estraverse@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7840,6 +10012,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.0",
       "purl": "pkg:npm/estraverse@5.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7854,6 +10030,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/esutils@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7866,6 +10046,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.3",
       "purl": "pkg:npm/fast-deep-equal@3.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7880,6 +10064,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fast-glob@3.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7892,6 +10080,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.1.0",
       "purl": "pkg:npm/fast-json-stable-stringify@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7906,6 +10098,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/fast-levenshtein@2.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7918,6 +10114,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.18.0",
       "purl": "pkg:npm/fastq@1.18.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7932,6 +10132,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/file-entry-cache@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7944,6 +10148,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "7.1.1",
       "purl": "pkg:npm/fill-range@7.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7958,6 +10166,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/find-up@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7970,6 +10182,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.2.0",
       "purl": "pkg:npm/flat-cache@3.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -7984,6 +10200,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/flatted@3.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -7996,6 +10216,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.0",
       "purl": "pkg:npm/fs.realpath@1.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8010,6 +10234,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob-parent@5.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8022,6 +10250,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.2",
       "purl": "pkg:npm/glob-parent@6.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8036,6 +10268,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/glob@7.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8048,6 +10284,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "13.24.0",
       "purl": "pkg:npm/globals@13.24.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8062,6 +10302,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/globby@11.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8074,6 +10318,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/graphemer@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8088,6 +10336,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/has-flag@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8100,6 +10352,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.3.2",
       "purl": "pkg:npm/ignore@5.3.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8114,6 +10370,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/import-fresh@3.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8126,6 +10386,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.4",
       "purl": "pkg:npm/imurmurhash@0.1.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8140,6 +10404,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/inflight@1.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8152,6 +10420,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.4",
       "purl": "pkg:npm/inherits@2.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8166,6 +10438,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-extglob@2.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8178,6 +10454,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.3",
       "purl": "pkg:npm/is-glob@4.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8192,6 +10472,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/is-number@7.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8204,6 +10488,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.3",
       "purl": "pkg:npm/is-path-inside@3.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8218,6 +10506,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/isexe@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8230,6 +10522,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.1.0",
       "purl": "pkg:npm/js-yaml@4.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8244,6 +10540,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/json-buffer@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8256,6 +10556,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.4.1",
       "purl": "pkg:npm/json-schema-traverse@0.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8270,6 +10574,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8282,6 +10590,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.5.4",
       "purl": "pkg:npm/keyv@4.5.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8296,6 +10608,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/levn@0.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8308,6 +10624,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.0",
       "purl": "pkg:npm/locate-path@6.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8322,6 +10642,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/lodash.merge@4.6.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8334,6 +10658,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.1",
       "purl": "pkg:npm/merge2@1.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8348,6 +10676,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/micromatch@4.0.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8361,6 +10693,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/minimatch@3.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8373,6 +10709,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.7.2",
       "purl": "pkg:npm/ms@0.7.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -8391,6 +10731,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8403,6 +10747,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/natural-compare-lite@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8417,6 +10765,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/natural-compare@1.4.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8429,6 +10781,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.4.0",
       "purl": "pkg:npm/once@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8443,6 +10799,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/optionator@0.9.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8455,6 +10815,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.0",
       "purl": "pkg:npm/p-limit@3.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8469,6 +10833,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/p-locate@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8481,6 +10849,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/parent-module@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8495,6 +10867,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-exists@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8507,6 +10883,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.1",
       "purl": "pkg:npm/path-is-absolute@1.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8521,6 +10901,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/path-key@3.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8533,6 +10917,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "4.0.0",
       "purl": "pkg:npm/path-type@4.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8547,6 +10935,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/picomatch@2.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8559,6 +10951,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.1",
       "purl": "pkg:npm/prelude-ls@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8573,6 +10969,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/punycode@2.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8585,6 +10985,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.3",
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8599,6 +11003,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/resolve-from@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8611,6 +11019,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.0.4",
       "purl": "pkg:npm/reusify@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8625,6 +11037,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/rimraf@3.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8637,6 +11053,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.2.0",
       "purl": "pkg:npm/run-parallel@1.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8651,6 +11071,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/semver@7.6.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8663,6 +11087,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.0",
       "purl": "pkg:npm/shebang-command@2.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8677,6 +11105,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/shebang-regex@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8689,6 +11121,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.0.0",
       "purl": "pkg:npm/slash@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8703,6 +11139,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/strip-ansi@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8715,6 +11155,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "3.1.1",
       "purl": "pkg:npm/strip-json-comments@3.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8729,6 +11173,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/supports-color@7.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8741,6 +11189,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.2.0",
       "purl": "pkg:npm/text-table@0.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8755,6 +11207,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8767,6 +11223,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "1.14.1",
       "purl": "pkg:npm/tslib@1.14.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8781,6 +11241,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/tsutils@3.21.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8793,6 +11257,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.4.0",
       "purl": "pkg:npm/type-check@0.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8807,6 +11275,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/type-fest@0.20.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8819,6 +11291,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "5.7.3",
       "purl": "pkg:npm/typescript@5.7.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8833,6 +11309,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/uri-js@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8845,6 +11325,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.2",
       "purl": "pkg:npm/which@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8859,6 +11343,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/word-wrap@1.2.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8872,6 +11360,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
         }
@@ -8884,6 +11376,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "0.1.0",
       "purl": "pkg:npm/yocto-queue@0.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "package-lock.json"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -8955,6 +11451,10 @@ Warning: `parsers` exists as both a subcommand of datadog-sbom-generator and as 
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nested/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -8967,6 +11467,10 @@ Warning: `parsers` exists as both a subcommand of datadog-sbom-generator and as 
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -9021,6 +11525,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9061,6 +11569,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "2.0.4",
       "purl": "pkg:composer/sentry/sdk@2.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -9126,6 +11638,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:maven/com.foobar/common@1.0-SNAPSHOT",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "other-dir/pom.xml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -9150,6 +11666,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "other-dir/pom.xml"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -9173,6 +11697,10 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "version": "6.0.5",
       "purl": "pkg:nuget/Test.Core@6.0.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "packages.lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -9277,6 +11805,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ably/ably-php@1.1.10",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9305,6 +11837,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/aws/aws-crt-php@v1.2.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9321,6 +11857,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.317.2",
       "purl": "pkg:composer/aws/aws-sdk-php@3.317.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -9350,6 +11890,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/brick/math@0.12.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -9374,6 +11918,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/carbonphp/carbon-doctrine-types@3.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9387,6 +11935,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/dflydev/dot-access-data@v3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9399,6 +11951,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.10",
       "purl": "pkg:composer/doctrine/inflector@2.0.10",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -9424,6 +11980,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/doctrine/lexer@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9436,6 +11996,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v3.3.3",
       "purl": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -9461,6 +12025,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/egulias/email-validator@4.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -9484,6 +12052,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.23.1",
       "purl": "pkg:composer/fakerphp/faker@v1.23.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -9513,6 +12085,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/fruitcake/php-cors@v1.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -9537,6 +12113,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/graham-campbell/result-type@v1.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9549,6 +12129,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.9.2",
       "purl": "pkg:composer/guzzlehttp/guzzle@7.9.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -9574,6 +12158,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/guzzlehttp/promises@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9587,6 +12175,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/guzzlehttp/psr7@2.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9599,6 +12191,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.0.3",
       "purl": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -9624,6 +12220,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/hamcrest/hamcrest-php@v2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9641,6 +12241,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/collections@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9653,6 +12257,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v11.19.0",
       "purl": "pkg:composer/illuminate/conditionable@v11.19.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -9667,6 +12275,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/contracts@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9680,6 +12292,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/macroable@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9692,6 +12308,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v0.1.24",
       "purl": "pkg:composer/laravel/prompts@v0.1.24",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -9717,6 +12337,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/laravel/serializable-closure@v1.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -9740,6 +12364,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.5.1",
       "purl": "pkg:composer/league/commonmark@2.5.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -9765,6 +12393,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/config@v1.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -9777,6 +12409,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.28.0",
       "purl": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -9806,6 +12442,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem-local@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9822,6 +12462,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.28.0",
       "purl": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -9851,6 +12495,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem-read-only@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9879,6 +12527,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9896,6 +12548,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/mime-type-detection@1.15.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9912,6 +12568,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.6.12",
       "purl": "pkg:composer/mockery/mockery@1.6.12",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -9941,6 +12601,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/monolog/monolog@3.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -9965,6 +12629,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/mtdowling/jmespath.php@2.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9982,6 +12650,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/myclabs/deep-copy@1.12.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -9998,6 +12670,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.7.0",
       "purl": "pkg:composer/nesbot/carbon@3.7.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -10023,6 +12699,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/nette/schema@v1.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10036,6 +12716,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/nette/utils@v4.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10048,6 +12732,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v5.1.0",
       "purl": "pkg:composer/nikic/php-parser@v5.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10065,6 +12753,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v2.0.1",
       "purl": "pkg:composer/nunomaduro/termwind@v2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -10089,6 +12781,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.8.1",
       "purl": "pkg:composer/nyholm/psr7@1.8.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10118,6 +12814,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/pda/pheanstalk@v5.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10146,6 +12846,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phar-io/manifest@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10162,6 +12866,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.2.1",
       "purl": "pkg:composer/phar-io/version@3.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10180,6 +12888,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpoption/phpoption@1.9.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10192,6 +12904,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.11.9",
       "purl": "pkg:composer/phpstan/phpstan@1.11.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10221,6 +12937,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-code-coverage@11.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10237,6 +12957,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.0.1",
       "purl": "pkg:composer/phpunit/php-file-iterator@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10255,6 +12979,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-invoker@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10271,6 +12999,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.1",
       "purl": "pkg:composer/phpunit/php-text-template@4.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10289,6 +13021,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-timer@7.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10305,6 +13041,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "11.3.0",
       "purl": "pkg:composer/phpunit/phpunit@11.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10334,6 +13074,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/predis/predis@v2.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10362,6 +13106,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/cache@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10379,6 +13127,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/clock@1.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10391,6 +13143,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.2",
       "purl": "pkg:composer/psr/container@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -10416,6 +13172,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/event-dispatcher@1.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10428,6 +13188,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.3",
       "purl": "pkg:composer/psr/http-client@1.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -10442,6 +13206,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/http-factory@1.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10455,6 +13223,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/http-message@2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10467,6 +13239,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.0",
       "purl": "pkg:composer/psr/log@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -10492,6 +13268,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/simple-cache@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -10516,6 +13296,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ralouphie/getallheaders@3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10529,6 +13313,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ramsey/collection@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10541,6 +13329,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.7.6",
       "purl": "pkg:composer/ramsey/uuid@4.7.6",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -10565,6 +13357,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v0.10.1",
       "purl": "pkg:composer/resend/resend-php@v0.10.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10594,6 +13390,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/rybakit/msgpack@v0.9.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10610,6 +13410,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.2",
       "purl": "pkg:composer/sebastian/cli-parser@3.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10628,6 +13432,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10644,6 +13452,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.1",
       "purl": "pkg:composer/sebastian/code-unit@3.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10662,6 +13474,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/comparator@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10678,6 +13494,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.1",
       "purl": "pkg:composer/sebastian/complexity@4.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10696,6 +13516,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/diff@6.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10712,6 +13536,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.2.0",
       "purl": "pkg:composer/sebastian/environment@7.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10730,6 +13558,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/exporter@6.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10746,6 +13578,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.2",
       "purl": "pkg:composer/sebastian/global-state@7.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10764,6 +13600,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/lines-of-code@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10780,6 +13620,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.1",
       "purl": "pkg:composer/sebastian/object-enumerator@6.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10798,6 +13642,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/object-reflector@4.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10814,6 +13662,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.2",
       "purl": "pkg:composer/sebastian/recursion-context@6.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10832,6 +13684,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/type@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10848,6 +13704,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.0.1",
       "purl": "pkg:composer/sebastian/version@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10866,6 +13726,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/cache-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -10882,6 +13746,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/cache@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -10911,6 +13779,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/clock@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10923,6 +13795,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/console@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -10948,6 +13824,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/css-selector@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10961,6 +13841,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -10973,6 +13857,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/error-handler@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -10998,6 +13886,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/event-dispatcher-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11011,6 +13903,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/event-dispatcher@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11023,6 +13919,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/finder@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11048,6 +13948,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/http-client-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -11064,6 +13968,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/http-client@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -11093,6 +14001,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/http-foundation@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -11116,6 +14028,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/http-kernel@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11141,6 +14057,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/mailer@v7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -11164,6 +14084,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.2",
       "purl": "pkg:composer/symfony/mime@v7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11189,6 +14113,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-ctype@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11201,6 +14129,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -11215,6 +14147,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11227,6 +14163,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -11241,6 +14181,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11253,6 +14197,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-php72@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -11267,6 +14215,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-php80@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11279,6 +14231,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-php83@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11304,6 +14260,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-uuid@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11316,6 +14276,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/process@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11340,6 +14304,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/psr-http-message-bridge@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -11369,6 +14337,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/routing@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -11393,6 +14365,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/service-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11405,6 +14381,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/string@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -11419,6 +14399,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/translation-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11432,6 +14416,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/translation@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11444,6 +14432,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.1",
       "purl": "pkg:composer/symfony/uid@v7.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11469,6 +14461,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/var-dumper@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -11493,6 +14489,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/var-exporter@v7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -11510,6 +14510,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/theseer/tokenizer@1.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -11526,6 +14530,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v2.2.7",
       "purl": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11551,6 +14559,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/vlucas/phpdotenv@v5.6.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -11574,6 +14586,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.1",
       "purl": "pkg:composer/voku/portable-ascii@2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11599,6 +14615,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/webmozart/assert@1.11.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -11612,6 +14632,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:conan/zlib@1.2.11",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "conan.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Conan"
         }
@@ -11624,6 +14648,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.2.9",
       "purl": "pkg:gem/RedCloth@4.2.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11649,6 +14677,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actioncable@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11661,6 +14693,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionmailbox@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11675,6 +14711,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actionmailer@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11687,6 +14727,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionpack@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11701,6 +14745,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actiontext@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11713,6 +14761,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionview@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11727,6 +14779,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activejob@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11739,6 +14795,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/activemodel@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11753,6 +14813,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activerecord@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11765,6 +14829,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/activestorage@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11779,6 +14847,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activesupport@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11791,6 +14863,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.8.7",
       "purl": "pkg:gem/addressable@2.8.7",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11805,6 +14881,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/base64@0.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11817,6 +14897,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.1.8",
       "purl": "pkg:gem/bigdecimal@3.1.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11831,6 +14915,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/builder@3.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11843,6 +14931,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.39.2",
       "purl": "pkg:gem/capybara@3.39.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11857,6 +14949,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/childprocess@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11869,6 +14965,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.10.2",
       "purl": "pkg:gem/chronic@0.10.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -11894,6 +14994,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/coderay@1.0.9",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -11918,6 +15022,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/concurrent-ruby@1.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11930,6 +15038,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.4.1",
       "purl": "pkg:gem/connection_pool@2.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11944,6 +15056,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/crass@1.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11956,6 +15072,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "10.0.1",
       "purl": "pkg:gem/cucumber-ci-environment@10.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11970,6 +15090,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-core@13.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -11982,6 +15106,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "17.1.0",
       "purl": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -11996,6 +15124,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-gherkin@27.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12008,6 +15140,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "21.4.1",
       "purl": "pkg:gem/cucumber-html-formatter@21.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12022,6 +15158,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-messages@22.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12034,6 +15174,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:gem/cucumber-rails@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -12063,6 +15207,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-tag-expressions@6.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12075,6 +15223,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.10.0",
       "purl": "pkg:gem/cucumber-websteps@0.10.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -12104,6 +15256,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber@9.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12116,6 +15272,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.2.0",
       "purl": "pkg:gem/database_cleaner-active_record@2.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12130,6 +15290,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/database_cleaner-core@2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12142,6 +15306,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.2",
       "purl": "pkg:gem/database_cleaner@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -12171,6 +15339,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/date@3.3.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12183,6 +15355,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.5.1",
       "purl": "pkg:gem/diff-lcs@1.5.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12197,6 +15373,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/drb@2.2.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12210,6 +15390,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/erubi@1.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12222,6 +15406,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.9.0",
       "purl": "pkg:gem/factory_girl@4.9.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -12251,6 +15439,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/ffi@1.17.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12263,6 +15455,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.2.1",
       "purl": "pkg:gem/globalid@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12277,6 +15473,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/i18n@1.14.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12289,6 +15489,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.7.2",
       "purl": "pkg:gem/io-console@0.7.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12303,6 +15507,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/irb@1.14.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12315,6 +15523,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.6.0",
       "purl": "pkg:gem/jquery-rails@4.6.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -12340,6 +15552,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/launchy@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12352,6 +15568,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.22.0",
       "purl": "pkg:gem/loofah@2.22.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12366,6 +15586,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/mail@2.8.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12378,6 +15602,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.4",
       "purl": "pkg:gem/marcel@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12392,6 +15620,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/matrix@0.4.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12404,6 +15636,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.1.5",
       "purl": "pkg:gem/mini_mime@1.1.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12418,6 +15654,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/mini_portile2@2.8.7",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12430,6 +15670,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.24.1",
       "purl": "pkg:gem/minitest@5.24.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12444,6 +15688,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/multi_test@1.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12456,6 +15704,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.2.0",
       "purl": "pkg:gem/mutex_m@0.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12470,6 +15722,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/net-imap@0.4.14",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12482,6 +15738,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.1.2",
       "purl": "pkg:gem/net-pop@0.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12496,6 +15756,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/net-protocol@0.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12508,6 +15772,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.5.0",
       "purl": "pkg:gem/net-smtp@0.5.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12522,6 +15790,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/nio4r@2.7.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12534,6 +15806,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.15.6",
       "purl": "pkg:gem/nokogiri@1.15.6",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12548,6 +15824,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/psych@5.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12560,6 +15840,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.1",
       "purl": "pkg:gem/public_suffix@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12574,6 +15858,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/racc@1.8.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12586,6 +15874,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.2",
       "purl": "pkg:gem/rack-openid@1.4.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -12611,6 +15903,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rack-session@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12623,6 +15919,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.0",
       "purl": "pkg:gem/rack-test@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12637,6 +15937,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rack@3.1.7",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12649,6 +15953,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.0",
       "purl": "pkg:gem/rackup@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12663,6 +15971,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rails-dom-testing@2.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12676,6 +15988,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rails-html-sanitizer@1.6.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12688,6 +16004,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/rails@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -12713,6 +16033,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/railties@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12725,6 +16049,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "13.2.1",
       "purl": "pkg:gem/rake@13.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12739,6 +16067,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rdoc@6.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12751,6 +16083,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.9.2",
       "purl": "pkg:gem/regexp_parser@2.9.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12765,6 +16101,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/reline@0.5.9",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12777,6 +16117,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.2.0",
       "purl": "pkg:gem/rspec-activemodel-mocks@1.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -12806,6 +16150,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-collection_matchers@1.2.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -12834,6 +16182,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-core@3.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12846,6 +16198,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.13.1",
       "purl": "pkg:gem/rspec-expectations@3.13.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12860,6 +16216,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-mocks@3.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12873,6 +16233,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-support@3.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12885,6 +16249,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.13.0",
       "purl": "pkg:gem/rspec@3.13.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -12914,6 +16282,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/ruby-openid@2.9.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -12937,6 +16309,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.7.3",
       "purl": "pkg:gem/sqlite3@1.7.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -12962,6 +16338,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/stringio@3.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12974,6 +16354,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.3.0",
       "purl": "pkg:gem/sys-uname@1.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12988,6 +16372,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/thor@1.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13000,6 +16388,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.4.1",
       "purl": "pkg:gem/timeout@0.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -13014,6 +16406,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/tzinfo@2.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13026,6 +16422,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.8.1",
       "purl": "pkg:gem/webrick@1.8.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -13040,6 +16440,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/websocket-driver@0.7.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13053,6 +16457,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/websocket-extensions@0.1.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13065,6 +16473,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.12",
       "purl": "pkg:gem/will_paginate@3.0.12",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13090,6 +16502,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/xpath@3.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13103,6 +16519,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/zeitwerk@2.6.17",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13115,6 +16535,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.0",
       "purl": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "go.mod"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13140,6 +16564,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:golang/github.com/Private/packages/pkg/util/backoff@1.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "go.mod"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13162,6 +16590,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "name": "github.com/kubernetes/apimachinery",
       "purl": "pkg:golang/github.com/kubernetes/apimachinery",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "go.mod"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13187,6 +16619,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:golang/stdlib@1.21.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "go.mod"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13203,6 +16639,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.2",
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -13232,6 +16676,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/junit/junit@4.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -13255,6 +16703,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.13.2",
       "purl": "pkg:maven/junit/junit@4.13.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -13280,6 +16732,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.hamcrest/hamcrest-core@1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -13297,6 +16753,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -13312,6 +16772,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "name": "org.springframework.boot:spring-boot-starter-test",
       "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -13340,6 +16804,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13364,6 +16832,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.security/spring-security-crypto@5.7.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Gradle"
         }
@@ -13384,6 +16856,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.security/spring-security-crypto@5.7.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Gradle"
         }
@@ -13403,6 +16879,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "8.7.0",
       "purl": "pkg:npm/acorn@8.7.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13428,6 +16908,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13452,6 +16936,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/datadog-sbom-generator@0.0.0-use.local",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -13464,6 +16952,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.0",
       "purl": "pkg:npm/debug@1.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -13485,6 +16977,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.6.9",
       "purl": "pkg:npm/debug@2.6.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -13514,6 +17010,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/debug@4.3.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -13535,6 +17035,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/lodash@4.17.20",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13551,6 +17055,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.0",
       "purl": "pkg:npm/ms@2.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -13569,6 +17077,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ms@2.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -13585,6 +17097,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.3",
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "npm/package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -13614,6 +17130,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/supports-color@10.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -13642,6 +17162,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "npm/package-lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13665,6 +17189,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.1.2",
       "purl": "pkg:nuget/Downloader@3.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13690,6 +17218,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:nuget/MaterialDesignThemes@5.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13713,6 +17245,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.5",
       "purl": "pkg:nuget/Test.Core@6.0.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "packages.lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13738,6 +17274,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:nuget/Test.Core@6.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13761,6 +17301,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.9.3",
       "purl": "pkg:pypi/beautifulsoup4@4.9.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13786,6 +17330,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/certifi@2024.8.30",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Requirements"
         }
@@ -13805,6 +17353,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.4.0",
       "purl": "pkg:pypi/charset-normalizer@3.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13830,6 +17382,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/django-debug-toolbar@3.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13853,6 +17409,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.4.0",
       "purl": "pkg:pypi/django-filter@2.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13878,6 +17438,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/django@2.2.24",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13901,6 +17465,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.10",
       "purl": "pkg:pypi/idna@3.10",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -13926,6 +17494,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/markupsafe@2.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Pipfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -13949,6 +17521,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.23.3",
       "purl": "pkg:pypi/numpy@1.23.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "poetry.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -13978,6 +17554,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/pandas@2.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "other-requirements.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -14002,6 +17586,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/requests@2.32.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -14025,6 +17613,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.2.3",
       "purl": "pkg:pypi/urllib3@2.2.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Requirements"
@@ -14104,6 +17696,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ably/ably-php@1.1.10",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14132,6 +17728,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/aws/aws-crt-php@v1.2.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14148,6 +17748,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.317.2",
       "purl": "pkg:composer/aws/aws-sdk-php@3.317.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -14177,6 +17781,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/brick/math@0.12.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -14201,6 +17809,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/carbonphp/carbon-doctrine-types@3.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14214,6 +17826,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/dflydev/dot-access-data@v3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14226,6 +17842,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.10",
       "purl": "pkg:composer/doctrine/inflector@2.0.10",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -14251,6 +17871,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/doctrine/lexer@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14263,6 +17887,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v3.3.3",
       "purl": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -14288,6 +17916,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/egulias/email-validator@4.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -14311,6 +17943,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.23.1",
       "purl": "pkg:composer/fakerphp/faker@v1.23.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -14340,6 +17976,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/fruitcake/php-cors@v1.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -14364,6 +18004,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/graham-campbell/result-type@v1.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14376,6 +18020,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.9.2",
       "purl": "pkg:composer/guzzlehttp/guzzle@7.9.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -14401,6 +18049,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/guzzlehttp/promises@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14414,6 +18066,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/guzzlehttp/psr7@2.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14426,6 +18082,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.0.3",
       "purl": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -14451,6 +18111,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/hamcrest/hamcrest-php@v2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14468,6 +18132,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/collections@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14480,6 +18148,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v11.19.0",
       "purl": "pkg:composer/illuminate/conditionable@v11.19.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -14494,6 +18166,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/contracts@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14507,6 +18183,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/macroable@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14519,6 +18199,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v0.1.24",
       "purl": "pkg:composer/laravel/prompts@v0.1.24",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -14544,6 +18228,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/laravel/serializable-closure@v1.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -14567,6 +18255,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.5.1",
       "purl": "pkg:composer/league/commonmark@2.5.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -14592,6 +18284,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/config@v1.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14604,6 +18300,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.28.0",
       "purl": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -14633,6 +18333,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem-local@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14649,6 +18353,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.28.0",
       "purl": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -14678,6 +18386,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem-read-only@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14706,6 +18418,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14723,6 +18439,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/mime-type-detection@1.15.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14739,6 +18459,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.6.12",
       "purl": "pkg:composer/mockery/mockery@1.6.12",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -14768,6 +18492,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/monolog/monolog@3.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -14792,6 +18520,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/mtdowling/jmespath.php@2.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14809,6 +18541,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/myclabs/deep-copy@1.12.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14825,6 +18561,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.7.0",
       "purl": "pkg:composer/nesbot/carbon@3.7.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -14850,6 +18590,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/nette/schema@v1.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14863,6 +18607,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/nette/utils@v4.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -14875,6 +18623,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v5.1.0",
       "purl": "pkg:composer/nikic/php-parser@v5.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -14892,6 +18644,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v2.0.1",
       "purl": "pkg:composer/nunomaduro/termwind@v2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -14916,6 +18672,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.8.1",
       "purl": "pkg:composer/nyholm/psr7@1.8.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -14945,6 +18705,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/pda/pheanstalk@v5.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14973,6 +18737,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phar-io/manifest@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -14989,6 +18757,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.2.1",
       "purl": "pkg:composer/phar-io/version@3.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15007,6 +18779,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpoption/phpoption@1.9.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15019,6 +18795,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.11.9",
       "purl": "pkg:composer/phpstan/phpstan@1.11.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15048,6 +18828,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-code-coverage@11.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15064,6 +18848,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.0.1",
       "purl": "pkg:composer/phpunit/php-file-iterator@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15082,6 +18870,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-invoker@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15098,6 +18890,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.1",
       "purl": "pkg:composer/phpunit/php-text-template@4.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15116,6 +18912,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-timer@7.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15132,6 +18932,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "11.3.0",
       "purl": "pkg:composer/phpunit/phpunit@11.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15161,6 +18965,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/predis/predis@v2.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15189,6 +18997,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/cache@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15206,6 +19018,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/clock@1.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15218,6 +19034,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.2",
       "purl": "pkg:composer/psr/container@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -15243,6 +19063,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/event-dispatcher@1.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15255,6 +19079,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.3",
       "purl": "pkg:composer/psr/http-client@1.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -15269,6 +19097,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/http-factory@1.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15282,6 +19114,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/http-message@2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15294,6 +19130,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.0",
       "purl": "pkg:composer/psr/log@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -15319,6 +19159,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/simple-cache@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -15343,6 +19187,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ralouphie/getallheaders@3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15356,6 +19204,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ramsey/collection@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15368,6 +19220,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.7.6",
       "purl": "pkg:composer/ramsey/uuid@4.7.6",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -15392,6 +19248,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v0.10.1",
       "purl": "pkg:composer/resend/resend-php@v0.10.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15421,6 +19281,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/rybakit/msgpack@v0.9.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15437,6 +19301,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.2",
       "purl": "pkg:composer/sebastian/cli-parser@3.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15455,6 +19323,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15471,6 +19343,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.1",
       "purl": "pkg:composer/sebastian/code-unit@3.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15489,6 +19365,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/comparator@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15505,6 +19385,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.1",
       "purl": "pkg:composer/sebastian/complexity@4.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15523,6 +19407,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/diff@6.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15539,6 +19427,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.2.0",
       "purl": "pkg:composer/sebastian/environment@7.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15557,6 +19449,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/exporter@6.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15573,6 +19469,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.2",
       "purl": "pkg:composer/sebastian/global-state@7.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15591,6 +19491,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/lines-of-code@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15607,6 +19511,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.1",
       "purl": "pkg:composer/sebastian/object-enumerator@6.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15625,6 +19533,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/object-reflector@4.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15641,6 +19553,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.2",
       "purl": "pkg:composer/sebastian/recursion-context@6.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15659,6 +19575,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/type@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15675,6 +19595,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.0.1",
       "purl": "pkg:composer/sebastian/version@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15693,6 +19617,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/cache-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15709,6 +19637,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/cache@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15738,6 +19670,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/clock@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15750,6 +19686,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/console@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -15775,6 +19715,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/css-selector@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15788,6 +19732,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15800,6 +19748,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/error-handler@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -15825,6 +19777,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/event-dispatcher-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15838,6 +19794,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/event-dispatcher@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -15850,6 +19810,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/finder@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -15875,6 +19839,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/http-client-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -15891,6 +19859,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/http-client@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -15920,6 +19892,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/http-foundation@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -15943,6 +19919,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/http-kernel@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -15968,6 +19948,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/mailer@v7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -15991,6 +19975,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.2",
       "purl": "pkg:composer/symfony/mime@v7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -16016,6 +20004,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-ctype@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16028,6 +20020,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -16042,6 +20038,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16054,6 +20054,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -16068,6 +20072,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16080,6 +20088,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-php72@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -16094,6 +20106,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-php80@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16106,6 +20122,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-php83@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -16131,6 +20151,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-uuid@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16143,6 +20167,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/process@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -16167,6 +20195,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/psr-http-message-bridge@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -16196,6 +20228,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/routing@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -16220,6 +20256,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/service-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16232,6 +20272,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/string@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -16246,6 +20290,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/translation-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16259,6 +20307,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/translation@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16271,6 +20323,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.1",
       "purl": "pkg:composer/symfony/uid@v7.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -16296,6 +20352,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/var-dumper@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -16320,6 +20380,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/var-exporter@v7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -16337,6 +20401,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/theseer/tokenizer@1.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -16353,6 +20421,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v2.2.7",
       "purl": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -16378,6 +20450,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/vlucas/phpdotenv@v5.6.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -16401,6 +20477,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.1",
       "purl": "pkg:composer/voku/portable-ascii@2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -16426,6 +20506,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/webmozart/assert@1.11.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -16439,6 +20523,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:conan/zlib@1.2.11",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "conan.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Conan"
         }
@@ -16451,6 +20539,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.2.9",
       "purl": "pkg:gem/RedCloth@4.2.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -16476,6 +20568,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actioncable@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16488,6 +20584,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionmailbox@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16502,6 +20602,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actionmailer@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16514,6 +20618,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionpack@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16528,6 +20636,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actiontext@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16540,6 +20652,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionview@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16554,6 +20670,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activejob@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16566,6 +20686,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/activemodel@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16580,6 +20704,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activerecord@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16592,6 +20720,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/activestorage@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16606,6 +20738,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activesupport@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16618,6 +20754,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.8.7",
       "purl": "pkg:gem/addressable@2.8.7",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16632,6 +20772,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/base64@0.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16644,6 +20788,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.1.8",
       "purl": "pkg:gem/bigdecimal@3.1.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16658,6 +20806,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/builder@3.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16670,6 +20822,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.39.2",
       "purl": "pkg:gem/capybara@3.39.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16684,6 +20840,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/childprocess@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16696,6 +20856,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.10.2",
       "purl": "pkg:gem/chronic@0.10.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -16721,6 +20885,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/coderay@1.0.9",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -16745,6 +20913,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/concurrent-ruby@1.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16757,6 +20929,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.4.1",
       "purl": "pkg:gem/connection_pool@2.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16771,6 +20947,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/crass@1.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16783,6 +20963,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "10.0.1",
       "purl": "pkg:gem/cucumber-ci-environment@10.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16797,6 +20981,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-core@13.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16809,6 +20997,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "17.1.0",
       "purl": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16823,6 +21015,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-gherkin@27.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16835,6 +21031,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "21.4.1",
       "purl": "pkg:gem/cucumber-html-formatter@21.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16849,6 +21049,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-messages@22.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16861,6 +21065,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:gem/cucumber-rails@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -16890,6 +21098,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-tag-expressions@6.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16902,6 +21114,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.10.0",
       "purl": "pkg:gem/cucumber-websteps@0.10.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -16931,6 +21147,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber@9.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16943,6 +21163,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.2.0",
       "purl": "pkg:gem/database_cleaner-active_record@2.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -16957,6 +21181,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/database_cleaner-core@2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -16969,6 +21197,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.2",
       "purl": "pkg:gem/database_cleaner@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -16998,6 +21230,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/date@3.3.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17010,6 +21246,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.5.1",
       "purl": "pkg:gem/diff-lcs@1.5.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17024,6 +21264,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/drb@2.2.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17037,6 +21281,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/erubi@1.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17049,6 +21297,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.9.0",
       "purl": "pkg:gem/factory_girl@4.9.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -17078,6 +21330,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/ffi@1.17.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17090,6 +21346,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.2.1",
       "purl": "pkg:gem/globalid@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17104,6 +21364,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/i18n@1.14.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17116,6 +21380,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.7.2",
       "purl": "pkg:gem/io-console@0.7.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17130,6 +21398,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/irb@1.14.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17142,6 +21414,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.6.0",
       "purl": "pkg:gem/jquery-rails@4.6.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -17167,6 +21443,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/launchy@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17179,6 +21459,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.22.0",
       "purl": "pkg:gem/loofah@2.22.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17193,6 +21477,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/mail@2.8.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17205,6 +21493,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.4",
       "purl": "pkg:gem/marcel@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17219,6 +21511,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/matrix@0.4.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17231,6 +21527,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.1.5",
       "purl": "pkg:gem/mini_mime@1.1.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17245,6 +21545,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/mini_portile2@2.8.7",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17257,6 +21561,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.24.1",
       "purl": "pkg:gem/minitest@5.24.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17271,6 +21579,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/multi_test@1.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17283,6 +21595,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.2.0",
       "purl": "pkg:gem/mutex_m@0.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17297,6 +21613,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/net-imap@0.4.14",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17309,6 +21629,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.1.2",
       "purl": "pkg:gem/net-pop@0.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17323,6 +21647,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/net-protocol@0.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17335,6 +21663,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.5.0",
       "purl": "pkg:gem/net-smtp@0.5.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17349,6 +21681,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/nio4r@2.7.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17361,6 +21697,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.15.6",
       "purl": "pkg:gem/nokogiri@1.15.6",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17375,6 +21715,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/psych@5.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17387,6 +21731,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.1",
       "purl": "pkg:gem/public_suffix@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17401,6 +21749,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/racc@1.8.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17413,6 +21765,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.2",
       "purl": "pkg:gem/rack-openid@1.4.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -17438,6 +21794,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rack-session@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17450,6 +21810,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.0",
       "purl": "pkg:gem/rack-test@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17464,6 +21828,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rack@3.1.7",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17476,6 +21844,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.0",
       "purl": "pkg:gem/rackup@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17490,6 +21862,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rails-dom-testing@2.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17503,6 +21879,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rails-html-sanitizer@1.6.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17515,6 +21895,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/rails@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -17540,6 +21924,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/railties@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17552,6 +21940,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "13.2.1",
       "purl": "pkg:gem/rake@13.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17566,6 +21958,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rdoc@6.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17578,6 +21974,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.9.2",
       "purl": "pkg:gem/regexp_parser@2.9.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17592,6 +21992,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/reline@0.5.9",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17604,6 +22008,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.2.0",
       "purl": "pkg:gem/rspec-activemodel-mocks@1.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -17633,6 +22041,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-collection_matchers@1.2.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -17661,6 +22073,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-core@3.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17673,6 +22089,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.13.1",
       "purl": "pkg:gem/rspec-expectations@3.13.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17687,6 +22107,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-mocks@3.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17700,6 +22124,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-support@3.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17712,6 +22140,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.13.0",
       "purl": "pkg:gem/rspec@3.13.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -17741,6 +22173,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/ruby-openid@2.9.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -17764,6 +22200,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.7.3",
       "purl": "pkg:gem/sqlite3@1.7.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -17789,6 +22229,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/stringio@3.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17801,6 +22245,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.3.0",
       "purl": "pkg:gem/sys-uname@1.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17815,6 +22263,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/thor@1.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17827,6 +22279,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.4.1",
       "purl": "pkg:gem/timeout@0.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17841,6 +22297,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/tzinfo@2.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17853,6 +22313,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.8.1",
       "purl": "pkg:gem/webrick@1.8.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -17867,6 +22331,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/websocket-driver@0.7.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17880,6 +22348,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/websocket-extensions@0.1.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17892,6 +22364,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.12",
       "purl": "pkg:gem/will_paginate@3.0.12",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -17917,6 +22393,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/xpath@3.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17930,6 +22410,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/zeitwerk@2.6.17",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -17942,6 +22426,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.0",
       "purl": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "go.mod"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -17967,6 +22455,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:golang/stdlib@1.21.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "go.mod"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -17983,6 +22475,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.2",
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -18012,6 +22512,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/junit/junit@4.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -18035,6 +22539,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.13.2",
       "purl": "pkg:maven/junit/junit@4.13.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -18060,6 +22568,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.hamcrest/hamcrest-core@1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -18077,6 +22589,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -18092,6 +22608,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "name": "org.springframework.boot:spring-boot-starter-test",
       "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -18120,6 +22640,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18144,6 +22668,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.security/spring-security-crypto@5.7.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Gradle"
         }
@@ -18164,6 +22692,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.security/spring-security-crypto@5.7.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Gradle"
         }
@@ -18183,6 +22715,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "8.7.0",
       "purl": "pkg:npm/acorn@8.7.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -18208,6 +22744,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18232,6 +22772,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/datadog-sbom-generator@0.0.0-use.local",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -18244,6 +22788,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.6.9",
       "purl": "pkg:npm/debug@2.6.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -18273,6 +22821,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/debug@4.3.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -18294,6 +22846,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/lodash@4.17.20",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18310,6 +22866,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.0",
       "purl": "pkg:npm/ms@2.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -18328,6 +22888,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ms@2.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -18344,6 +22908,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.3",
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "npm/package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -18373,6 +22941,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/supports-color@10.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -18401,6 +22973,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "npm/package-lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18424,6 +23000,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.1.2",
       "purl": "pkg:nuget/Downloader@3.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -18449,6 +23029,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:nuget/MaterialDesignThemes@5.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18472,6 +23056,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.5",
       "purl": "pkg:nuget/Test.Core@6.0.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "packages.lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -18497,6 +23085,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:nuget/Test.Core@6.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18520,6 +23112,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.9.3",
       "purl": "pkg:pypi/beautifulsoup4@4.9.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -18545,6 +23141,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/certifi@2024.8.30",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Requirements"
         }
@@ -18564,6 +23164,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.4.0",
       "purl": "pkg:pypi/charset-normalizer@3.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -18589,6 +23193,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/django-debug-toolbar@3.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18612,6 +23220,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.4.0",
       "purl": "pkg:pypi/django-filter@2.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -18637,6 +23249,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/django@2.2.24",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18660,6 +23276,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.10",
       "purl": "pkg:pypi/idna@3.10",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -18685,6 +23305,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/markupsafe@2.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Pipfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18708,6 +23332,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.23.3",
       "purl": "pkg:pypi/numpy@1.23.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "poetry.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -18737,6 +23365,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/pandas@2.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "other-requirements.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18761,6 +23397,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/requests@2.32.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18784,6 +23424,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.2.3",
       "purl": "pkg:pypi/urllib3@2.2.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Requirements"
@@ -18863,6 +23507,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ably/ably-php@1.1.10",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -18891,6 +23539,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/aws/aws-crt-php@v1.2.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -18907,6 +23559,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.317.2",
       "purl": "pkg:composer/aws/aws-sdk-php@3.317.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -18936,6 +23592,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/brick/math@0.12.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -18960,6 +23620,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/carbonphp/carbon-doctrine-types@3.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -18973,6 +23637,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/dflydev/dot-access-data@v3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -18985,6 +23653,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.10",
       "purl": "pkg:composer/doctrine/inflector@2.0.10",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -19010,6 +23682,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/doctrine/lexer@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19022,6 +23698,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v3.3.3",
       "purl": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -19047,6 +23727,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/egulias/email-validator@4.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -19070,6 +23754,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.23.1",
       "purl": "pkg:composer/fakerphp/faker@v1.23.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19099,6 +23787,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/fruitcake/php-cors@v1.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -19123,6 +23815,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/graham-campbell/result-type@v1.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19135,6 +23831,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.9.2",
       "purl": "pkg:composer/guzzlehttp/guzzle@7.9.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -19160,6 +23860,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/guzzlehttp/promises@2.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19173,6 +23877,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/guzzlehttp/psr7@2.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19185,6 +23893,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.0.3",
       "purl": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -19210,6 +23922,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/hamcrest/hamcrest-php@v2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19227,6 +23943,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/collections@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19239,6 +23959,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v11.19.0",
       "purl": "pkg:composer/illuminate/conditionable@v11.19.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -19253,6 +23977,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/contracts@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19266,6 +23994,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/illuminate/macroable@v11.19.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19278,6 +24010,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v0.1.24",
       "purl": "pkg:composer/laravel/prompts@v0.1.24",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -19303,6 +24039,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/laravel/serializable-closure@v1.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -19326,6 +24066,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.5.1",
       "purl": "pkg:composer/league/commonmark@2.5.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -19351,6 +24095,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/config@v1.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19363,6 +24111,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.28.0",
       "purl": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19392,6 +24144,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem-local@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19408,6 +24164,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.28.0",
       "purl": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19437,6 +24197,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem-read-only@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19465,6 +24229,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/flysystem@3.28.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19482,6 +24250,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/league/mime-type-detection@1.15.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19498,6 +24270,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.6.12",
       "purl": "pkg:composer/mockery/mockery@1.6.12",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19527,6 +24303,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/monolog/monolog@3.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -19551,6 +24331,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/mtdowling/jmespath.php@2.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19568,6 +24352,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/myclabs/deep-copy@1.12.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19584,6 +24372,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.7.0",
       "purl": "pkg:composer/nesbot/carbon@3.7.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -19609,6 +24401,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/nette/schema@v1.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19622,6 +24418,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/nette/utils@v4.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19634,6 +24434,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v5.1.0",
       "purl": "pkg:composer/nikic/php-parser@v5.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19651,6 +24455,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v2.0.1",
       "purl": "pkg:composer/nunomaduro/termwind@v2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -19675,6 +24483,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.8.1",
       "purl": "pkg:composer/nyholm/psr7@1.8.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19704,6 +24516,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/pda/pheanstalk@v5.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19732,6 +24548,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phar-io/manifest@2.0.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19748,6 +24568,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.2.1",
       "purl": "pkg:composer/phar-io/version@3.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19766,6 +24590,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpoption/phpoption@1.9.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19778,6 +24606,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.11.9",
       "purl": "pkg:composer/phpstan/phpstan@1.11.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19807,6 +24639,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-code-coverage@11.0.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19823,6 +24659,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.0.1",
       "purl": "pkg:composer/phpunit/php-file-iterator@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19841,6 +24681,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-invoker@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19857,6 +24701,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.1",
       "purl": "pkg:composer/phpunit/php-text-template@4.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19875,6 +24723,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/phpunit/php-timer@7.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19891,6 +24743,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "11.3.0",
       "purl": "pkg:composer/phpunit/phpunit@11.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -19920,6 +24776,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/predis/predis@v2.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19948,6 +24808,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/cache@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -19965,6 +24829,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/clock@1.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -19977,6 +24845,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.2",
       "purl": "pkg:composer/psr/container@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20002,6 +24874,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/event-dispatcher@1.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20014,6 +24890,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.3",
       "purl": "pkg:composer/psr/http-client@1.0.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -20028,6 +24908,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/http-factory@1.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20041,6 +24925,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/http-message@2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20053,6 +24941,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.0",
       "purl": "pkg:composer/psr/log@3.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20078,6 +24970,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/psr/simple-cache@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -20102,6 +24998,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ralouphie/getallheaders@3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20115,6 +25015,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/ramsey/collection@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20127,6 +25031,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.7.6",
       "purl": "pkg:composer/ramsey/uuid@4.7.6",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20151,6 +25059,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v0.10.1",
       "purl": "pkg:composer/resend/resend-php@v0.10.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20180,6 +25092,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/rybakit/msgpack@v0.9.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20196,6 +25112,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.2",
       "purl": "pkg:composer/sebastian/cli-parser@3.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20214,6 +25134,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20230,6 +25154,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.1",
       "purl": "pkg:composer/sebastian/code-unit@3.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20248,6 +25176,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/comparator@6.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20264,6 +25196,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.1",
       "purl": "pkg:composer/sebastian/complexity@4.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20282,6 +25218,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/diff@6.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20298,6 +25238,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.2.0",
       "purl": "pkg:composer/sebastian/environment@7.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20316,6 +25260,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/exporter@6.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20332,6 +25280,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.2",
       "purl": "pkg:composer/sebastian/global-state@7.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20350,6 +25302,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/lines-of-code@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20366,6 +25322,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.1",
       "purl": "pkg:composer/sebastian/object-enumerator@6.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20384,6 +25344,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/object-reflector@4.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20400,6 +25364,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.2",
       "purl": "pkg:composer/sebastian/recursion-context@6.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20418,6 +25386,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/sebastian/type@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20434,6 +25406,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.0.1",
       "purl": "pkg:composer/sebastian/version@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20452,6 +25428,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/cache-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20468,6 +25448,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/cache@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20497,6 +25481,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/clock@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20509,6 +25497,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/console@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20534,6 +25526,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/css-selector@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20547,6 +25543,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20559,6 +25559,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/error-handler@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20584,6 +25588,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/event-dispatcher-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20597,6 +25605,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/event-dispatcher@v7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20609,6 +25621,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/finder@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20634,6 +25650,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/http-client-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -20650,6 +25670,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/http-client@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20679,6 +25703,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/http-foundation@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -20702,6 +25730,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/http-kernel@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20727,6 +25759,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/mailer@v7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -20750,6 +25786,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.2",
       "purl": "pkg:composer/symfony/mime@v7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20775,6 +25815,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-ctype@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20787,6 +25831,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -20801,6 +25849,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20813,6 +25865,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -20827,6 +25883,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20839,6 +25899,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-php72@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -20853,6 +25917,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-php80@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20865,6 +25933,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v1.30.0",
       "purl": "pkg:composer/symfony/polyfill-php83@v1.30.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20890,6 +25962,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/polyfill-uuid@v1.30.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20902,6 +25978,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/process@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -20926,6 +26006,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/psr-http-message-bridge@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -20955,6 +26039,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/routing@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -20979,6 +26067,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/service-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -20991,6 +26083,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.3",
       "purl": "pkg:composer/symfony/string@v7.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
@@ -21005,6 +26101,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/translation-contracts@v3.5.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -21018,6 +26118,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/translation@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -21030,6 +26134,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v7.1.1",
       "purl": "pkg:composer/symfony/uid@v7.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -21055,6 +26163,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/var-dumper@v7.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -21079,6 +26191,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/symfony/var-exporter@v7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -21096,6 +26212,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/theseer/tokenizer@1.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -21112,6 +26232,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "v2.2.7",
       "purl": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -21137,6 +26261,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/vlucas/phpdotenv@v5.6.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -21160,6 +26288,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.1",
       "purl": "pkg:composer/voku/portable-ascii@2.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -21185,6 +26317,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:composer/webmozart/assert@1.11.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "composer/composer.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Composer"
         }
@@ -21198,6 +26334,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:conan/zlib@1.2.11",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "conan.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Conan"
         }
@@ -21210,6 +26350,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.2.9",
       "purl": "pkg:gem/RedCloth@4.2.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -21235,6 +26379,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actioncable@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21247,6 +26395,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionmailbox@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21261,6 +26413,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actionmailer@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21273,6 +26429,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionpack@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21287,6 +26447,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/actiontext@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21299,6 +26463,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/actionview@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21313,6 +26481,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activejob@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21325,6 +26497,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/activemodel@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21339,6 +26515,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activerecord@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21351,6 +26531,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/activestorage@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21365,6 +26549,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/activesupport@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21377,6 +26565,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.8.7",
       "purl": "pkg:gem/addressable@2.8.7",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21391,6 +26583,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/base64@0.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21403,6 +26599,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.1.8",
       "purl": "pkg:gem/bigdecimal@3.1.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21417,6 +26617,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/builder@3.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21429,6 +26633,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.39.2",
       "purl": "pkg:gem/capybara@3.39.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21443,6 +26651,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/childprocess@5.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21455,6 +26667,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.10.2",
       "purl": "pkg:gem/chronic@0.10.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -21480,6 +26696,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/coderay@1.0.9",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -21504,6 +26724,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/concurrent-ruby@1.3.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21516,6 +26740,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.4.1",
       "purl": "pkg:gem/connection_pool@2.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21530,6 +26758,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/crass@1.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21542,6 +26774,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "10.0.1",
       "purl": "pkg:gem/cucumber-ci-environment@10.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21556,6 +26792,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-core@13.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21568,6 +26808,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "17.1.0",
       "purl": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21582,6 +26826,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-gherkin@27.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21594,6 +26842,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "21.4.1",
       "purl": "pkg:gem/cucumber-html-formatter@21.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21608,6 +26860,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-messages@22.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21620,6 +26876,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:gem/cucumber-rails@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -21649,6 +26909,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber-tag-expressions@6.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21661,6 +26925,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.10.0",
       "purl": "pkg:gem/cucumber-websteps@0.10.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -21690,6 +26958,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/cucumber@9.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21702,6 +26974,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.2.0",
       "purl": "pkg:gem/database_cleaner-active_record@2.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21716,6 +26992,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/database_cleaner-core@2.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21728,6 +27008,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.2",
       "purl": "pkg:gem/database_cleaner@2.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -21757,6 +27041,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/date@3.3.4",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21769,6 +27057,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.5.1",
       "purl": "pkg:gem/diff-lcs@1.5.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21783,6 +27075,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/drb@2.2.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21796,6 +27092,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/erubi@1.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21808,6 +27108,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.9.0",
       "purl": "pkg:gem/factory_girl@4.9.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -21837,6 +27141,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/ffi@1.17.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21849,6 +27157,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.2.1",
       "purl": "pkg:gem/globalid@1.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21863,6 +27175,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/i18n@1.14.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21875,6 +27191,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.7.2",
       "purl": "pkg:gem/io-console@0.7.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21889,6 +27209,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/irb@1.14.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21901,6 +27225,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.6.0",
       "purl": "pkg:gem/jquery-rails@4.6.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -21926,6 +27254,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/launchy@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21938,6 +27270,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.22.0",
       "purl": "pkg:gem/loofah@2.22.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21952,6 +27288,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/mail@2.8.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21964,6 +27304,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.4",
       "purl": "pkg:gem/marcel@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -21978,6 +27322,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/matrix@0.4.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -21990,6 +27338,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.1.5",
       "purl": "pkg:gem/mini_mime@1.1.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22004,6 +27356,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/mini_portile2@2.8.7",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22016,6 +27372,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.24.1",
       "purl": "pkg:gem/minitest@5.24.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22030,6 +27390,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/multi_test@1.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22042,6 +27406,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.2.0",
       "purl": "pkg:gem/mutex_m@0.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22056,6 +27424,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/net-imap@0.4.14",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22068,6 +27440,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.1.2",
       "purl": "pkg:gem/net-pop@0.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22082,6 +27458,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/net-protocol@0.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22094,6 +27474,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.5.0",
       "purl": "pkg:gem/net-smtp@0.5.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22108,6 +27492,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/nio4r@2.7.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22120,6 +27508,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.15.6",
       "purl": "pkg:gem/nokogiri@1.15.6",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22134,6 +27526,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/psych@5.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22146,6 +27542,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.1",
       "purl": "pkg:gem/public_suffix@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22160,6 +27560,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/racc@1.8.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22172,6 +27576,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.2",
       "purl": "pkg:gem/rack-openid@1.4.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -22197,6 +27605,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rack-session@2.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22209,6 +27621,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.0",
       "purl": "pkg:gem/rack-test@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22223,6 +27639,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rack@3.1.7",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22235,6 +27655,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.0",
       "purl": "pkg:gem/rackup@2.1.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22249,6 +27673,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rails-dom-testing@2.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22262,6 +27690,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rails-html-sanitizer@1.6.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22274,6 +27706,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.1.2",
       "purl": "pkg:gem/rails@7.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -22299,6 +27735,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/railties@7.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22311,6 +27751,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "13.2.1",
       "purl": "pkg:gem/rake@13.2.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22325,6 +27769,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rdoc@6.7.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22337,6 +27785,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.9.2",
       "purl": "pkg:gem/regexp_parser@2.9.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22351,6 +27803,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/reline@0.5.9",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22363,6 +27819,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.2.0",
       "purl": "pkg:gem/rspec-activemodel-mocks@1.2.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -22392,6 +27852,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-collection_matchers@1.2.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -22420,6 +27884,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-core@3.13.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22432,6 +27900,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.13.1",
       "purl": "pkg:gem/rspec-expectations@3.13.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22446,6 +27918,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-mocks@3.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22459,6 +27935,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/rspec-support@3.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22471,6 +27951,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.13.0",
       "purl": "pkg:gem/rspec@3.13.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -22500,6 +27984,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/ruby-openid@2.9.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -22523,6 +28011,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.7.3",
       "purl": "pkg:gem/sqlite3@1.7.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -22548,6 +28040,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/stringio@3.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22560,6 +28056,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.3.0",
       "purl": "pkg:gem/sys-uname@1.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22574,6 +28074,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/thor@1.3.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22586,6 +28090,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.4.1",
       "purl": "pkg:gem/timeout@0.4.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22600,6 +28108,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/tzinfo@2.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22612,6 +28124,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.8.1",
       "purl": "pkg:gem/webrick@1.8.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -22626,6 +28142,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/websocket-driver@0.7.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22639,6 +28159,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/websocket-extensions@0.1.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22651,6 +28175,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.12",
       "purl": "pkg:gem/will_paginate@3.0.12",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -22676,6 +28204,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/xpath@3.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22689,6 +28221,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:gem/zeitwerk@2.6.17",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Gemfile.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -22701,6 +28237,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.0",
       "purl": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "go.mod"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -22726,6 +28266,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:golang/stdlib@1.21.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "go.mod"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -22742,6 +28286,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.2",
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -22771,6 +28323,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/junit/junit@4.13.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -22794,6 +28350,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.13.2",
       "purl": "pkg:maven/junit/junit@4.13.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -22819,6 +28379,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.hamcrest/hamcrest-core@1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -22836,6 +28400,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -22851,6 +28419,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "name": "org.springframework.boot:spring-boot-starter-test",
       "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -22879,6 +28451,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "maven-spring/pom.xml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -22903,6 +28479,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.security/spring-security-crypto@5.7.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-groovy/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Gradle"
         }
@@ -22923,6 +28503,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/org.springframework.security/spring-security-crypto@5.7.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "gradle-kotlin/gradle.lockfile"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Gradle"
         }
@@ -22942,6 +28526,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "8.7.0",
       "purl": "pkg:npm/acorn@8.7.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -22967,6 +28555,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -22991,6 +28583,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/datadog-sbom-generator@0.0.0-use.local",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23003,6 +28599,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.6.9",
       "purl": "pkg:npm/debug@2.6.9",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -23032,6 +28632,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/debug@4.3.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -23053,6 +28657,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/lodash@4.17.20",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23069,6 +28677,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.0",
       "purl": "pkg:npm/ms@2.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -23087,6 +28699,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ms@2.1.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pnpm-9/pnpm-lock.yaml"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -23103,6 +28719,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.3",
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "npm/package-lock.json"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -23132,6 +28752,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/supports-color@10.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn/yarn.lock"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         },
@@ -23160,6 +28784,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "npm/package-lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23183,6 +28811,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.1.2",
       "purl": "pkg:nuget/Downloader@3.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23208,6 +28840,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:nuget/MaterialDesignThemes@5.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23231,6 +28867,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "6.0.5",
       "purl": "pkg:nuget/Test.Core@6.0.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "packages.lock.json"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23256,6 +28896,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:nuget/Test.Core@6.0.6",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "nuget/packages.lock.json"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23279,6 +28923,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.9.3",
       "purl": "pkg:pypi/beautifulsoup4@4.9.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23304,6 +28952,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/certifi@2024.8.30",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Requirements"
         }
@@ -23323,6 +28975,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.4.0",
       "purl": "pkg:pypi/charset-normalizer@3.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23348,6 +29004,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/django-debug-toolbar@3.2.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23371,6 +29031,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.4.0",
       "purl": "pkg:pypi/django-filter@2.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23396,6 +29060,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/django@2.2.24",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23419,6 +29087,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.10",
       "purl": "pkg:pypi/idna@3.10",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23444,6 +29116,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/markupsafe@2.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "Pipfile.lock"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23467,6 +29143,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.23.3",
       "purl": "pkg:pypi/numpy@1.23.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "poetry.lock"
+        },
         {
           "name": "osv-scanner:is-dev",
           "value": "true"
@@ -23496,6 +29176,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/pandas@2.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "other-requirements.txt"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements-test.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23520,6 +29208,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:pypi/requests@2.32.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23543,6 +29235,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.2.3",
       "purl": "pkg:pypi/urllib3@2.2.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "requirements.txt"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Requirements"
@@ -23633,6 +29329,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:maven/com.foobar/common@1.0-SNAPSHOT",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "other-dir/pom.xml"
+        },
+        {
           "name": "osv-scanner:is-direct",
           "value": "true"
         },
@@ -23656,6 +29356,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.0.2",
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "other-dir/pom.xml"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23729,6 +29437,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23741,6 +29453,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.12.1",
       "purl": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -23755,6 +29471,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23767,6 +29487,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.5",
       "purl": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -23781,6 +29505,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23793,6 +29521,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.15",
       "purl": "pkg:npm/%40types%2Fjson-schema@7.0.15",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -23807,6 +29539,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40types%2Fsemver@7.5.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23819,6 +29555,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23844,6 +29584,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23856,6 +29600,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -23870,6 +29618,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23882,6 +29634,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -23896,6 +29652,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23908,6 +29668,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -23922,6 +29686,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/array-union@2.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23935,6 +29703,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/braces@3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23947,6 +29719,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.4.0",
       "purl": "pkg:npm/debug@4.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -23972,6 +29748,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/dir-glob@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -23984,6 +29764,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.1",
       "purl": "pkg:npm/eslint-scope@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -23998,6 +29782,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24010,6 +29798,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.3.0",
       "purl": "pkg:npm/esrecurse@4.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24024,6 +29816,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/estraverse@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24036,6 +29832,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.3.0",
       "purl": "pkg:npm/estraverse@5.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24050,6 +29850,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/fast-glob@3.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24062,6 +29866,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.18.0",
       "purl": "pkg:npm/fastq@1.18.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24076,6 +29884,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/fill-range@7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24088,6 +29900,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.2",
       "purl": "pkg:npm/glob-parent@5.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24102,6 +29918,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/globby@11.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24114,6 +29934,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:npm/graphemer@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24128,6 +29952,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ignore@5.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24140,6 +29968,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.1",
       "purl": "pkg:npm/is-extglob@2.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24154,6 +29986,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/is-glob@4.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24166,6 +30002,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.0",
       "purl": "pkg:npm/is-number@7.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24180,6 +30020,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/merge2@1.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24192,6 +30036,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.8",
       "purl": "pkg:npm/micromatch@4.0.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24206,6 +30054,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24218,6 +30070,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:npm/natural-compare-lite@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24232,6 +30088,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/path-type@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24244,6 +30104,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.3.1",
       "purl": "pkg:npm/picomatch@2.3.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24258,6 +30122,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24270,6 +30138,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.4",
       "purl": "pkg:npm/reusify@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24284,6 +30156,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/run-parallel@1.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24296,6 +30172,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.6.3",
       "purl": "pkg:npm/semver@7.6.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24310,6 +30190,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/slash@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24322,6 +30206,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.0.1",
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24336,6 +30224,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/tslib@1.14.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24348,6 +30240,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.21.0",
       "purl": "pkg:npm/tsutils@3.21.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24390,6 +30286,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24402,6 +30302,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.12.1",
       "purl": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24416,6 +30320,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24428,6 +30336,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.5",
       "purl": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24442,6 +30354,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24454,6 +30370,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.15",
       "purl": "pkg:npm/%40types%2Fjson-schema@7.0.15",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24468,6 +30388,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40types%2Fsemver@7.5.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24480,6 +30404,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -24505,6 +30433,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24517,6 +30449,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24531,6 +30467,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24543,6 +30483,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24557,6 +30501,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24569,6 +30517,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24583,6 +30535,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/array-union@2.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24596,6 +30552,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/braces@3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24608,6 +30568,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.4.0",
       "purl": "pkg:npm/debug@4.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -24633,6 +30597,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/dir-glob@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24645,6 +30613,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.1",
       "purl": "pkg:npm/eslint-scope@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24659,6 +30631,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24671,6 +30647,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.3.0",
       "purl": "pkg:npm/esrecurse@4.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24685,6 +30665,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/estraverse@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24697,6 +30681,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.3.0",
       "purl": "pkg:npm/estraverse@5.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24711,6 +30699,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/fast-glob@3.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24723,6 +30715,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.18.0",
       "purl": "pkg:npm/fastq@1.18.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24737,6 +30733,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/fill-range@7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24749,6 +30749,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.2",
       "purl": "pkg:npm/glob-parent@5.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24763,6 +30767,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/globby@11.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24775,6 +30783,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:npm/graphemer@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24789,6 +30801,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ignore@5.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24801,6 +30817,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.1",
       "purl": "pkg:npm/is-extglob@2.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24815,6 +30835,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/is-glob@4.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24827,6 +30851,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.0",
       "purl": "pkg:npm/is-number@7.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24841,6 +30869,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/merge2@1.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24853,6 +30885,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.8",
       "purl": "pkg:npm/micromatch@4.0.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24867,6 +30903,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24879,6 +30919,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:npm/natural-compare-lite@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24893,6 +30937,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/path-type@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24905,6 +30953,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.3.1",
       "purl": "pkg:npm/picomatch@2.3.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24919,6 +30971,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24931,6 +30987,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.4",
       "purl": "pkg:npm/reusify@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24945,6 +31005,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/run-parallel@1.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24957,6 +31021,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.6.3",
       "purl": "pkg:npm/semver@7.6.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24971,6 +31039,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/slash@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -24983,6 +31055,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.0.0-use.local",
       "purl": "pkg:npm/suiftly.io@0.0.0-use.local",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -24997,6 +31073,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25010,6 +31090,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/tslib@1.14.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25022,6 +31106,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.21.0",
       "purl": "pkg:npm/tsutils@3.21.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25064,6 +31152,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25076,6 +31168,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.12.1",
       "purl": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25090,6 +31186,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25102,6 +31202,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.0.5",
       "purl": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25116,6 +31220,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25128,6 +31236,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.15",
       "purl": "pkg:npm/%40types%2Fjson-schema@7.0.15",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25142,6 +31254,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40types%2Fsemver@7.5.8",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25154,6 +31270,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -25179,6 +31299,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25191,6 +31315,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25205,6 +31333,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25217,6 +31349,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25231,6 +31367,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25243,6 +31383,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.62.0",
       "purl": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25257,6 +31401,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/array-union@2.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25270,6 +31418,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/braces@3.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25282,6 +31434,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.4.0",
       "purl": "pkg:npm/debug@4.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:is-direct",
           "value": "true"
@@ -25307,6 +31463,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/dir-glob@3.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25319,6 +31479,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.1",
       "purl": "pkg:npm/eslint-scope@5.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25333,6 +31497,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25345,6 +31513,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.3.0",
       "purl": "pkg:npm/esrecurse@4.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25359,6 +31531,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/estraverse@4.3.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25371,6 +31547,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.3.0",
       "purl": "pkg:npm/estraverse@5.3.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25385,6 +31565,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/fast-glob@3.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25397,6 +31581,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.18.0",
       "purl": "pkg:npm/fastq@1.18.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25411,6 +31599,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/fill-range@7.1.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25423,6 +31615,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "5.1.2",
       "purl": "pkg:npm/glob-parent@5.1.2",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25437,6 +31633,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/globby@11.1.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25449,6 +31649,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:npm/graphemer@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25463,6 +31667,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ignore@5.3.2",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25475,6 +31683,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.1.1",
       "purl": "pkg:npm/is-extglob@2.1.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25489,6 +31701,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/is-glob@4.0.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25501,6 +31717,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.0.0",
       "purl": "pkg:npm/is-number@7.0.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25515,6 +31735,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/merge2@1.4.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25527,6 +31751,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "4.0.8",
       "purl": "pkg:npm/micromatch@4.0.8",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25541,6 +31769,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/ms@2.1.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25553,6 +31785,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.4.0",
       "purl": "pkg:npm/natural-compare-lite@1.4.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25567,6 +31803,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/path-type@4.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25579,6 +31819,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "2.3.1",
       "purl": "pkg:npm/picomatch@2.3.1",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25593,6 +31837,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25605,6 +31853,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "1.0.4",
       "purl": "pkg:npm/reusify@1.0.4",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25619,6 +31871,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/run-parallel@1.2.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25631,6 +31887,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "7.6.3",
       "purl": "pkg:npm/semver@7.6.3",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25645,6 +31905,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/slash@3.0.0",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25657,6 +31921,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "0.0.0-use.local",
       "purl": "pkg:npm/suiftly.io@0.0.0-use.local",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
@@ -25671,6 +31939,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25684,6 +31956,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "purl": "pkg:npm/tslib@1.14.1",
       "properties": [
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -25696,6 +31972,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "version": "3.21.0",
       "purl": "pkg:npm/tsutils@3.21.0",
       "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "yarn.lock"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"

--- a/internal/output/__snapshots__/cyclonedx_test.snap
+++ b/internal/output/__snapshots__/cyclonedx_test.snap
@@ -67,14 +67,26 @@
       "type": "library",
       "name": "dev.foo:lib1",
       "version": "1.0-SNAPSHOT",
-      "purl": "pkg:maven/dev.foo/lib1@1.0-SNAPSHOT"
+      "purl": "pkg:maven/dev.foo/lib1@1.0-SNAPSHOT",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:maven/dev.foo/lib2@1.0-SNAPSHOT",
       "type": "library",
       "name": "dev.foo:lib2",
       "version": "1.0-SNAPSHOT",
-      "purl": "pkg:maven/dev.foo/lib2@1.0-SNAPSHOT"
+      "purl": "pkg:maven/dev.foo/lib2@1.0-SNAPSHOT",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        }
+      ]
     }
   ],
   "dependencies": [
@@ -136,7 +148,13 @@
       "type": "library",
       "name": "com.nobody:mine1",
       "version": "1.2.3",
-      "purl": "pkg:maven/com.nobody/mine1@1.2.3"
+      "purl": "pkg:maven/com.nobody/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        }
+      ]
     }
   ]
 }
@@ -167,7 +185,13 @@
       "type": "library",
       "name": "com.nobody:mine1",
       "version": "1.2.3",
-      "purl": "pkg:maven/com.nobody/mine1@1.2.3"
+      "purl": "pkg:maven/com.nobody/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "pom.xml"
+        }
+      ]
     }
   ]
 }
@@ -198,7 +222,13 @@
       "type": "library",
       "name": "com.nobody:mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/com.nobody%3Amine1@1.2.3"
+      "purl": "pkg:npm/com.nobody%3Amine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ]
 }
@@ -240,6 +270,10 @@
           "value": "org.example:*"
         },
         {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/pom.xml"
+        },
+        {
           "name": "osv-scanner:is-dev",
           "value": "true"
         }
@@ -274,28 +308,56 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/third/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine1@1.3.5",
       "type": "library",
       "name": "mine1",
       "version": "1.3.5",
-      "purl": "pkg:npm/mine1@1.3.5"
+      "purl": "pkg:npm/mine1@1.3.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/third/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine2@3.2.5",
       "type": "library",
       "name": "mine2",
       "version": "3.2.5",
-      "purl": "pkg:npm/mine2@3.2.5"
+      "purl": "pkg:npm/mine2@3.2.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine3@0.4.1",
       "type": "library",
       "name": "mine3",
       "version": "0.4.1",
-      "purl": "pkg:npm/mine3@0.4.1"
+      "purl": "pkg:npm/mine3@0.4.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -350,28 +412,56 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/third/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine1@1.3.5",
       "type": "library",
       "name": "mine1",
       "version": "1.3.5",
-      "purl": "pkg:npm/mine1@1.3.5"
+      "purl": "pkg:npm/mine1@1.3.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/third/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine2@3.2.5",
       "type": "library",
       "name": "mine2",
       "version": "3.2.5",
-      "purl": "pkg:npm/mine2@3.2.5"
+      "purl": "pkg:npm/mine2@3.2.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine3@0.4.1",
       "type": "library",
       "name": "mine3",
       "version": "0.4.1",
-      "purl": "pkg:npm/mine3@0.4.1"
+      "purl": "pkg:npm/mine3@0.4.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -426,7 +516,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -470,7 +566,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -514,7 +616,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -558,14 +666,26 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine2@5.9.0",
       "type": "library",
       "name": "mine2",
       "version": "5.9.0",
-      "purl": "pkg:npm/mine2@5.9.0"
+      "purl": "pkg:npm/mine2@5.9.0",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -609,28 +729,52 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.2",
-      "purl": "pkg:npm/mine1@1.2.2"
+      "purl": "pkg:npm/mine1@1.2.2",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine1@1.2.3",
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine2@3.2.5",
       "type": "library",
       "name": "mine2",
       "version": "3.2.5",
-      "purl": "pkg:npm/mine2@3.2.5"
+      "purl": "pkg:npm/mine2@3.2.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine3@0.4.1",
       "type": "library",
       "name": "mine3",
       "version": "0.4.1",
-      "purl": "pkg:npm/mine3@0.4.1"
+      "purl": "pkg:npm/mine3@0.4.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -707,28 +851,52 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.2",
-      "purl": "pkg:npm/mine1@1.2.2"
+      "purl": "pkg:npm/mine1@1.2.2",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine1@1.2.3",
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine2@3.2.5",
       "type": "library",
       "name": "mine2",
       "version": "3.2.5",
-      "purl": "pkg:npm/mine2@3.2.5"
+      "purl": "pkg:npm/mine2@3.2.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine3@0.4.1",
       "type": "library",
       "name": "mine3",
       "version": "0.4.1",
-      "purl": "pkg:npm/mine3@0.4.1"
+      "purl": "pkg:npm/mine3@0.4.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -805,28 +973,56 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/third/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine1@1.3.5",
       "type": "library",
       "name": "mine1",
       "version": "1.3.5",
-      "purl": "pkg:npm/mine1@1.3.5"
+      "purl": "pkg:npm/mine1@1.3.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/third/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine2@3.2.5",
       "type": "library",
       "name": "mine2",
       "version": "3.2.5",
-      "purl": "pkg:npm/mine2@3.2.5"
+      "purl": "pkg:npm/mine2@3.2.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine3@0.4.1",
       "type": "library",
       "name": "mine3",
       "version": "0.4.1",
-      "purl": "pkg:npm/mine3@0.4.1"
+      "purl": "pkg:npm/mine3@0.4.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ]
 }
@@ -857,28 +1053,56 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/third/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine1@1.3.5",
       "type": "library",
       "name": "mine1",
       "version": "1.3.5",
-      "purl": "pkg:npm/mine1@1.3.5"
+      "purl": "pkg:npm/mine1@1.3.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/third/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine2@3.2.5",
       "type": "library",
       "name": "mine2",
       "version": "3.2.5",
-      "purl": "pkg:npm/mine2@3.2.5"
+      "purl": "pkg:npm/mine2@3.2.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine3@0.4.1",
       "type": "library",
       "name": "mine3",
       "version": "0.4.1",
-      "purl": "pkg:npm/mine3@0.4.1"
+      "purl": "pkg:npm/mine3@0.4.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -933,28 +1157,52 @@
       "type": "library",
       "name": "author1/mine1",
       "version": "1.2.3",
-      "purl": "pkg:composer/author1/mine1@1.2.3"
+      "purl": "pkg:composer/author1/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:composer/author3/mine3@0.4.1",
       "type": "library",
       "name": "author3/mine3",
       "version": "0.4.1",
-      "purl": "pkg:composer/author3/mine3@0.4.1"
+      "purl": "pkg:composer/author3/mine3@0.4.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine1@1.2.2",
       "type": "library",
       "name": "mine1",
       "version": "1.2.2",
-      "purl": "pkg:npm/mine1@1.2.2"
+      "purl": "pkg:npm/mine1@1.2.2",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:nuget/mine2@3.2.5",
       "type": "library",
       "name": "mine2",
       "version": "3.2.5",
-      "purl": "pkg:nuget/mine2@3.2.5"
+      "purl": "pkg:nuget/mine2@3.2.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1031,28 +1279,52 @@
       "type": "library",
       "name": "author1/mine1",
       "version": "1.2.3",
-      "purl": "pkg:composer/author1/mine1@1.2.3"
+      "purl": "pkg:composer/author1/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:composer/author3/mine3@0.4.1",
       "type": "library",
       "name": "author3/mine3",
       "version": "0.4.1",
-      "purl": "pkg:composer/author3/mine3@0.4.1"
+      "purl": "pkg:composer/author3/mine3@0.4.1",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine1@1.2.2",
       "type": "library",
       "name": "mine1",
       "version": "1.2.2",
-      "purl": "pkg:npm/mine1@1.2.2"
+      "purl": "pkg:npm/mine1@1.2.2",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:nuget/mine2@3.2.5",
       "type": "library",
       "name": "mine2",
       "version": "3.2.5",
-      "purl": "pkg:nuget/mine2@3.2.5"
+      "purl": "pkg:nuget/mine2@3.2.5",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1195,7 +1467,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ]
 }
@@ -1226,7 +1504,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1281,7 +1565,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1325,7 +1615,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1369,7 +1665,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1413,7 +1715,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1457,7 +1765,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1518,7 +1832,13 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1579,14 +1899,26 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine3@0.10.2-rc",
       "type": "library",
       "name": "mine3",
       "version": "0.10.2-rc",
-      "purl": "pkg:npm/mine3@0.10.2-rc"
+      "purl": "pkg:npm/mine3@0.10.2-rc",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1628,14 +1960,26 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        }
+      ]
     },
     {
       "bom-ref": "pkg:npm/mine2@5.9.0",
       "type": "library",
       "name": "mine2",
       "version": "5.9.0",
-      "purl": "pkg:npm/mine2@5.9.0"
+      "purl": "pkg:npm/mine2@5.9.0",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [
@@ -1679,7 +2023,17 @@
       "type": "library",
       "name": "mine1",
       "version": "1.2.3",
-      "purl": "pkg:npm/mine1@1.2.3"
+      "purl": "pkg:npm/mine1@1.2.3",
+      "properties": [
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/first/lockfile"
+        },
+        {
+          "name": "datadog-sbom-generator:lockfile-filepath",
+          "value": "path/to/my/second/lockfile"
+        }
+      ]
     }
   ],
   "vulnerabilities": [

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -1,6 +1,7 @@
 package sbom
 
 import (
+	"iter"
 	"slices"
 	"strings"
 	"time"
@@ -12,6 +13,8 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
+
+const propertyPrefix = "datadog-sbom-generator:"
 
 type PackageProcessingHook = func(component *cyclonedx.Component, details models.PackageVulns)
 
@@ -121,8 +124,16 @@ func buildMetadataComponent(tool Tool) *cyclonedx.Metadata {
 	}
 }
 
-func buildProperties(metadatas models.PackageMetadata) []cyclonedx.Property {
+func buildProperties(metadatas models.PackageMetadata, lockfilePaths iter.Seq[string]) []cyclonedx.Property {
 	properties := make([]cyclonedx.Property, 0)
+
+	// Reporting all lockfile paths found for that library
+	for lockfilePath := range lockfilePaths {
+		properties = append(properties, cyclonedx.Property{
+			Name:  propertyPrefix + "lockfile-filepath",
+			Value: lockfilePath,
+		})
+	}
 
 	for metadataType, value := range metadatas {
 		if len(value) == 0 {
@@ -131,14 +142,14 @@ func buildProperties(metadatas models.PackageMetadata) []cyclonedx.Property {
 		// TODO(daniel.strong) Remove this conditional when we support datadog-sbom-generator prefixes in all metadata keys.
 		if strings.HasPrefix(string(metadataType), string(models.ReachableSymbolLocationMetadata)) {
 			properties = append(properties, cyclonedx.Property{
-				Name:  "datadog-sbom-generator:" + string(metadataType),
+				Name:  propertyPrefix + string(metadataType),
 				Value: value,
 			})
 		} else if metadataType == models.ExclusionMetadata {
 			props := strings.Split(value, ",")
 			for _, prop := range props {
 				properties = append(properties, cyclonedx.Property{
-					Name:  "datadog-sbom-generator:" + string(metadataType),
+					Name:  propertyPrefix + string(metadataType),
 					Value: prop,
 				})
 			}
@@ -197,7 +208,7 @@ func createLibraryComponent(packageURL string, packageDetail models.PackageVulns
 	component.Name = packageDetail.Package.Name
 	component.Version = packageDetail.Package.Version
 
-	properties := buildProperties(packageDetail.Metadata)
+	properties := buildProperties(packageDetail.Metadata, maps.Keys(packageDetail.LockfilePath))
 	component.Properties = &properties
 
 	return component

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -1,7 +1,6 @@
 package sbom
 
 import (
-	"iter"
 	"slices"
 	"strings"
 	"time"
@@ -124,11 +123,11 @@ func buildMetadataComponent(tool Tool) *cyclonedx.Metadata {
 	}
 }
 
-func buildProperties(metadatas models.PackageMetadata, lockfilePaths iter.Seq[string]) []cyclonedx.Property {
+func buildProperties(metadatas models.PackageMetadata, lockfilePaths []string) []cyclonedx.Property {
 	properties := make([]cyclonedx.Property, 0)
 
 	// Reporting all lockfile paths found for that library
-	for lockfilePath := range lockfilePaths {
+	for _, lockfilePath := range lockfilePaths {
 		properties = append(properties, cyclonedx.Property{
 			Name:  propertyPrefix + "lockfile-filepath",
 			Value: lockfilePath,
@@ -208,7 +207,10 @@ func createLibraryComponent(packageURL string, packageDetail models.PackageVulns
 	component.Name = packageDetail.Package.Name
 	component.Version = packageDetail.Package.Version
 
-	properties := buildProperties(packageDetail.Metadata, maps.Keys(packageDetail.LockfilePath))
+	sortedLockfilePaths := slices.AppendSeq(make([]string, 0), maps.Keys(packageDetail.LockfilePath))
+	slices.Sort(sortedLockfilePaths)
+
+	properties := buildProperties(packageDetail.Metadata, sortedLockfilePaths)
 	component.Properties = &properties
 
 	return component

--- a/internal/utility/purl/package_grouper.go
+++ b/internal/utility/purl/package_grouper.go
@@ -27,6 +27,8 @@ func Group(packageSources []models.PackageSource) (map[string]models.PackageVuln
 				// Entry already exists, we need to merge slices which are not expected to be the exact same
 				packageVulns.DepGroups = append(packageVulns.DepGroups, pkg.DepGroups...)
 				packageVulns.Locations = append(packageVulns.Locations, pkg.Locations...)
+				packageVulns.LockfilePath[packageSource.Source.Path] = struct{}{}
+
 				if packageVulns.Metadata == nil {
 					packageVulns.Metadata = pkg.Metadata
 				} else {
@@ -37,6 +39,9 @@ func Group(packageSources []models.PackageSource) (map[string]models.PackageVuln
 				uniquePackages[packageURL.ToString()] = packageVulns
 			} else {
 				// Entry does not exists yet, lets create it
+				lockfilePaths := make(map[string]struct{})
+				lockfilePaths[packageSource.Source.Path] = struct{}{}
+
 				newPackageVuln := models.PackageVulns{
 					Package:                   pkg.Package,
 					Locations:                 slices.Clone(pkg.Locations),
@@ -44,6 +49,7 @@ func Group(packageSources []models.PackageSource) (map[string]models.PackageVuln
 					Vulnerabilities:           slices.Clone(pkg.Vulnerabilities),
 					Metadata:                  pkg.Metadata,
 					AdvisoriesForReachability: pkg.AdvisoriesForReachability,
+					LockfilePath:              lockfilePaths,
 				}
 				uniquePackages[packageURL.ToString()] = newPackageVuln
 			}

--- a/internal/utility/purl/package_grouper_test.go
+++ b/internal/utility/purl/package_grouper_test.go
@@ -97,12 +97,20 @@ func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {
 				{ID: "GHSA-456"},
 			},
 			DepGroups: []string{"build", "test"},
+			LockfilePath: map[string]struct{}{
+				"/dir/lockfile.xml":   {},
+				"/dir2/lockfile.json": {},
+			},
 		},
 		"pkg:maven/foo.bar/package-2@1.0.0": {
 			Package: models.PackageInfo{
 				Name:      "foo.bar:package-2",
 				Version:   "1.0.0",
 				Ecosystem: string(models.EcosystemMaven),
+			},
+			LockfilePath: map[string]struct{}{
+				"/dir/lockfile.xml":   {},
+				"/dir2/lockfile.json": {},
 			},
 		},
 	}
@@ -173,6 +181,10 @@ func TestGroupPackageByPURL_ShouldReportDependencyAsDirect(t *testing.T) {
 				Name:      "foo.bar:the-first-package",
 				Version:   "1.0.0",
 				Ecosystem: string(models.EcosystemMaven),
+			},
+			LockfilePath: map[string]struct{}{
+				"/lockfile.xml":     {},
+				"/dir/lockfile.xml": {},
 			},
 			Metadata: map[models.PackageMetadataType]string{
 				models.PackageManagerMetadata:     "Maven",

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -43,12 +43,13 @@ type License string
 // Vulnerabilities grouped by package
 // TODO: rename this to be Package as it now includes license information too.
 type PackageVulns struct {
-	Package                   PackageInfo        `json:"package"`
-	DepGroups                 []string           `json:"dependency_groups,omitempty"`
-	Locations                 []PackageLocations `json:"locations,omitempty"`
-	Vulnerabilities           []Vulnerability    `json:"vulnerabilities,omitempty"`
-	Metadata                  PackageMetadata    `json:"metadata,omitempty"`
-	AdvisoriesForReachability []string           `json:"reachability_advisories,omitempty"`
+	Package                   PackageInfo         `json:"package"`
+	DepGroups                 []string            `json:"dependency_groups,omitempty"`
+	Locations                 []PackageLocations  `json:"locations,omitempty"`
+	Vulnerabilities           []Vulnerability     `json:"vulnerabilities,omitempty"`
+	Metadata                  PackageMetadata     `json:"metadata,omitempty"`
+	AdvisoriesForReachability []string            `json:"reachability_advisories,omitempty"`
+	LockfilePath              map[string]struct{} `json:"lockfile_path,omitempty"`
 }
 
 type AnalysisInfo struct {


### PR DESCRIPTION
> Note : This is currently done as a proof of concept and should not be merged and deployed without a thorough review and RFC

## 🚀 Motivation 
Improve the link between runtime and static analysis by reporting lockfile paths in SBOM output. This enhancement will better help correlate dependencies with their source files and improve integration with codeowners systems.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | N/A

## 📝 Summary
Added lockfile filepath reporting to SBOM components by introducing a new property `datadog-sbom-generator:lockfile-filepath` to each package entry. This change tracks which specific lockfile (e.g., package-lock.json, yarn.lock, Gemfile.lock, composer.lock, requirements.txt) contains each dependency, enabling better correlation between static analysis and runtime dependencies. The implementation updates test snapshots across multiple package managers and lockfile formats to include the new filepath metadata.

## 🧪 Testing
- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🚧 Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: