### PR TITLE
[K9VULN-1327] Improve performance of sbom generator

### DIFF
--- a/pkg/lockfile/matcher-dependency-map.go
+++ b/pkg/lockfile/matcher-dependency-map.go
@@ -109,6 +109,8 @@ func propagateDepGroups(root *PackageDetails, visitedMap map[*PackageDetails]str
 		return
 	}
 	visitedMap[root] = struct{}{}
+
+	// Build the merged dependency groups map
 	newDepGroups := make(map[string]bool)
 	for _, group := range root.DepGroups {
 		newDepGroups[group] = true
@@ -118,7 +120,17 @@ func propagateDepGroups(root *PackageDetails, visitedMap map[*PackageDetails]str
 		for _, group := range deps.DepGroups {
 			newDepGroups[group] = true
 		}
-		deps.DepGroups = slices.Collect(maps.Keys(newDepGroups))
+	}
+
+	// Compute the slice once outside the loop instead of N times
+	var mergedGroups []string
+	if len(newDepGroups) > 0 {
+		mergedGroups = slices.Collect(maps.Keys(newDepGroups))
+	}
+
+	// Just assign the same slice to all children (simple assignment, no allocation)
+	for _, deps := range root.Dependencies {
+		deps.DepGroups = mergedGroups
 		propagateDepGroups(deps, visitedMap)
 	}
 }

--- a/pkg/lockfile/matcher-dependency-map.go
+++ b/pkg/lockfile/matcher-dependency-map.go
@@ -1,10 +1,7 @@
 package lockfile
 
 import (
-	"slices"
 	"strings"
-
-	"maps"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -125,7 +122,10 @@ func propagateDepGroups(root *PackageDetails, visitedMap map[*PackageDetails]str
 	// Compute the slice once outside the loop instead of N times
 	var mergedGroups []string
 	if len(newDepGroups) > 0 {
-		mergedGroups = slices.Collect(maps.Keys(newDepGroups))
+		mergedGroups = make([]string, 0, len(newDepGroups))
+		for group := range newDepGroups {
+			mergedGroups = append(mergedGroups, group)
+		}
 	}
 
 	// Just assign the same slice to all children (simple assignment, no allocation)


### PR DESCRIPTION
## 🚀 Motivation 
In the sbom-generator we traverse the dependency tree to merge dependency groups from a direct parent down to its children.  In this case the children inherit the groups from their ancestors like the graph below: 

```
 MyApp (root - has "prod" group)
  ├── express (direct dependency - inherits "prod")
  │   └── accepts (transitive - inherits "prod" from express)
  │   └── cookie (transitive - inherits "prod" from express)
  ├── lodash (direct dependency - inherits "prod")
  └── typescript (direct, "dev" group - gets both "prod" + "dev")
      └── some-typescript-util (transitive - inherits "prod" + "dev")
```

In order to do this we make a new slice at each node of the tree to contain the merged groups, meaning we will create many identical slices at each level in the event a project has a large dependency tree.
## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A  
Jira Ticket | N/A

## 📝 Summary
With this PR we build the entire merged dep groups map first, and then create just one slice per tree level rather than for each distinct node.  This makes it so that rather than `N` slice allocations we just have 1, and so that we no longer call `slices.Collect` for every node in the tree effectively  changed our number of slice operations from O(n²) to O(n).

## 🧪 Testing
- [ ] New tests were added for new logic.
- [ ] Existing tests were updated for new logic, and not only so that they pass\!
- [x] Benchmark results prove that performance is the same or better.

This change reduces algorithmic complexity and achieves a **27% performance improvement** (47s → 34.3s) when scanning large npm workspace projects with complex dependency trees.  In this case `web-ui` was used as the test repo to scan against.

## 🚧 Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: