### PR TITLE
feat(lockfile): add lockfile positions for transitive dependencies across all parsers

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -84,7 +84,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -104,7 +104,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -152,10 +152,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"subdir/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"subdir/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -179,13 +179,13 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"ignored/Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"ignored/Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"subdir/Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"subdir/Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -209,13 +209,13 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"ignored/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"ignored/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           },
           {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":5,/"column_end/":31,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":24,/"column_end/":30,/"role/":/"manifest/"}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108}}"
           }
         ]
       }
@@ -287,6 +287,88 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
 [parser] Enabling: jar
 Scanning directory './fixtures/integration-jar', resolved absolute path '<rootdir>/fixtures/integration-jar'
 Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 package
+[reachability] Reachability analysis is disabled
+---
+
+[TestRun/Scan_bun_with_ranged_package.json_dependencies - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:npm/lodash@4.17.21",
+      "type": "library",
+      "name": "lodash",
+      "version": "4.17.21",
+      "purl": "pkg:npm/lodash@4.17.21",
+      "properties": [
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "Bun"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":5,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":6,/"column_end/":12,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":16,/"column_end/":24,/"role/":/"manifest/"}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:npm/typescript@5.3.3",
+      "type": "library",
+      "name": "typescript",
+      "version": "5.3.3",
+      "purl": "pkg:npm/typescript@5.3.3",
+      "properties": [
+        {
+          "name": "datadog:is-dev",
+          "value": "true"
+        },
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "Bun"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+---
+
+[TestRun/Scan_bun_with_ranged_package.json_dependencies - 2]
+Scanning directory './fixtures/integration-bun/ranges', resolved absolute path '<rootdir>/fixtures/integration-bun/ranges'
+Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 packages
 [reachability] Reachability analysis is disabled
 ---
 
@@ -400,7 +482,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":30,/"line_end/":43,/"column_start/":1,/"column_end/":2}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":30,/"line_end/":43,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -420,7 +502,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":45,/"line_end/":49,/"column_start/":1,/"column_end/":78}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":45,/"line_end/":49,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -440,7 +522,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":171,/"line_end/":175,/"column_start/":1,/"column_end/":78}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":171,/"line_end/":175,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -488,7 +570,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":60,/"line_end/":64,/"column_start/":1,/"column_end/":78}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":60,/"line_end/":64,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -532,7 +614,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":72,/"line_end/":76,/"column_start/":1,/"column_end/":77}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":72,/"line_end/":76,/"column_start/":1,/"column_end/":77,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -552,7 +634,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":78,/"line_end/":82,/"column_start/":1,/"column_end/":78}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":78,/"line_end/":82,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -572,7 +654,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":109,/"line_end/":116,/"column_start/":1,/"column_end/":2}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":109,/"line_end/":116,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -592,7 +674,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":118,/"line_end/":125,/"column_start/":1,/"column_end/":2}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":118,/"line_end/":125,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -612,7 +694,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":94,/"line_end/":101,/"column_start/":1,/"column_end/":2}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":94,/"line_end/":101,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -632,7 +714,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":103,/"line_end/":107,/"column_start/":1,/"column_end/":78}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":103,/"line_end/":107,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -652,7 +734,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":84,/"line_end/":92,/"column_start/":1,/"column_end/":2}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":84,/"line_end/":92,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -672,7 +754,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":127,/"line_end/":131,/"column_start/":1,/"column_end/":78}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":127,/"line_end/":131,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -744,7 +826,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":148,/"line_end/":157,/"column_start/":1,/"column_end/":2}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":148,/"line_end/":157,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -788,7 +870,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":177,/"line_end/":181,/"column_start/":1,/"column_end/":78}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":177,/"line_end/":181,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -808,7 +890,7 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":183,/"line_end/":192,/"column_start/":1,/"column_end/":2}}"
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":183,/"line_end/":192,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -1632,7 +1714,7 @@ Scanned <rootdir>/fixtures/integration-nuget/csproj-sample-app-manage-versions-c
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":20,/"line_end/":24,/"column_start/":7,/"column_end/":8}}"
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":20,/"line_end/":24,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -1656,7 +1738,7 @@ Scanned <rootdir>/fixtures/integration-nuget/csproj-sample-app-manage-versions-c
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":5,/"line_end/":13,/"column_start/":7,/"column_end/":8}}"
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":5,/"line_end/":13,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -1766,7 +1848,7 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -1790,7 +1872,7 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -1806,14 +1888,7 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -1886,7 +1961,7 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -1988,13 +2063,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":37,/"line_end/":50,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":48,/"line_end/":50,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":48,/"line_end/":50,/"column_start/":3,/"column_end/":31}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2014,13 +2086,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":57,/"line_end/":65,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":52,/"line_end/":54,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":52,/"line_end/":54,/"column_start/":3,/"column_end/":31}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2040,13 +2109,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":75,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":56,/"line_end/":57,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":56,/"line_end/":57,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2066,13 +2132,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":76,/"line_end/":84,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":59,/"line_end/":61,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":59,/"line_end/":61,/"column_start/":3,/"column_end/":31}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2092,13 +2155,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":85,/"line_end/":94,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":63,/"line_end/":64,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":63,/"line_end/":64,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2118,13 +2178,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":95,/"line_end/":100,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":66,/"line_end/":67,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":66,/"line_end/":67,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2144,13 +2201,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":101,/"line_end/":110,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":69,/"line_end/":70,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":69,/"line_end/":70,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":68,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":68,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2170,13 +2224,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":111,/"line_end/":119,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":72,/"line_end/":73,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":72,/"line_end/":73,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":70,/"line_end/":77,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":70,/"line_end/":77,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2196,13 +2247,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":120,/"line_end/":131,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":75,/"line_end/":78,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":75,/"line_end/":78,/"column_start/":3,/"column_end/":17}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":79,/"line_end/":86,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":79,/"line_end/":86,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2222,13 +2270,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":132,/"line_end/":137,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":80,/"line_end/":81,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":80,/"line_end/":81,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":88,/"line_end/":93,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":88,/"line_end/":93,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2252,13 +2297,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":138,/"line_end/":147,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":83,/"line_end/":85,/"column_start/":3,/"column_end/":32,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":83,/"line_end/":85,/"column_start/":3,/"column_end/":32}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":95,/"line_end/":100,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":95,/"line_end/":100,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2278,13 +2320,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":148,/"line_end/":153,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":87,/"line_end/":88,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":87,/"line_end/":88,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":102,/"line_end/":107,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":102,/"line_end/":107,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2304,10 +2343,7 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":168,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":90,/"line_end/":93,/"column_start/":3,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":90,/"line_end/":93,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2355,13 +2391,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":182,/"line_end/":190,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":99,/"line_end/":101,/"column_start/":3,/"column_end/":27,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":99,/"line_end/":101,/"column_start/":3,/"column_end/":27}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":120,/"line_end/":125,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":120,/"line_end/":125,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2381,13 +2414,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":191,/"line_end/":204,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":103,/"line_end/":105,/"column_start/":3,/"column_end/":34,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":103,/"line_end/":105,/"column_start/":3,/"column_end/":34}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":136,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":136,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2407,13 +2437,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":205,/"line_end/":210,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":107,/"line_end/":108,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":107,/"line_end/":108,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":138,/"line_end/":143,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":138,/"line_end/":143,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2433,13 +2460,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":211,/"line_end/":216,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":110,/"line_end/":111,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":110,/"line_end/":111,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":145,/"line_end/":150,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":145,/"line_end/":150,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2487,13 +2511,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":51,/"line_end/":56,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":116,/"line_end/":117,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
             "location": "{/"block/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":116,/"line_end/":117,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2513,13 +2534,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":231,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":119,/"line_end/":120,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":119,/"line_end/":120,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":166,/"line_end/":173,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":166,/"line_end/":173,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2563,10 +2581,7 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":232,/"line_end/":247,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":128,/"line_end/":131,/"column_start/":3,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":128,/"line_end/":131,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2586,13 +2601,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":264,/"line_end/":283,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":133,/"line_end/":134,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":133,/"line_end/":134,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2708,13 +2720,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":293,/"line_end/":301,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":153,/"line_end/":154,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":153,/"line_end/":154,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2734,13 +2743,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":311,/"line_end/":320,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":156,/"line_end/":157,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":156,/"line_end/":157,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":249,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":249,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2760,13 +2766,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":310,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":159,/"line_end/":161,/"column_start/":3,/"column_end/":32,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":159,/"line_end/":161,/"column_start/":3,/"column_end/":32}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":251,/"line_end/":256,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":251,/"line_end/":256,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2786,13 +2789,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":321,/"line_end/":332,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":163,/"line_end/":165,/"column_start/":3,/"column_end/":27,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":163,/"line_end/":165,/"column_start/":3,/"column_end/":27}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":258,/"line_end/":265,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":258,/"line_end/":265,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2812,13 +2812,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":333,/"line_end/":350,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":167,/"line_end/":170,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":167,/"line_end/":170,/"column_start/":3,/"column_end/":17}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":279,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":279,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2838,13 +2835,10 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":356,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":172,/"line_end/":173,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":172,/"line_end/":173,/"column_start/":3,/"column_end/":125}}"
-          },
-          {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":281,/"line_end/":286,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":281,/"line_end/":286,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -2859,6 +2853,67 @@ Scanning directory './fixtures/integration-npm/with-workspace', resolved absolut
 Scanned <rootdir>/fixtures/integration-npm/with-workspace/package-lock.json file and found 35 packages
 Scanned <rootdir>/fixtures/integration-npm/with-workspace/pnpm-lock.yaml file and found 35 packages
 Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and found 34 packages
+[reachability] Reachability analysis is disabled
+---
+
+[TestRun/Scan_package.json_without_lock_file - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:npm/lodash",
+      "type": "library",
+      "name": "lodash",
+      "purl": "pkg:npm/lodash",
+      "properties": [
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "NPM"
+        },
+        {
+          "name": "datadog:requires-transitive-enrichment",
+          "value": "true"
+        },
+        {
+          "name": "datadog:version-range",
+          "value": "^4.17.21"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":3,/"line_end/":3,/"column_start/":5,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":3,/"line_end/":3,/"column_start/":6,/"column_end/":12,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":3,/"line_end/":3,/"column_start/":16,/"column_end/":24,/"role/":/"manifest/"}}"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+---
+
+[TestRun/Scan_package.json_without_lock_file - 2]
+Scanning directory './fixtures/integration-package-json', resolved absolute path '<rootdir>/fixtures/integration-package-json'
+Scanned <rootdir>/fixtures/integration-package-json/package.json file and found 1 package
 [reachability] Reachability analysis is disabled
 ---
 
@@ -2895,12 +2950,47 @@ Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and fou
         {
           "name": "datadog:package-manager",
           "value": "uv"
+        },
+        {
+          "name": "datadog:requires-transitive-enrichment",
+          "value": "true"
         }
       ],
       "evidence": {
         "occurrences": [
           {
             "location": "{/"block/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":5,/"column_end/":20,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":6,/"column_end/":11,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":13,/"column_end/":18,/"role/":/"manifest/"}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/numpy",
+      "type": "library",
+      "name": "numpy",
+      "purl": "pkg:pypi/numpy",
+      "properties": [
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "uv"
+        },
+        {
+          "name": "datadog:requires-transitive-enrichment",
+          "value": "true"
+        },
+        {
+          "name": "datadog:version-range",
+          "value": "/u003e=1.24"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pyproject.toml/",/"line_start/":8,/"line_end/":8,/"column_start/":5,/"column_end/":19,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pyproject.toml/",/"line_start/":8,/"line_end/":8,/"column_start/":6,/"column_end/":11,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pyproject.toml/",/"line_start/":8,/"line_end/":8,/"column_start/":11,/"column_end/":17,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -2923,6 +3013,10 @@ Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and fou
         {
           "name": "datadog:package-manager",
           "value": "uv"
+        },
+        {
+          "name": "datadog:requires-transitive-enrichment",
+          "value": "true"
         }
       ],
       "evidence": {
@@ -2947,6 +3041,10 @@ Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and fou
         {
           "name": "datadog:package-manager",
           "value": "uv"
+        },
+        {
+          "name": "datadog:requires-transitive-enrichment",
+          "value": "true"
         }
       ],
       "evidence": {
@@ -2964,7 +3062,7 @@ Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and fou
 
 [TestRun/Scan_pyproject.toml_without_lock_file - 2]
 Scanning directory './fixtures/integration-pyproject', resolved absolute path '<rootdir>/fixtures/integration-pyproject'
-Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3 packages
+Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4 packages
 [reachability] Reachability analysis is disabled
 ---
 
@@ -3002,7 +3100,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3022,7 +3120,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3042,7 +3140,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3062,7 +3160,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3082,7 +3180,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3102,7 +3200,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3122,7 +3220,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":68,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":68,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3142,7 +3240,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":70,/"line_end/":77,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":70,/"line_end/":77,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3162,7 +3260,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":79,/"line_end/":86,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":79,/"line_end/":86,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3182,7 +3280,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":88,/"line_end/":93,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":88,/"line_end/":93,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3206,7 +3304,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":95,/"line_end/":100,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":95,/"line_end/":100,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3226,7 +3324,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":102,/"line_end/":107,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":102,/"line_end/":107,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3274,7 +3372,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":120,/"line_end/":125,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":120,/"line_end/":125,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3294,7 +3392,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":136,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":136,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3314,7 +3412,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":138,/"line_end/":143,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":138,/"line_end/":143,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3334,7 +3432,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":145,/"line_end/":150,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":145,/"line_end/":150,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3402,7 +3500,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":166,/"line_end/":173,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":166,/"line_end/":173,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3446,7 +3544,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3562,7 +3660,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3582,7 +3680,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":249,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":249,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3602,7 +3700,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":251,/"line_end/":256,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":251,/"line_end/":256,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3622,7 +3720,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":258,/"line_end/":265,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":258,/"line_end/":265,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3642,7 +3740,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":279,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":279,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3662,7 +3760,7 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":281,/"line_end/":286,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":281,/"line_end/":286,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3716,7 +3814,7 @@ Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and fou
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -3785,7 +3883,8 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
                 "line_start": 9,
                 "line_end": 39,
                 "column_start": 5,
-                "column_end": 6
+                "column_end": 6,
+                "role": "lockfile"
               }
             }
           ],
@@ -3838,7 +3937,7 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"nested/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"nested/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -4262,7 +4361,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -4306,14 +4405,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     }
   ]
 }
@@ -4410,7 +4502,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -4458,7 +4550,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -4562,14 +4654,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":7,/"line_end/":14,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -4582,14 +4667,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":15,/"line_end/":19,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -4602,14 +4680,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":20,/"line_end/":28,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -4622,14 +4693,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":29,/"line_end/":33,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -4642,14 +4706,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":34,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -4662,14 +4719,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":47,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -4682,14 +4732,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":48,/"line_end/":52,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -4702,14 +4745,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":53,/"line_end/":79,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -4722,14 +4758,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":80,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -4742,14 +4771,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":109,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -4762,14 +4784,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":110,/"line_end/":114,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -4782,14 +4797,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":115,/"line_end/":138,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -4802,14 +4810,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":139,/"line_end/":153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -4822,14 +4823,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -4842,14 +4836,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":163,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -4862,14 +4849,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -4886,14 +4866,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -4906,14 +4879,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":70,/"line_end/":77,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -4926,14 +4892,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -4946,14 +4905,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":201,/"line_end/":209,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -4966,14 +4918,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":210,/"line_end/":214,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -4986,14 +4931,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":215,/"line_end/":229,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -5006,14 +4944,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":230,/"line_end/":234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -5026,14 +4957,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":227,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -5046,14 +4970,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":235,/"line_end/":246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -5066,14 +4983,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":247,/"line_end/":254,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -5086,14 +4996,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":255,/"line_end/":262,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -5106,14 +5009,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":263,/"line_end/":270,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -5126,14 +5022,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":283,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -5146,14 +5035,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":284,/"line_end/":288,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -5166,14 +5048,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":289,/"line_end/":293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -5186,14 +5061,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":294,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -5206,14 +5074,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":299,/"line_end/":306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -5226,14 +5087,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":307,/"line_end/":311,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -5246,14 +5100,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":312,/"line_end/":316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -5266,14 +5113,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":317,/"line_end/":325,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -5290,14 +5130,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":185,/"line_end/":190,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -5310,14 +5143,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":326,/"line_end/":330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -5330,14 +5156,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":331,/"line_end/":335,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -5350,14 +5169,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":336,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -5370,14 +5182,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":345,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -5390,14 +5195,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":346,/"line_end/":350,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -5410,14 +5208,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":355,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -5430,14 +5221,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":356,/"line_end/":363,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -5450,14 +5234,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":364,/"line_end/":368,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -5470,14 +5247,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":369,/"line_end/":373,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -5490,14 +5260,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":374,/"line_end/":381,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -5510,14 +5273,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":382,/"line_end/":386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -5530,14 +5286,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":387,/"line_end/":394,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     }
   ]
 }
@@ -5578,14 +5327,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -5598,14 +5340,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -5618,14 +5353,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -5638,14 +5366,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -5658,14 +5379,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -5678,14 +5392,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -5698,14 +5405,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -5718,14 +5418,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -5738,14 +5431,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -5758,14 +5444,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -5778,14 +5457,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -5798,14 +5470,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -5842,14 +5507,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -5862,14 +5520,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -5882,14 +5533,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -5902,14 +5546,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -5922,14 +5559,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -5942,14 +5572,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -5962,14 +5585,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -5982,14 +5598,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -6002,14 +5611,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -6022,14 +5624,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -6042,14 +5637,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -6062,14 +5650,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -6082,14 +5663,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -6102,14 +5676,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -6122,14 +5689,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -6142,14 +5702,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -6162,14 +5715,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -6182,14 +5728,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -6202,14 +5741,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -6222,14 +5754,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -6242,14 +5767,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -6262,14 +5780,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -6282,14 +5793,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -6302,14 +5806,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -6350,14 +5847,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -6370,14 +5860,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -6390,14 +5873,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -6410,14 +5886,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -6430,14 +5899,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -6450,14 +5912,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -6470,14 +5925,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -6490,14 +5938,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -6510,14 +5951,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -6530,14 +5964,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -6550,14 +5977,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -6570,14 +5990,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -6590,14 +6003,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -6610,14 +6016,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -6630,14 +6029,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -6650,14 +6042,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -6670,14 +6055,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -6690,14 +6068,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -6710,14 +6081,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -6730,14 +6094,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -6750,14 +6107,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -6770,14 +6120,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -6790,14 +6133,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -6810,14 +6146,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -6830,14 +6159,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -6850,14 +6172,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -6870,14 +6185,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -6890,14 +6198,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -6910,14 +6211,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -6930,14 +6224,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -6950,14 +6237,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -6970,14 +6250,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -6990,14 +6263,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -7010,14 +6276,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -7030,14 +6289,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -7050,14 +6302,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -7070,14 +6315,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -7090,14 +6328,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -7110,14 +6341,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -7130,14 +6354,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -7150,14 +6367,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -7170,14 +6380,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -7190,14 +6393,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -7210,14 +6406,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -7230,14 +6419,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -7250,14 +6432,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -7270,14 +6445,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -7290,14 +6458,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -7310,14 +6471,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -7330,14 +6484,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -7350,14 +6497,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -7370,14 +6510,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -7390,14 +6523,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -7410,14 +6536,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -7434,14 +6553,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -7454,14 +6566,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -7474,14 +6579,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -7494,14 +6592,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -7514,14 +6605,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -7534,14 +6618,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -7554,14 +6631,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -7574,14 +6644,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -7594,14 +6657,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -7614,14 +6670,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -7634,14 +6683,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -7654,14 +6696,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -7674,14 +6709,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -7694,14 +6722,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -7714,14 +6735,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -7734,14 +6748,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -7754,14 +6761,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -7774,14 +6774,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -7794,14 +6787,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -7814,14 +6800,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -7834,14 +6813,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -7854,14 +6826,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -7874,14 +6839,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -7894,14 +6852,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -7914,14 +6865,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -7934,14 +6878,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -7954,14 +6891,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -7974,14 +6904,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -7994,14 +6917,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -8014,14 +6930,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -8034,14 +6943,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -8054,14 +6956,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -8074,14 +6969,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -8094,14 +6982,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -8114,14 +6995,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -8134,14 +7008,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -8154,14 +7021,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -8174,14 +7034,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -8194,14 +7047,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -8214,14 +7060,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     }
   ]
 }
@@ -8262,14 +7101,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -8282,14 +7114,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -8302,14 +7127,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -8322,14 +7140,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -8342,14 +7153,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -8362,14 +7166,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -8382,14 +7179,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -8402,14 +7192,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -8422,14 +7205,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -8442,14 +7218,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -8462,14 +7231,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -8482,14 +7244,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -8526,14 +7281,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -8546,14 +7294,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -8566,14 +7307,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -8586,14 +7320,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -8606,14 +7333,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -8626,14 +7346,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -8646,14 +7359,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -8666,14 +7372,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -8686,14 +7385,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -8706,14 +7398,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -8726,14 +7411,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -8746,14 +7424,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -8766,14 +7437,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -8786,14 +7450,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -8806,14 +7463,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -8826,14 +7476,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -8846,14 +7489,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -8866,14 +7502,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -8886,14 +7515,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -8906,14 +7528,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -8926,14 +7541,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -8946,14 +7554,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -8966,14 +7567,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -8986,14 +7580,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -9034,14 +7621,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -9054,14 +7634,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -9074,14 +7647,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -9094,14 +7660,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -9114,14 +7673,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -9134,14 +7686,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -9154,14 +7699,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -9174,14 +7712,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -9194,14 +7725,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -9214,14 +7738,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -9234,14 +7751,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -9254,14 +7764,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -9274,14 +7777,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -9294,14 +7790,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -9314,14 +7803,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -9334,14 +7816,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -9354,14 +7829,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -9374,14 +7842,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -9394,14 +7855,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -9414,14 +7868,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -9434,14 +7881,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -9454,14 +7894,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -9474,14 +7907,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -9494,14 +7920,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -9514,14 +7933,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -9534,14 +7946,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -9554,14 +7959,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -9574,14 +7972,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -9594,14 +7985,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -9614,14 +7998,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -9634,14 +8011,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -9654,14 +8024,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -9674,14 +8037,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -9694,14 +8050,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -9714,14 +8063,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -9734,14 +8076,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -9754,14 +8089,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -9774,14 +8102,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -9794,14 +8115,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -9814,14 +8128,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -9834,14 +8141,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -9854,14 +8154,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -9874,14 +8167,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -9894,14 +8180,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -9914,14 +8193,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -9934,14 +8206,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -9954,14 +8219,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -9974,14 +8232,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -9994,14 +8245,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -10014,14 +8258,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -10034,14 +8271,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -10054,14 +8284,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -10074,14 +8297,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -10094,14 +8310,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -10118,14 +8327,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -10138,14 +8340,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -10158,14 +8353,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -10178,14 +8366,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -10198,14 +8379,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -10218,14 +8392,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -10238,14 +8405,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -10258,14 +8418,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -10278,14 +8431,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -10298,14 +8444,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -10318,14 +8457,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -10338,14 +8470,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -10358,14 +8483,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -10378,14 +8496,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -10398,14 +8509,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -10418,14 +8522,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -10438,14 +8535,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -10458,14 +8548,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -10478,14 +8561,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -10498,14 +8574,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -10518,14 +8587,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -10538,14 +8600,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -10558,14 +8613,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -10578,14 +8626,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -10598,14 +8639,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -10618,14 +8652,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -10638,14 +8665,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -10658,14 +8678,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -10678,14 +8691,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -10698,14 +8704,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -10718,14 +8717,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -10738,14 +8730,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -10758,14 +8743,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -10778,14 +8756,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -10798,14 +8769,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -10818,14 +8782,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -10838,14 +8795,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -10858,14 +8808,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -10878,14 +8821,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -10898,14 +8834,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     }
   ]
 }
@@ -10946,14 +8875,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -10966,14 +8888,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -10986,14 +8901,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -11006,14 +8914,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -11026,14 +8927,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -11046,14 +8940,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -11066,14 +8953,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -11086,14 +8966,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -11106,14 +8979,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -11126,14 +8992,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -11146,14 +9005,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -11166,14 +9018,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -11210,14 +9055,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -11230,14 +9068,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -11250,14 +9081,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -11270,14 +9094,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -11290,14 +9107,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -11310,14 +9120,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -11330,14 +9133,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -11350,14 +9146,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -11370,14 +9159,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -11390,14 +9172,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -11410,14 +9185,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -11430,14 +9198,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -11450,14 +9211,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -11470,14 +9224,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -11490,14 +9237,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -11510,14 +9250,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -11530,14 +9263,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -11550,14 +9276,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -11570,14 +9289,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -11590,14 +9302,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -11610,14 +9315,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -11630,14 +9328,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -11650,14 +9341,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -11670,14 +9354,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -11718,14 +9395,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -11738,14 +9408,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -11758,14 +9421,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -11778,14 +9434,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -11798,14 +9447,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -11818,14 +9460,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -11838,14 +9473,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -11858,14 +9486,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -11878,14 +9499,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -11898,14 +9512,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -11918,14 +9525,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -11938,14 +9538,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -11958,14 +9551,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -11978,14 +9564,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -11998,14 +9577,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -12018,14 +9590,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -12038,14 +9603,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -12058,14 +9616,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -12078,14 +9629,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -12098,14 +9642,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -12118,14 +9655,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -12138,14 +9668,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -12158,14 +9681,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -12178,14 +9694,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -12198,14 +9707,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -12218,14 +9720,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -12238,14 +9733,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -12258,14 +9746,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -12278,14 +9759,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -12298,14 +9772,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -12318,14 +9785,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -12338,14 +9798,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -12358,14 +9811,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -12378,14 +9824,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -12398,14 +9837,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -12418,14 +9850,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -12438,14 +9863,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -12458,14 +9876,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -12478,14 +9889,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -12498,14 +9902,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -12518,14 +9915,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -12538,14 +9928,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -12558,14 +9941,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -12578,14 +9954,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -12598,14 +9967,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -12618,14 +9980,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -12638,14 +9993,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -12658,14 +10006,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -12678,14 +10019,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -12698,14 +10032,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -12718,14 +10045,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -12738,14 +10058,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -12758,14 +10071,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -12778,14 +10084,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -12802,14 +10101,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -12822,14 +10114,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -12842,14 +10127,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -12862,14 +10140,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -12882,14 +10153,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -12902,14 +10166,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -12922,14 +10179,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -12942,14 +10192,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -12962,14 +10205,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -12982,14 +10218,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -13002,14 +10231,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -13022,14 +10244,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -13042,14 +10257,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -13062,14 +10270,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -13082,14 +10283,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -13102,14 +10296,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -13122,14 +10309,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -13142,14 +10322,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -13162,14 +10335,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -13182,14 +10348,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -13202,14 +10361,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -13222,14 +10374,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -13242,14 +10387,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -13262,14 +10400,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -13282,14 +10413,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -13302,14 +10426,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -13322,14 +10439,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -13342,14 +10452,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -13362,14 +10465,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -13382,14 +10478,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -13402,14 +10491,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -13422,14 +10504,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -13442,14 +10517,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -13462,14 +10530,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -13482,14 +10543,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -13502,14 +10556,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -13522,14 +10569,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -13542,14 +10582,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -13562,14 +10595,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -13582,14 +10608,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     }
   ]
 }
@@ -13630,14 +10649,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":45,/"line_end/":68,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -13650,14 +10662,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":94,/"line_end/":103,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -13670,14 +10675,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":35,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -13690,14 +10688,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":36,/"line_end/":44,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -13710,14 +10701,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":104,/"line_end/":119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -13730,14 +10714,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":145,/"line_end/":158,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -13750,14 +10727,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":159,/"line_end/":166,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -13770,14 +10740,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":167,/"line_end/":179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -13790,14 +10753,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":180,/"line_end/":188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -13810,14 +10766,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":189,/"line_end/":201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -13830,14 +10779,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":202,/"line_end/":207,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -13850,14 +10792,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":208,/"line_end/":213,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -13894,14 +10829,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -13914,14 +10842,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":324,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -13934,14 +10855,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -13954,14 +10868,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":391,/"line_end/":403,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -13974,14 +10881,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":404,/"line_end/":430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -13994,14 +10894,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":454,/"line_end/":479,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -14014,14 +10907,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":480,/"line_end/":496,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -14034,14 +10920,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":497,/"line_end/":503,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -14054,14 +10933,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":526,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -14074,14 +10946,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":504,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -14094,14 +10959,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":527,/"line_end/":543,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -14114,14 +10972,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":544,/"line_end/":553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -14134,14 +10985,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":554,/"line_end/":569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -14154,14 +10998,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":570,/"line_end/":576,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -14174,14 +11011,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":577,/"line_end/":585,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -14194,14 +11024,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":586,/"line_end/":592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -14214,14 +11037,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":593,/"line_end/":603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -14234,14 +11050,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":604,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -14254,14 +11063,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":625,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -14274,14 +11076,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":626,/"line_end/":642,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -14294,14 +11089,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":643,/"line_end/":655,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -14314,14 +11102,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":656,/"line_end/":662,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -14334,14 +11115,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":663,/"line_end/":669,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -14354,14 +11128,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":670,/"line_end/":684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -14402,14 +11169,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":69,/"line_end/":86,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -14422,14 +11182,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":695,/"line_end/":701,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -14442,14 +11195,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":702,/"line_end/":713,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -14462,14 +11208,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":714,/"line_end/":726,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -14482,14 +11221,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":727,/"line_end/":739,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -14502,14 +11234,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":797,/"line_end/":809,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -14522,14 +11247,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":840,/"line_end/":856,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -14542,14 +11260,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":810,/"line_end/":821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -14562,14 +11273,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":740,/"line_end/":796,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -14582,14 +11286,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":874,/"line_end/":891,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -14602,14 +11299,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":892,/"line_end/":904,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -14622,14 +11312,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":915,/"line_end/":926,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -14642,14 +11325,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":936,/"line_end/":944,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -14662,14 +11338,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":857,/"line_end/":866,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -14682,14 +11351,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":945,/"line_end/":954,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -14702,14 +11364,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":955,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -14722,14 +11377,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -14742,14 +11390,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":990,/"line_end/":996,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -14762,14 +11403,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":997,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -14782,14 +11416,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1012,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -14802,14 +11429,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1013,/"line_end/":1025,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -14822,14 +11442,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1026,/"line_end/":1037,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -14842,14 +11455,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1038,/"line_end/":1054,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -14862,14 +11468,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1055,/"line_end/":1069,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -14882,14 +11481,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1070,/"line_end/":1076,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -14902,14 +11494,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1077,/"line_end/":1083,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -14922,14 +11507,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":989,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -14942,14 +11520,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1106,/"line_end/":1118,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -14962,14 +11533,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1084,/"line_end/":1105,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -14982,14 +11546,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1119,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -15002,14 +11559,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1154,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -15022,14 +11572,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1155,/"line_end/":1160,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -15042,14 +11585,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1161,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -15062,14 +11598,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -15082,14 +11611,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1180,/"line_end/":1196,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -15102,14 +11624,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1197,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -15122,14 +11637,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1218,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -15142,14 +11650,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1219,/"line_end/":1225,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -15162,14 +11663,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1226,/"line_end/":1234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -15182,14 +11676,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1235,/"line_end/":1246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -15202,14 +11689,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1247,/"line_end/":1255,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -15222,14 +11702,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1256,/"line_end/":1265,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -15242,14 +11715,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1266,/"line_end/":1272,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -15262,14 +11728,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1273,/"line_end/":1285,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -15282,14 +11741,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1286,/"line_end/":1292,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -15302,14 +11754,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1293,/"line_end/":1299,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -15322,14 +11767,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1300,/"line_end/":1306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -15342,14 +11780,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1307,/"line_end/":1316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -15362,14 +11793,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1317,/"line_end/":1330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -15382,14 +11806,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1331,/"line_end/":1346,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -15402,14 +11819,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1347,/"line_end/":1353,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -15422,14 +11832,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1354,/"line_end/":1362,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -15442,14 +11845,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1363,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -15462,14 +11858,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1388,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -15486,14 +11875,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1389,/"line_end/":1395,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -15506,14 +11888,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":87,/"line_end/":93,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -15526,14 +11901,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1403,/"line_end/":1408,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -15546,14 +11914,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1396,/"line_end/":1402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -15566,14 +11927,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1409,/"line_end/":1418,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -15586,14 +11940,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1419,/"line_end/":1436,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -15606,14 +11953,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1437,/"line_end/":1452,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -15626,14 +11966,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1453,/"line_end/":1468,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -15646,14 +11979,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1469,/"line_end/":1481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -15666,14 +11992,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1482,/"line_end/":1491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -15686,14 +12005,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1492,/"line_end/":1501,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -15706,14 +12018,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1502,/"line_end/":1511,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -15726,14 +12031,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1512,/"line_end/":1520,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -15746,14 +12044,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1521,/"line_end/":1532,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -15766,14 +12057,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1533,/"line_end/":1542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -15786,14 +12070,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1543,/"line_end/":1552,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -15806,14 +12083,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1553,/"line_end/":1572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -15826,14 +12096,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1573,/"line_end/":1582,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -15846,14 +12109,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1583,/"line_end/":1592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -15866,14 +12122,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1593,/"line_end/":1609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -15886,14 +12135,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1610,/"line_end/":1632,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -15906,14 +12148,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1633,/"line_end/":1644,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -15926,14 +12161,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1645,/"line_end/":1657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -15946,14 +12174,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1658,/"line_end/":1667,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -15966,14 +12187,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1668,/"line_end/":1676,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -15986,14 +12200,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1677,/"line_end/":1689,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -16006,14 +12213,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1690,/"line_end/":1702,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -16026,14 +12226,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1703,/"line_end/":1715,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -16046,14 +12239,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1716,/"line_end/":1722,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -16066,14 +12252,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1723,/"line_end/":1734,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -16086,14 +12265,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1735,/"line_end/":1740,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -16106,14 +12278,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1741,/"line_end/":1755,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -16126,14 +12291,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1756,/"line_end/":1768,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -16146,14 +12304,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1769,/"line_end/":1781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -16166,14 +12317,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1782,/"line_end/":1795,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -16186,14 +12330,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1796,/"line_end/":1805,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -16206,14 +12343,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1806,/"line_end/":1821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -16226,14 +12356,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1822,/"line_end/":1831,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -16246,14 +12369,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1832,/"line_end/":1838,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -16266,14 +12382,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1839,/"line_end/":1851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
-          }
-        ]
-      }
+      ]
     }
   ]
 }
@@ -16298,6 +12407,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
 | Java       | Gradle          | gradle/verification-metadata.xml |
 | Java       | Maven           | maven_install.json               |
 | Java       | Maven           | pom.xml                          |
+| Javascript | Bun             | bun.lock                         |
 | Javascript | NPM             | package-lock.json                |
 | Javascript | Pnpm            | pnpm-lock.yaml                   |
 | Javascript | Yarn            | yarn.lock                        |
@@ -16353,7 +12463,7 @@ Warning: `parsers` exists as both a subcommand of datadog-sbom-generator and as 
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"nested/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"nested/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16426,7 +12536,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16474,7 +12584,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16597,7 +12707,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":5,/"line_end/":10,/"column_start/":7,/"column_end/":8}}"
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":5,/"line_end/":10,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16713,10 +12823,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -16724,7 +12830,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5280,/"line_end/":5332,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16748,7 +12854,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16765,10 +12871,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -16776,7 +12878,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":25,/"column_end/":33,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5387,/"line_end/":5481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16820,7 +12922,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16840,7 +12942,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16884,7 +12986,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -16949,10 +13051,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -16960,7 +13058,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":24,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5482,/"line_end/":5544,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17004,7 +13102,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17048,7 +13146,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17068,7 +13166,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17116,7 +13214,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17136,7 +13234,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17156,7 +13254,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17176,7 +13274,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17196,7 +13294,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17288,7 +13386,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17305,10 +13403,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17316,7 +13410,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5679,/"line_end/":5733,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17340,7 +13434,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17357,10 +13451,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17368,7 +13458,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5783,/"line_end/":5828,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17385,10 +13475,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17396,7 +13482,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5829,/"line_end/":5875,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17420,7 +13506,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17444,7 +13530,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17461,10 +13547,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17472,7 +13554,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":25,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5932,/"line_end/":6014,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17520,7 +13602,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17544,7 +13626,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17588,7 +13670,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17608,7 +13690,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17632,7 +13714,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17673,10 +13755,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17684,7 +13762,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":5,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":6,/"column_end/":17,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":21,/"column_end/":25,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6199,/"line_end/":6276,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17701,10 +13779,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17712,7 +13786,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":5,/"column_end/":29,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":24,/"column_end/":28,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6277,/"line_end/":6342,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17736,7 +13810,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17760,7 +13834,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17780,7 +13854,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17797,10 +13871,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17808,7 +13878,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":5,/"column_end/":33,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":25,/"column_end/":32,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6461,/"line_end/":6518,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17832,7 +13902,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17856,7 +13926,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17880,7 +13950,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17904,7 +13974,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17928,7 +13998,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17945,10 +14015,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17956,7 +14022,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":5,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":25,/"column_end/":36,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6842,/"line_end/":6941,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -17973,10 +14039,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -17984,7 +14046,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":23,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6942,/"line_end/":7002,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18008,7 +14070,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18028,7 +14090,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18072,7 +14134,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18092,7 +14154,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18112,7 +14174,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18132,7 +14194,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18200,7 +14262,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18220,7 +14282,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18261,10 +14323,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -18272,7 +14330,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":71,/"line_end/":71,/"column_start/":5,/"column_end/":35,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":71,/"line_end/":71,/"column_start/":6,/"column_end/":23,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":71,/"line_end/":71,/"column_start/":27,/"column_end/":34,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7052,/"line_end/":7108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18296,7 +14354,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18320,7 +14378,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18344,7 +14402,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18368,7 +14426,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18392,7 +14450,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18416,7 +14474,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18440,7 +14498,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18464,7 +14522,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18488,7 +14546,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18512,7 +14570,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18536,7 +14594,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18560,7 +14618,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18584,7 +14642,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18608,7 +14666,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18632,7 +14690,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18656,7 +14714,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18680,7 +14738,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18697,10 +14755,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -18708,7 +14762,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":72,/"line_end/":72,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":72,/"line_end/":72,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":72,/"line_end/":72,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8094,/"line_end/":8190,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18728,7 +14782,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18772,7 +14826,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18792,7 +14846,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18836,7 +14890,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18856,7 +14910,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18904,7 +14958,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -18921,10 +14975,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -18932,7 +14982,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":73,/"line_end/":73,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":73,/"line_end/":73,/"column_start/":6,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":73,/"line_end/":73,/"column_start/":29,/"column_end/":33,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8267,/"line_end/":8360,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19048,7 +15098,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19068,7 +15118,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19088,7 +15138,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19108,7 +15158,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19128,7 +15178,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19148,7 +15198,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19168,7 +15218,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19212,7 +15262,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19253,10 +15303,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19264,7 +15310,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":74,/"line_end/":74,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":74,/"line_end/":74,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":74,/"line_end/":74,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8439,/"line_end/":8521,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19308,7 +15354,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19328,7 +15374,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19348,7 +15394,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19368,7 +15414,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19440,7 +15486,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19464,7 +15510,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19556,7 +15602,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19620,7 +15666,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19640,7 +15686,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19660,7 +15706,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19680,7 +15726,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19700,7 +15746,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19720,7 +15766,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19740,7 +15786,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19760,7 +15806,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19780,7 +15826,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19800,7 +15846,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19820,7 +15866,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19840,7 +15886,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19860,7 +15906,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19880,7 +15926,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19900,7 +15946,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19920,7 +15966,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -19940,7 +15986,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20008,7 +16054,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20028,7 +16074,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20048,7 +16094,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20068,7 +16114,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20088,7 +16134,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20108,7 +16154,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20128,7 +16174,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20148,7 +16194,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20168,7 +16214,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20216,7 +16262,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20264,7 +16310,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20284,7 +16330,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20304,7 +16350,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20352,7 +16398,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20372,7 +16418,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20392,7 +16438,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20412,7 +16458,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20460,7 +16506,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20480,7 +16526,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20500,7 +16546,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20520,7 +16566,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20540,7 +16586,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20584,7 +16630,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20604,7 +16650,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20624,7 +16670,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20644,7 +16690,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20664,7 +16710,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20684,7 +16730,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20704,7 +16750,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20724,7 +16770,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20744,7 +16790,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20764,7 +16810,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20784,7 +16830,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20804,7 +16850,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20824,7 +16870,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20844,7 +16890,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20864,7 +16910,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20884,7 +16930,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20904,7 +16950,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20924,7 +16970,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20944,7 +16990,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -20988,7 +17034,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21008,7 +17054,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21028,7 +17074,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21048,7 +17094,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21068,7 +17114,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21088,7 +17134,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21132,7 +17178,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21152,7 +17198,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21172,7 +17218,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21192,7 +17238,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21212,7 +17258,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21288,7 +17334,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21308,7 +17354,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21328,7 +17374,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21348,7 +17394,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21444,7 +17490,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21464,7 +17510,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21484,7 +17530,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21504,7 +17550,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21524,7 +17570,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21544,7 +17590,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21564,7 +17610,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21584,7 +17630,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21628,7 +17674,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21648,7 +17694,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21871,7 +17917,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -21895,7 +17941,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22069,7 +18115,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm/pnpm-lock.yaml/",/"line_start/":21,/"line_end/":25,/"column_start/":3,/"column_end/":14}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm/pnpm-lock.yaml/",/"line_start/":21,/"line_end/":25,/"column_start/":3,/"column_end/":14,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22125,7 +18171,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22149,7 +18195,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22173,7 +18219,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22197,7 +18243,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22781,10 +18827,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -22792,7 +18834,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5280,/"line_end/":5332,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22816,7 +18858,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22833,10 +18875,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -22844,7 +18882,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":25,/"column_end/":33,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5387,/"line_end/":5481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22888,7 +18926,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22908,7 +18946,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -22952,7 +18990,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23017,10 +19055,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -23028,7 +19062,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":24,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5482,/"line_end/":5544,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23072,7 +19106,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23116,7 +19150,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23136,7 +19170,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23184,7 +19218,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23204,7 +19238,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23224,7 +19258,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23244,7 +19278,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23264,7 +19298,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23356,7 +19390,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23373,10 +19407,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -23384,7 +19414,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5679,/"line_end/":5733,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23408,7 +19438,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23425,10 +19455,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -23436,7 +19462,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5783,/"line_end/":5828,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23453,10 +19479,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -23464,7 +19486,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5829,/"line_end/":5875,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23488,7 +19510,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23512,7 +19534,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23529,10 +19551,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -23540,7 +19558,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":25,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5932,/"line_end/":6014,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23588,7 +19606,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23612,7 +19630,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23656,7 +19674,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23676,7 +19694,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23700,7 +19718,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23741,10 +19759,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -23752,7 +19766,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":5,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":6,/"column_end/":17,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":21,/"column_end/":25,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6199,/"line_end/":6276,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23769,10 +19783,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -23780,7 +19790,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":5,/"column_end/":29,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":24,/"column_end/":28,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6277,/"line_end/":6342,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23804,7 +19814,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23828,7 +19838,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23848,7 +19858,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23865,10 +19875,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -23876,7 +19882,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":5,/"column_end/":33,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":25,/"column_end/":32,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6461,/"line_end/":6518,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23900,7 +19906,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23924,7 +19930,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23948,7 +19954,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23972,7 +19978,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -23996,7 +20002,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24013,10 +20019,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -24024,7 +20026,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":5,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":25,/"column_end/":36,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6842,/"line_end/":6941,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24041,10 +20043,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -24052,7 +20050,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":23,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6942,/"line_end/":7002,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24076,7 +20074,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24096,7 +20094,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24140,7 +20138,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24160,7 +20158,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24180,7 +20178,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24200,7 +20198,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24268,7 +20266,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24288,7 +20286,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24329,10 +20327,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -24340,7 +20334,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":5,/"column_end/":35,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":6,/"column_end/":23,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":27,/"column_end/":34,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7052,/"line_end/":7108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24364,7 +20358,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24388,7 +20382,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24412,7 +20406,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24436,7 +20430,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24460,7 +20454,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24484,7 +20478,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24508,7 +20502,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24532,7 +20526,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24556,7 +20550,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24580,7 +20574,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24604,7 +20598,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24628,7 +20622,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24652,7 +20646,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24676,7 +20670,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24700,7 +20694,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24724,7 +20718,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24748,7 +20742,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24765,10 +20759,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -24776,7 +20766,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8094,/"line_end/":8190,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24796,7 +20786,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24840,7 +20830,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24860,7 +20850,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24904,7 +20894,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24924,7 +20914,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24972,7 +20962,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -24989,10 +20979,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25000,7 +20986,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":6,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":29,/"column_end/":33,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8267,/"line_end/":8360,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25116,7 +21102,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25136,7 +21122,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25156,7 +21142,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25176,7 +21162,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25196,7 +21182,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25216,7 +21202,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25236,7 +21222,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25280,7 +21266,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25321,10 +21307,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25332,7 +21314,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8439,/"line_end/":8521,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25376,7 +21358,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25396,7 +21378,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25416,7 +21398,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25436,7 +21418,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25508,7 +21490,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25532,7 +21514,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25624,7 +21606,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25688,7 +21670,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25708,7 +21690,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25728,7 +21710,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25748,7 +21730,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25768,7 +21750,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25788,7 +21770,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25808,7 +21790,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25828,7 +21810,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25848,7 +21830,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25868,7 +21850,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25888,7 +21870,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25908,7 +21890,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25928,7 +21910,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25948,7 +21930,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25968,7 +21950,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -25988,7 +21970,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26008,7 +21990,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26076,7 +22058,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26096,7 +22078,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26116,7 +22098,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26136,7 +22118,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26156,7 +22138,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26176,7 +22158,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26196,7 +22178,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26216,7 +22198,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26236,7 +22218,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26284,7 +22266,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26332,7 +22314,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26352,7 +22334,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26372,7 +22354,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26420,7 +22402,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26440,7 +22422,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26460,7 +22442,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26480,7 +22462,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26528,7 +22510,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26548,7 +22530,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26568,7 +22550,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26588,7 +22570,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26608,7 +22590,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26652,7 +22634,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26672,7 +22654,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26692,7 +22674,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26712,7 +22694,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26732,7 +22714,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26752,7 +22734,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26772,7 +22754,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26792,7 +22774,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26812,7 +22794,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26832,7 +22814,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26852,7 +22834,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26872,7 +22854,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26892,7 +22874,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26912,7 +22894,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26932,7 +22914,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26952,7 +22934,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26972,7 +22954,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26992,7 +22974,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27012,7 +22994,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27056,7 +23038,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27076,7 +23058,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27096,7 +23078,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27116,7 +23098,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27136,7 +23118,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27156,7 +23138,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27200,7 +23182,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27220,7 +23202,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27240,7 +23222,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27260,7 +23242,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27280,7 +23262,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27356,7 +23338,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27376,7 +23358,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27396,7 +23378,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27416,7 +23398,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27512,7 +23494,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27532,7 +23514,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27552,7 +23534,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27572,7 +23554,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27592,7 +23574,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27612,7 +23594,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27632,7 +23614,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27652,7 +23634,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27696,7 +23678,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27716,7 +23698,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27892,7 +23874,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27916,7 +23898,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28118,7 +24100,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28142,7 +24124,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28166,7 +24148,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28190,7 +24172,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28774,10 +24756,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -28785,7 +24763,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5280,/"line_end/":5332,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28809,7 +24787,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28826,10 +24804,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -28837,7 +24811,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":25,/"column_end/":33,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5387,/"line_end/":5481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28881,7 +24855,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28901,7 +24875,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28945,7 +24919,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29010,10 +24984,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -29021,7 +24991,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":24,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5482,/"line_end/":5544,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29065,7 +25035,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29109,7 +25079,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29129,7 +25099,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29177,7 +25147,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29197,7 +25167,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29217,7 +25187,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29237,7 +25207,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29257,7 +25227,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29349,7 +25319,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29366,10 +25336,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -29377,7 +25343,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5679,/"line_end/":5733,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29401,7 +25367,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29418,10 +25384,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -29429,7 +25391,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5783,/"line_end/":5828,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29446,10 +25408,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -29457,7 +25415,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5829,/"line_end/":5875,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29481,7 +25439,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29505,7 +25463,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29522,10 +25480,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -29533,7 +25487,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":25,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5932,/"line_end/":6014,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29581,7 +25535,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29605,7 +25559,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29649,7 +25603,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29669,7 +25623,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29693,7 +25647,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29734,10 +25688,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -29745,7 +25695,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":5,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":6,/"column_end/":17,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":21,/"column_end/":25,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6199,/"line_end/":6276,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29762,10 +25712,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -29773,7 +25719,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":5,/"column_end/":29,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":24,/"column_end/":28,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6277,/"line_end/":6342,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29797,7 +25743,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29821,7 +25767,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29841,7 +25787,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29858,10 +25804,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -29869,7 +25811,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":5,/"column_end/":33,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":25,/"column_end/":32,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6461,/"line_end/":6518,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29893,7 +25835,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29917,7 +25859,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29941,7 +25883,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29965,7 +25907,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -29989,7 +25931,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30006,10 +25948,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -30017,7 +25955,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":5,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":25,/"column_end/":36,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6842,/"line_end/":6941,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30034,10 +25972,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -30045,7 +25979,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":23,/"column_end/":29,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6942,/"line_end/":7002,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30069,7 +26003,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30089,7 +26023,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30133,7 +26067,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30153,7 +26087,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30173,7 +26107,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30193,7 +26127,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30261,7 +26195,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30281,7 +26215,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30322,10 +26256,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -30333,7 +26263,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":5,/"column_end/":35,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":6,/"column_end/":23,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":27,/"column_end/":34,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7052,/"line_end/":7108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30357,7 +26287,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30381,7 +26311,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30405,7 +26335,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30429,7 +26359,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30453,7 +26383,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30477,7 +26407,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30501,7 +26431,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30525,7 +26455,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30549,7 +26479,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30573,7 +26503,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30597,7 +26527,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30621,7 +26551,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30645,7 +26575,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30669,7 +26599,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30693,7 +26623,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30717,7 +26647,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30741,7 +26671,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30758,10 +26688,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -30769,7 +26695,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8094,/"line_end/":8190,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30789,7 +26715,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30833,7 +26759,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30853,7 +26779,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30897,7 +26823,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30917,7 +26843,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30965,7 +26891,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -30982,10 +26908,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -30993,7 +26915,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":6,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":29,/"column_end/":33,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8267,/"line_end/":8360,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31109,7 +27031,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31129,7 +27051,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31149,7 +27071,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31169,7 +27091,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31189,7 +27111,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31209,7 +27131,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31229,7 +27151,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31273,7 +27195,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31314,10 +27236,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -31325,7 +27243,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8439,/"line_end/":8521,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31369,7 +27287,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31389,7 +27307,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31409,7 +27327,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31429,7 +27347,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31501,7 +27419,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31525,7 +27443,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31617,7 +27535,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31681,7 +27599,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31701,7 +27619,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31721,7 +27639,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31741,7 +27659,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31761,7 +27679,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31781,7 +27699,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31801,7 +27719,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31821,7 +27739,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31841,7 +27759,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31861,7 +27779,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31881,7 +27799,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31901,7 +27819,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31921,7 +27839,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31941,7 +27859,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31961,7 +27879,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -31981,7 +27899,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32001,7 +27919,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32069,7 +27987,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32089,7 +28007,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32109,7 +28027,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32129,7 +28047,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32149,7 +28067,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32169,7 +28087,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32189,7 +28107,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32209,7 +28127,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32229,7 +28147,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32277,7 +28195,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32325,7 +28243,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32345,7 +28263,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32365,7 +28283,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32413,7 +28331,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32433,7 +28351,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32453,7 +28371,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32473,7 +28391,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32521,7 +28439,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32541,7 +28459,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32561,7 +28479,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32581,7 +28499,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32601,7 +28519,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32645,7 +28563,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32665,7 +28583,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32685,7 +28603,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32705,7 +28623,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32725,7 +28643,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32745,7 +28663,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32765,7 +28683,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32785,7 +28703,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32805,7 +28723,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32825,7 +28743,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32845,7 +28763,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32865,7 +28783,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32885,7 +28803,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32905,7 +28823,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32925,7 +28843,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32945,7 +28863,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32965,7 +28883,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -32985,7 +28903,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33005,7 +28923,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33049,7 +28967,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33069,7 +28987,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33089,7 +29007,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33109,7 +29027,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33129,7 +29047,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33149,7 +29067,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33193,7 +29111,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33213,7 +29131,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33233,7 +29151,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33253,7 +29171,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33273,7 +29191,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33349,7 +29267,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33369,7 +29287,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33389,7 +29307,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33409,7 +29327,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33505,7 +29423,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33525,7 +29443,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33545,7 +29463,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33565,7 +29483,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33585,7 +29503,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33605,7 +29523,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33625,7 +29543,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33645,7 +29563,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33689,7 +29607,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33709,7 +29627,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33885,7 +29803,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -33909,7 +29827,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34111,7 +30029,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34135,7 +30053,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34159,7 +30077,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34183,7 +30101,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125}}"
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34864,7 +30782,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34888,7 +30806,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34936,7 +30854,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":5,/"line_end/":10,/"column_start/":1,/"column_end/":33}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":5,/"line_end/":10,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34956,7 +30874,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":12,/"line_end/":15,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":12,/"line_end/":15,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34976,7 +30894,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":17,/"line_end/":23,/"column_start/":1,/"column_end/":26}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":17,/"line_end/":23,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -34996,7 +30914,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":25,/"line_end/":28,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":25,/"line_end/":28,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35016,7 +30934,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":30,/"line_end/":36,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":30,/"line_end/":36,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35036,7 +30954,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":38,/"line_end/":41,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":38,/"line_end/":41,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35056,7 +30974,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":46,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":46,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35100,7 +31018,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":64,/"line_end/":70,/"column_start/":1,/"column_end/":47}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":64,/"line_end/":70,/"column_start/":1,/"column_end/":47,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35120,7 +31038,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":72,/"line_end/":80,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":72,/"line_end/":80,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35140,7 +31058,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":82,/"line_end/":85,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":82,/"line_end/":85,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35160,7 +31078,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":87,/"line_end/":98,/"column_start/":1,/"column_end/":22}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":87,/"line_end/":98,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35180,7 +31098,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":100,/"line_end/":112,/"column_start/":1,/"column_end/":20}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":100,/"line_end/":112,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35200,7 +31118,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":114,/"line_end/":120,/"column_start/":1,/"column_end/":33}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":114,/"line_end/":120,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35220,7 +31138,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":122,/"line_end/":125,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":122,/"line_end/":125,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35240,7 +31158,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":132,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":132,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35267,7 +31185,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":134,/"line_end/":139,/"column_start/":1,/"column_end/":16}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":134,/"line_end/":139,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35287,7 +31205,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":141,/"line_end/":146,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":141,/"line_end/":146,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35307,7 +31225,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":148,/"line_end/":154,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":148,/"line_end/":154,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35327,7 +31245,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":156,/"line_end/":159,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":156,/"line_end/":159,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35347,7 +31265,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":166,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":166,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35367,7 +31285,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":168,/"line_end/":171,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":168,/"line_end/":171,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35387,7 +31305,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":173,/"line_end/":176,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":173,/"line_end/":176,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35407,7 +31325,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":187,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":187,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35427,7 +31345,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35447,7 +31365,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":196,/"line_end/":201,/"column_start/":1,/"column_end/":28}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":196,/"line_end/":201,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35467,7 +31385,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":203,/"line_end/":208,/"column_start/":1,/"column_end/":21}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":203,/"line_end/":208,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35487,7 +31405,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":210,/"line_end/":220,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":210,/"line_end/":220,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35507,7 +31425,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":222,/"line_end/":225,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":222,/"line_end/":225,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35527,7 +31445,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":227,/"line_end/":230,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":227,/"line_end/":230,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35547,7 +31465,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":235,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":235,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35567,7 +31485,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":237,/"line_end/":242,/"column_start/":1,/"column_end/":24}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":237,/"line_end/":242,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35587,7 +31505,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":244,/"line_end/":247,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":244,/"line_end/":247,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35607,7 +31525,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":249,/"line_end/":252,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":249,/"line_end/":252,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35627,7 +31545,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":254,/"line_end/":260,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":254,/"line_end/":260,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35647,7 +31565,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":262,/"line_end/":265,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":262,/"line_end/":265,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35667,7 +31585,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":270,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":270,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35687,7 +31605,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":272,/"line_end/":275,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":272,/"line_end/":275,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35707,7 +31625,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":277,/"line_end/":280,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":277,/"line_end/":280,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35727,7 +31645,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":282,/"line_end/":285,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":282,/"line_end/":285,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35747,7 +31665,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":287,/"line_end/":290,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":287,/"line_end/":290,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35767,7 +31685,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":292,/"line_end/":297,/"column_start/":1,/"column_end/":29}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":292,/"line_end/":297,/"column_start/":1,/"column_end/":29,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35787,7 +31705,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":299,/"line_end/":302,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":299,/"line_end/":302,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35807,7 +31725,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":304,/"line_end/":307,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":304,/"line_end/":307,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35827,7 +31745,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":23}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35847,7 +31765,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":319,/"column_start/":1,/"column_end/":108}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":319,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35867,7 +31785,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":321,/"line_end/":326,/"column_start/":1,/"column_end/":19}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":321,/"line_end/":326,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35915,7 +31833,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35935,7 +31853,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35955,7 +31873,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35975,7 +31893,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -35995,7 +31913,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36015,7 +31933,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36035,7 +31953,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":65,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":65,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36079,7 +31997,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":91,/"line_end/":99,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":91,/"line_end/":99,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36099,7 +32017,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":101,/"line_end/":116,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":101,/"line_end/":116,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36119,7 +32037,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":118,/"line_end/":123,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":118,/"line_end/":123,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36139,7 +32057,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":125,/"line_end/":141,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":125,/"line_end/":141,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36159,7 +32077,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":143,/"line_end/":159,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":143,/"line_end/":159,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36179,7 +32097,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":169,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":169,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36199,7 +32117,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":171,/"line_end/":176,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":171,/"line_end/":176,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36219,7 +32137,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":185,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":185,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36246,7 +32164,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":187,/"line_end/":197,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":187,/"line_end/":197,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36266,7 +32184,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":199,/"line_end/":206,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":199,/"line_end/":206,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36286,7 +32204,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":208,/"line_end/":216,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":208,/"line_end/":216,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36306,7 +32224,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":218,/"line_end/":223,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":218,/"line_end/":223,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36326,7 +32244,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":225,/"line_end/":232,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":225,/"line_end/":232,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36346,7 +32264,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":234,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":234,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36366,7 +32284,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":246,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":246,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36386,7 +32304,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":248,/"line_end/":259,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":248,/"line_end/":259,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36406,7 +32324,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":261,/"line_end/":268,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":261,/"line_end/":268,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36426,7 +32344,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":270,/"line_end/":277,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":270,/"line_end/":277,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36446,7 +32364,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":279,/"line_end/":286,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":279,/"line_end/":286,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36466,7 +32384,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":288,/"line_end/":300,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":288,/"line_end/":300,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36486,7 +32404,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":302,/"line_end/":307,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":302,/"line_end/":307,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36506,7 +32424,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36526,7 +32444,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":321,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":321,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36546,7 +32464,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":323,/"line_end/":330,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":323,/"line_end/":330,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36566,7 +32484,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":332,/"line_end/":337,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":332,/"line_end/":337,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36586,7 +32504,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":339,/"line_end/":344,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":339,/"line_end/":344,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36606,7 +32524,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":346,/"line_end/":354,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":346,/"line_end/":354,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36626,7 +32544,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":356,/"line_end/":361,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":356,/"line_end/":361,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36646,7 +32564,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":363,/"line_end/":368,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":363,/"line_end/":368,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36666,7 +32584,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":370,/"line_end/":375,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":370,/"line_end/":375,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36686,7 +32604,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":377,/"line_end/":382,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":377,/"line_end/":382,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36706,7 +32624,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":384,/"line_end/":389,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":384,/"line_end/":389,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36726,7 +32644,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":391,/"line_end/":396,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":391,/"line_end/":396,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36746,7 +32664,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":398,/"line_end/":405,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":398,/"line_end/":405,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36766,7 +32684,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":407,/"line_end/":414,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":407,/"line_end/":414,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36786,7 +32704,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":416,/"line_end/":421,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":416,/"line_end/":421,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36806,7 +32724,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":432,/"line_end/":439,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":432,/"line_end/":439,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36826,7 +32744,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":441,/"line_end/":446,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":441,/"line_end/":446,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36846,7 +32764,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":448,/"line_end/":457,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":448,/"line_end/":457,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36894,7 +32812,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36914,7 +32832,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36934,7 +32852,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36954,7 +32872,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36974,7 +32892,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -36994,7 +32912,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37014,7 +32932,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":65,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":65,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37058,7 +32976,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":91,/"line_end/":99,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":91,/"line_end/":99,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37078,7 +32996,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":101,/"line_end/":116,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":101,/"line_end/":116,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37098,7 +33016,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":118,/"line_end/":123,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":118,/"line_end/":123,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37118,7 +33036,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":125,/"line_end/":141,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":125,/"line_end/":141,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37138,7 +33056,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":143,/"line_end/":159,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":143,/"line_end/":159,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37158,7 +33076,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":169,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":169,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37178,7 +33096,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":171,/"line_end/":176,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":171,/"line_end/":176,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37198,7 +33116,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":185,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":185,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37225,7 +33143,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":187,/"line_end/":197,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":187,/"line_end/":197,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37245,7 +33163,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":199,/"line_end/":206,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":199,/"line_end/":206,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37265,7 +33183,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":208,/"line_end/":216,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":208,/"line_end/":216,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37285,7 +33203,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":218,/"line_end/":223,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":218,/"line_end/":223,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37305,7 +33223,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":225,/"line_end/":232,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":225,/"line_end/":232,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37325,7 +33243,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":234,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":234,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37345,7 +33263,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":246,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":246,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37365,7 +33283,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":248,/"line_end/":259,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":248,/"line_end/":259,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37385,7 +33303,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":261,/"line_end/":268,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":261,/"line_end/":268,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37405,7 +33323,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":270,/"line_end/":277,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":270,/"line_end/":277,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37425,7 +33343,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":279,/"line_end/":286,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":279,/"line_end/":286,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37445,7 +33363,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":288,/"line_end/":300,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":288,/"line_end/":300,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37465,7 +33383,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":302,/"line_end/":307,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":302,/"line_end/":307,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37485,7 +33403,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37505,7 +33423,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":321,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":321,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37525,7 +33443,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":323,/"line_end/":330,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":323,/"line_end/":330,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37545,7 +33463,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":332,/"line_end/":337,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":332,/"line_end/":337,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37565,7 +33483,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":339,/"line_end/":344,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":339,/"line_end/":344,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37585,7 +33503,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":346,/"line_end/":354,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":346,/"line_end/":354,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37605,7 +33523,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":356,/"line_end/":361,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":356,/"line_end/":361,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37625,7 +33543,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":363,/"line_end/":368,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":363,/"line_end/":368,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37645,7 +33563,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":370,/"line_end/":375,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":370,/"line_end/":375,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37665,7 +33583,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":377,/"line_end/":382,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":377,/"line_end/":382,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37685,7 +33603,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":384,/"line_end/":389,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":384,/"line_end/":389,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37705,7 +33623,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":391,/"line_end/":396,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":391,/"line_end/":396,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37725,7 +33643,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":398,/"line_end/":405,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":398,/"line_end/":405,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37745,7 +33663,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":407,/"line_end/":414,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":407,/"line_end/":414,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37765,7 +33683,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":416,/"line_end/":421,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":416,/"line_end/":421,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37785,7 +33703,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":432,/"line_end/":439,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":432,/"line_end/":439,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37805,7 +33723,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":441,/"line_end/":446,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":441,/"line_end/":446,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -37825,7 +33743,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":448,/"line_end/":457,/"column_start/":1,/"column_end/":17}}"
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":448,/"line_end/":457,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }

--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -80,7 +80,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -93,7 +100,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -134,7 +148,17 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -151,7 +175,20 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"ignored/Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -172,7 +209,13 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"ignored/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":5,/"column_end/":31,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":24,/"column_end/":30,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108}}"
           }
         ]
       }
@@ -244,88 +287,6 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
 [parser] Enabling: jar
 Scanning directory './fixtures/integration-jar', resolved absolute path '<rootdir>/fixtures/integration-jar'
 Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 package
-[reachability] Reachability analysis is disabled
----
-
-[TestRun/Scan_bun_with_ranged_package.json_dependencies - 1]
-{
-  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
-  "version": 1,
-  "metadata": {
-    "tools": {
-      "components": [
-        {
-          "type": "application",
-          "group": "datadog",
-          "name": "datadog-sbom-generator",
-          "version": "set at build time, see .goreleaser.yml ldflags section"
-        }
-      ]
-    }
-  },
-  "components": [
-    {
-      "bom-ref": "pkg:npm/lodash@4.17.21",
-      "type": "library",
-      "name": "lodash",
-      "version": "4.17.21",
-      "purl": "pkg:npm/lodash@4.17.21",
-      "properties": [
-        {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
-          "name": "datadog:package-manager",
-          "value": "Bun"
-        }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":5,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":6,/"column_end/":12,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":16,/"column_end/":24,/"role/":/"manifest/"}}"
-          }
-        ]
-      }
-    },
-    {
-      "bom-ref": "pkg:npm/typescript@5.3.3",
-      "type": "library",
-      "name": "typescript",
-      "version": "5.3.3",
-      "purl": "pkg:npm/typescript@5.3.3",
-      "properties": [
-        {
-          "name": "datadog:is-dev",
-          "value": "true"
-        },
-        {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
-          "name": "datadog:package-manager",
-          "value": "Bun"
-        }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
-          }
-        ]
-      }
-    }
-  ]
-}
-
----
-
-[TestRun/Scan_bun_with_ranged_package.json_dependencies - 2]
-Scanning directory './fixtures/integration-bun/ranges', resolved absolute path '<rootdir>/fixtures/integration-bun/ranges'
-Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 packages
 [reachability] Reachability analysis is disabled
 ---
 
@@ -435,7 +396,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":30,/"line_end/":43,/"column_start/":1,/"column_end/":2}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/itoa@1.0.14",
@@ -448,7 +416,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":45,/"line_end/":49,/"column_start/":1,/"column_end/":78}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/memchr@2.7.4",
@@ -461,7 +436,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":171,/"line_end/":175,/"column_start/":1,/"column_end/":78}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/mockall@0.13.1",
@@ -502,7 +484,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":60,/"line_end/":64,/"column_start/":1,/"column_end/":78}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/pkg-config@0.3.31",
@@ -539,7 +528,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":72,/"line_end/":76,/"column_start/":1,/"column_end/":77}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/predicates@3.1.2",
@@ -552,7 +548,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":78,/"line_end/":82,/"column_start/":1,/"column_end/":78}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/proc-macro2@1.0.92",
@@ -565,7 +568,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":109,/"line_end/":116,/"column_start/":1,/"column_end/":2}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/quote@1.0.37",
@@ -578,7 +588,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":118,/"line_end/":125,/"column_start/":1,/"column_end/":2}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/regex-automata@0.4.9",
@@ -591,7 +608,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":94,/"line_end/":101,/"column_start/":1,/"column_end/":2}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/regex-syntax@0.8.5",
@@ -604,7 +628,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":103,/"line_end/":107,/"column_start/":1,/"column_end/":78}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/regex@1.11.1",
@@ -617,7 +648,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":84,/"line_end/":92,/"column_start/":1,/"column_end/":2}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/ryu@1.0.18",
@@ -630,7 +668,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":127,/"line_end/":131,/"column_start/":1,/"column_end/":78}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/serde@0.9.15",
@@ -695,7 +740,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":148,/"line_end/":157,/"column_start/":1,/"column_end/":2}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/serde_json@1.0.132",
@@ -732,7 +784,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":177,/"line_end/":181,/"column_start/":1,/"column_end/":78}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/syn@2.0.90",
@@ -745,7 +804,14 @@ Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":183,/"line_end/":192,/"column_start/":1,/"column_end/":2}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/tokio@1.43.0",
@@ -1562,7 +1628,14 @@ Scanned <rootdir>/fixtures/integration-nuget/csproj-sample-app-manage-versions-c
           "name": "datadog:package-manager",
           "value": "NuGet"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":20,/"line_end/":24,/"column_start/":7,/"column_end/":8}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:nuget/Microsoft.NETFramework.ReferenceAssemblies@1.0.3",
@@ -1579,7 +1652,14 @@ Scanned <rootdir>/fixtures/integration-nuget/csproj-sample-app-manage-versions-c
           "name": "datadog:package-manager",
           "value": "NuGet"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":5,/"line_end/":13,/"column_start/":7,/"column_end/":8}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:nuget/Newtonsoft.Json@12.0.3",
@@ -1682,7 +1762,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -1699,7 +1786,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-html@0.0.1",
@@ -1712,7 +1806,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -1781,7 +1882,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -1876,7 +1984,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":37,/"line_end/":50,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":48,/"line_end/":50,/"column_start/":3,/"column_end/":31}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40babel%2Fhelper-validator-identifier@7.28.5",
@@ -1889,7 +2010,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":57,/"line_end/":65,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":52,/"line_end/":54,/"column_start/":3,/"column_end/":31}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fgen-mapping@0.3.13",
@@ -1902,7 +2036,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":75,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":56,/"line_end/":57,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fresolve-uri@3.1.2",
@@ -1915,7 +2062,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":76,/"line_end/":84,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":59,/"line_end/":61,/"column_start/":3,/"column_end/":31}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsource-map@0.3.11",
@@ -1928,7 +2088,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":85,/"line_end/":94,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":63,/"line_end/":64,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsourcemap-codec@1.5.5",
@@ -1941,7 +2114,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":95,/"line_end/":100,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":66,/"line_end/":67,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Ftrace-mapping@0.3.31",
@@ -1954,7 +2140,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":101,/"line_end/":110,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":69,/"line_end/":70,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":68,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fnode@24.10.1",
@@ -1967,7 +2166,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":111,/"line_end/":119,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":72,/"line_end/":73,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":70,/"line_end/":77,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.15.0",
@@ -1980,7 +2192,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":120,/"line_end/":131,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":75,/"line_end/":78,/"column_start/":3,/"column_end/":17}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":79,/"line_end/":86,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/buffer-from@1.1.2",
@@ -1993,7 +2218,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":132,/"line_end/":137,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":80,/"line_end/":81,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":88,/"line_end/":93,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/colors@1.4.0",
@@ -2010,7 +2248,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":138,/"line_end/":147,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":83,/"line_end/":85,/"column_start/":3,/"column_end/":32}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":95,/"line_end/":100,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/commander@2.20.3",
@@ -2023,7 +2274,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":148,/"line_end/":153,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":87,/"line_end/":88,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":102,/"line_end/":107,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fsevents@2.3.3",
@@ -2036,7 +2300,17 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":168,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":90,/"line_end/":93,/"column_start/":3,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/group-dependencies@0.0.11",
@@ -2077,7 +2351,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":182,/"line_end/":190,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":99,/"line_end/":101,/"column_start/":3,/"column_end/":27}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":120,/"line_end/":125,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/jest-worker@26.6.2",
@@ -2090,7 +2377,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":191,/"line_end/":204,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":103,/"line_end/":105,/"column_start/":3,/"column_end/":34}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":136,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-tokens@4.0.0",
@@ -2103,7 +2403,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":205,/"line_end/":210,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":107,/"line_end/":108,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":138,/"line_end/":143,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge-stream@2.0.0",
@@ -2116,7 +2429,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":211,/"line_end/":216,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":110,/"line_end/":111,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":145,/"line_end/":150,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picocolors@0.2.1",
@@ -2161,6 +2487,12 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":51,/"line_end/":56,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":116,/"line_end/":117,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
           }
         ]
@@ -2177,7 +2509,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":231,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":119,/"line_end/":120,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":166,/"line_end/":173,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rollup-plugin-terser@7.0.2",
@@ -2214,7 +2559,17 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":232,/"line_end/":247,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":128,/"line_end/":131,/"column_start/":3,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/safe-buffer@5.2.1",
@@ -2227,7 +2582,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":264,/"line_end/":283,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":133,/"line_end/":134,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@4.3.6",
@@ -2336,7 +2704,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":293,/"line_end/":301,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":153,/"line_end/":154,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map-support@0.5.21",
@@ -2349,7 +2730,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":311,/"line_end/":320,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":156,/"line_end/":157,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":249,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map@0.6.1",
@@ -2362,7 +2756,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":310,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":159,/"line_end/":161,/"column_start/":3,/"column_end/":32}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":251,/"line_end/":256,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -2375,7 +2782,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":321,/"line_end/":332,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":163,/"line_end/":165,/"column_start/":3,/"column_end/":27}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":258,/"line_end/":265,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/terser@5.44.1",
@@ -2388,7 +2808,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":333,/"line_end/":350,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":167,/"line_end/":170,/"column_start/":3,/"column_end/":17}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":279,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/undici-types@7.16.0",
@@ -2401,7 +2834,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":356,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":172,/"line_end/":173,/"column_start/":3,/"column_end/":125}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":281,/"line_end/":286,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -2413,67 +2859,6 @@ Scanning directory './fixtures/integration-npm/with-workspace', resolved absolut
 Scanned <rootdir>/fixtures/integration-npm/with-workspace/package-lock.json file and found 35 packages
 Scanned <rootdir>/fixtures/integration-npm/with-workspace/pnpm-lock.yaml file and found 35 packages
 Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and found 34 packages
-[reachability] Reachability analysis is disabled
----
-
-[TestRun/Scan_package.json_without_lock_file - 1]
-{
-  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
-  "version": 1,
-  "metadata": {
-    "tools": {
-      "components": [
-        {
-          "type": "application",
-          "group": "datadog",
-          "name": "datadog-sbom-generator",
-          "version": "set at build time, see .goreleaser.yml ldflags section"
-        }
-      ]
-    }
-  },
-  "components": [
-    {
-      "bom-ref": "pkg:npm/lodash",
-      "type": "library",
-      "name": "lodash",
-      "purl": "pkg:npm/lodash",
-      "properties": [
-        {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
-          "name": "datadog:package-manager",
-          "value": "NPM"
-        },
-        {
-          "name": "datadog:requires-transitive-enrichment",
-          "value": "true"
-        },
-        {
-          "name": "datadog:version-range",
-          "value": "^4.17.21"
-        }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":3,/"line_end/":3,/"column_start/":5,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":3,/"line_end/":3,/"column_start/":6,/"column_end/":12,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":3,/"line_end/":3,/"column_start/":16,/"column_end/":24,/"role/":/"manifest/"}}"
-          }
-        ]
-      }
-    }
-  ]
-}
-
----
-
-[TestRun/Scan_package.json_without_lock_file - 2]
-Scanning directory './fixtures/integration-package-json', resolved absolute path '<rootdir>/fixtures/integration-package-json'
-Scanned <rootdir>/fixtures/integration-package-json/package.json file and found 1 package
 [reachability] Reachability analysis is disabled
 ---
 
@@ -2510,47 +2895,12 @@ Scanned <rootdir>/fixtures/integration-package-json/package.json file and found 
         {
           "name": "datadog:package-manager",
           "value": "uv"
-        },
-        {
-          "name": "datadog:requires-transitive-enrichment",
-          "value": "true"
         }
       ],
       "evidence": {
         "occurrences": [
           {
             "location": "{/"block/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":5,/"column_end/":20,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":6,/"column_end/":11,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":13,/"column_end/":18,/"role/":/"manifest/"}}"
-          }
-        ]
-      }
-    },
-    {
-      "bom-ref": "pkg:pypi/numpy",
-      "type": "library",
-      "name": "numpy",
-      "purl": "pkg:pypi/numpy",
-      "properties": [
-        {
-          "name": "datadog:is-direct",
-          "value": "true"
-        },
-        {
-          "name": "datadog:package-manager",
-          "value": "uv"
-        },
-        {
-          "name": "datadog:requires-transitive-enrichment",
-          "value": "true"
-        },
-        {
-          "name": "datadog:version-range",
-          "value": "/u003e=1.24"
-        }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "{/"block/":{/"file_name/":/"pyproject.toml/",/"line_start/":8,/"line_end/":8,/"column_start/":5,/"column_end/":19,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pyproject.toml/",/"line_start/":8,/"line_end/":8,/"column_start/":6,/"column_end/":11,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pyproject.toml/",/"line_start/":8,/"line_end/":8,/"column_start/":11,/"column_end/":17,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -2573,10 +2923,6 @@ Scanned <rootdir>/fixtures/integration-package-json/package.json file and found 
         {
           "name": "datadog:package-manager",
           "value": "uv"
-        },
-        {
-          "name": "datadog:requires-transitive-enrichment",
-          "value": "true"
         }
       ],
       "evidence": {
@@ -2601,10 +2947,6 @@ Scanned <rootdir>/fixtures/integration-package-json/package.json file and found 
         {
           "name": "datadog:package-manager",
           "value": "uv"
-        },
-        {
-          "name": "datadog:requires-transitive-enrichment",
-          "value": "true"
         }
       ],
       "evidence": {
@@ -2622,7 +2964,7 @@ Scanned <rootdir>/fixtures/integration-package-json/package.json file and found 
 
 [TestRun/Scan_pyproject.toml_without_lock_file - 2]
 Scanning directory './fixtures/integration-pyproject', resolved absolute path '<rootdir>/fixtures/integration-pyproject'
-Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4 packages
+Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3 packages
 [reachability] Reachability analysis is disabled
 ---
 
@@ -2656,7 +2998,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40babel%2Fhelper-validator-identifier@7.28.5",
@@ -2669,7 +3018,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fgen-mapping@0.3.13",
@@ -2682,7 +3038,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fresolve-uri@3.1.2",
@@ -2695,7 +3058,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsource-map@0.3.11",
@@ -2708,7 +3078,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsourcemap-codec@1.5.5",
@@ -2721,7 +3098,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Ftrace-mapping@0.3.31",
@@ -2734,7 +3118,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":68,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fnode@24.10.1",
@@ -2747,7 +3138,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":70,/"line_end/":77,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.15.0",
@@ -2760,7 +3158,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":79,/"line_end/":86,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/buffer-from@1.1.2",
@@ -2773,7 +3178,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":88,/"line_end/":93,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/colors@1.4.0",
@@ -2790,7 +3202,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":95,/"line_end/":100,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/commander@2.20.3",
@@ -2803,7 +3222,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":102,/"line_end/":107,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/group-dependencies@0.0.11",
@@ -2844,7 +3270,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":120,/"line_end/":125,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/jest-worker@26.6.2",
@@ -2857,7 +3290,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":136,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-tokens@4.0.0",
@@ -2870,7 +3310,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":138,/"line_end/":143,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge-stream@2.0.0",
@@ -2883,7 +3330,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":145,/"line_end/":150,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picocolors@0.2.1",
@@ -2944,7 +3398,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":166,/"line_end/":173,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rollup-plugin-terser@7.0.2",
@@ -2981,7 +3442,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@4.3.6",
@@ -3090,7 +3558,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map-support@0.5.21",
@@ -3103,7 +3578,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":249,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map@0.6.1",
@@ -3116,7 +3598,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":251,/"line_end/":256,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -3129,7 +3618,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":258,/"line_end/":265,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/terser@5.44.1",
@@ -3142,7 +3638,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":279,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/undici-types@7.16.0",
@@ -3155,7 +3658,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 4
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":281,/"line_end/":286,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3202,7 +3712,14 @@ Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and fou
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -3261,6 +3778,17 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
             "ecosystem": "Packagist",
             "purl": "pkg:composer/sentry/sdk@2.0.4"
           },
+          "locations": [
+            {
+              "block": {
+                "file_name": "composer.lock",
+                "line_start": 9,
+                "line_end": 39,
+                "column_start": 5,
+                "column_end": 6
+              }
+            }
+          ],
           "metadata": {
             "package-manager": "Composer"
           }
@@ -3306,7 +3834,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"nested/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -3723,7 +4258,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3764,7 +4306,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3857,7 +4406,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3898,7 +4454,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3999,7 +4562,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":7,/"line_end/":14,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -4012,7 +4582,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":15,/"line_end/":19,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -4025,7 +4602,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":20,/"line_end/":28,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -4038,7 +4622,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":29,/"line_end/":33,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -4051,7 +4642,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":34,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -4064,7 +4662,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":47,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -4077,7 +4682,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":48,/"line_end/":52,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -4090,7 +4702,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":53,/"line_end/":79,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -4103,7 +4722,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":80,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -4116,7 +4742,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":109,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -4129,7 +4762,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":110,/"line_end/":114,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -4142,7 +4782,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":115,/"line_end/":138,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -4155,7 +4802,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":139,/"line_end/":153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -4168,7 +4822,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -4181,7 +4842,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":163,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -4194,7 +4862,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -4211,7 +4886,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -4224,7 +4906,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":70,/"line_end/":77,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -4237,7 +4926,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -4250,7 +4946,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":201,/"line_end/":209,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -4263,7 +4966,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":210,/"line_end/":214,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -4276,7 +4986,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":215,/"line_end/":229,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -4289,7 +5006,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":230,/"line_end/":234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -4302,7 +5026,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":227,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -4315,7 +5046,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":235,/"line_end/":246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -4328,7 +5066,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":247,/"line_end/":254,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -4341,7 +5086,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":255,/"line_end/":262,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -4354,7 +5106,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":263,/"line_end/":270,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -4367,7 +5126,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":283,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -4380,7 +5146,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":284,/"line_end/":288,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -4393,7 +5166,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":289,/"line_end/":293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -4406,7 +5186,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":294,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -4419,7 +5206,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":299,/"line_end/":306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -4432,7 +5226,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":307,/"line_end/":311,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -4445,7 +5246,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":312,/"line_end/":316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -4458,7 +5266,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":317,/"line_end/":325,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -4475,7 +5290,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":185,/"line_end/":190,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -4488,7 +5310,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":326,/"line_end/":330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -4501,7 +5330,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":331,/"line_end/":335,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -4514,7 +5350,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":336,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -4527,7 +5370,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":345,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -4540,7 +5390,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":346,/"line_end/":350,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -4553,7 +5410,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":355,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -4566,7 +5430,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":356,/"line_end/":363,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -4579,7 +5450,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":364,/"line_end/":368,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -4592,7 +5470,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":369,/"line_end/":373,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -4605,7 +5490,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":374,/"line_end/":381,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -4618,7 +5510,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":382,/"line_end/":386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -4631,7 +5530,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":387,/"line_end/":394,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -4672,7 +5578,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -4685,7 +5598,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -4698,7 +5618,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -4711,7 +5638,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -4724,7 +5658,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -4737,7 +5678,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -4750,7 +5698,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -4763,7 +5718,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -4776,7 +5738,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -4789,7 +5758,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -4802,7 +5778,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -4815,7 +5798,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -4852,7 +5842,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -4865,7 +5862,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -4878,7 +5882,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -4891,7 +5902,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -4904,7 +5922,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -4917,7 +5942,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -4930,7 +5962,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -4943,7 +5982,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -4956,7 +6002,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -4969,7 +6022,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -4982,7 +6042,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -4995,7 +6062,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -5008,7 +6082,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -5021,7 +6102,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -5034,7 +6122,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -5047,7 +6142,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -5060,7 +6162,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -5073,7 +6182,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -5086,7 +6202,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -5099,7 +6222,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -5112,7 +6242,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -5125,7 +6262,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -5138,7 +6282,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -5151,7 +6302,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -5192,7 +6350,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -5205,7 +6370,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -5218,7 +6390,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -5231,7 +6410,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -5244,7 +6430,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -5257,7 +6450,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -5270,7 +6470,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -5283,7 +6490,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -5296,7 +6510,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -5309,7 +6530,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -5322,7 +6550,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -5335,7 +6570,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -5348,7 +6590,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -5361,7 +6610,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -5374,7 +6630,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -5387,7 +6650,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -5400,7 +6670,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -5413,7 +6690,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -5426,7 +6710,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -5439,7 +6730,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -5452,7 +6750,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -5465,7 +6770,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -5478,7 +6790,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -5491,7 +6810,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -5504,7 +6830,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -5517,7 +6850,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -5530,7 +6870,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -5543,7 +6890,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -5556,7 +6910,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -5569,7 +6930,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -5582,7 +6950,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -5595,7 +6970,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -5608,7 +6990,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -5621,7 +7010,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -5634,7 +7030,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -5647,7 +7050,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -5660,7 +7070,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -5673,7 +7090,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -5686,7 +7110,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -5699,7 +7130,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -5712,7 +7150,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -5725,7 +7170,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -5738,7 +7190,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -5751,7 +7210,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -5764,7 +7230,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -5777,7 +7250,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -5790,7 +7270,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -5803,7 +7290,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -5816,7 +7310,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -5829,7 +7330,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -5842,7 +7350,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -5855,7 +7370,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -5868,7 +7390,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -5881,7 +7410,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -5898,7 +7434,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -5911,7 +7454,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -5924,7 +7474,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -5937,7 +7494,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -5950,7 +7514,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -5963,7 +7534,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -5976,7 +7554,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -5989,7 +7574,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -6002,7 +7594,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -6015,7 +7614,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -6028,7 +7634,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -6041,7 +7654,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -6054,7 +7674,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -6067,7 +7694,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -6080,7 +7714,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -6093,7 +7734,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -6106,7 +7754,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -6119,7 +7774,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -6132,7 +7794,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -6145,7 +7814,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -6158,7 +7834,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -6171,7 +7854,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -6184,7 +7874,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -6197,7 +7894,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -6210,7 +7914,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -6223,7 +7934,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -6236,7 +7954,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -6249,7 +7974,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -6262,7 +7994,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -6275,7 +8014,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -6288,7 +8034,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -6301,7 +8054,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -6314,7 +8074,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -6327,7 +8094,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -6340,7 +8114,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -6353,7 +8134,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -6366,7 +8154,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -6379,7 +8174,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -6392,7 +8194,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -6405,7 +8214,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -6446,7 +8262,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -6459,7 +8282,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -6472,7 +8302,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -6485,7 +8322,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -6498,7 +8342,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -6511,7 +8362,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -6524,7 +8382,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -6537,7 +8402,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -6550,7 +8422,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -6563,7 +8442,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -6576,7 +8462,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -6589,7 +8482,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -6626,7 +8526,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -6639,7 +8546,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -6652,7 +8566,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -6665,7 +8586,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -6678,7 +8606,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -6691,7 +8626,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -6704,7 +8646,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -6717,7 +8666,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -6730,7 +8686,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -6743,7 +8706,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -6756,7 +8726,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -6769,7 +8746,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -6782,7 +8766,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -6795,7 +8786,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -6808,7 +8806,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -6821,7 +8826,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -6834,7 +8846,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -6847,7 +8866,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -6860,7 +8886,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -6873,7 +8906,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -6886,7 +8926,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -6899,7 +8946,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -6912,7 +8966,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -6925,7 +8986,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -6966,7 +9034,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -6979,7 +9054,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -6992,7 +9074,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -7005,7 +9094,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -7018,7 +9114,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -7031,7 +9134,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -7044,7 +9154,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -7057,7 +9174,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -7070,7 +9194,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -7083,7 +9214,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -7096,7 +9234,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -7109,7 +9254,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -7122,7 +9274,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -7135,7 +9294,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -7148,7 +9314,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -7161,7 +9334,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -7174,7 +9354,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -7187,7 +9374,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -7200,7 +9394,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -7213,7 +9414,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -7226,7 +9434,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -7239,7 +9454,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -7252,7 +9474,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -7265,7 +9494,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -7278,7 +9514,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -7291,7 +9534,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -7304,7 +9554,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -7317,7 +9574,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -7330,7 +9594,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -7343,7 +9614,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -7356,7 +9634,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -7369,7 +9654,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -7382,7 +9674,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -7395,7 +9694,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -7408,7 +9714,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -7421,7 +9734,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -7434,7 +9754,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -7447,7 +9774,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -7460,7 +9794,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -7473,7 +9814,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -7486,7 +9834,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -7499,7 +9854,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -7512,7 +9874,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -7525,7 +9894,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -7538,7 +9914,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -7551,7 +9934,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -7564,7 +9954,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -7577,7 +9974,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -7590,7 +9994,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -7603,7 +10014,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -7616,7 +10034,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -7629,7 +10054,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -7642,7 +10074,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -7655,7 +10094,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -7672,7 +10118,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -7685,7 +10138,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -7698,7 +10158,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -7711,7 +10178,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -7724,7 +10198,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -7737,7 +10218,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -7750,7 +10238,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -7763,7 +10258,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -7776,7 +10278,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -7789,7 +10298,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -7802,7 +10318,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -7815,7 +10338,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -7828,7 +10358,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -7841,7 +10378,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -7854,7 +10398,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -7867,7 +10418,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -7880,7 +10438,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -7893,7 +10458,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -7906,7 +10478,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -7919,7 +10498,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -7932,7 +10518,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -7945,7 +10538,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -7958,7 +10558,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -7971,7 +10578,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -7984,7 +10598,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -7997,7 +10618,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -8010,7 +10638,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -8023,7 +10658,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -8036,7 +10678,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -8049,7 +10698,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -8062,7 +10718,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -8075,7 +10738,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -8088,7 +10758,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -8101,7 +10778,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -8114,7 +10798,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -8127,7 +10818,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -8140,7 +10838,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -8153,7 +10858,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -8166,7 +10878,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -8179,7 +10898,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -8220,7 +10946,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -8233,7 +10966,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -8246,7 +10986,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -8259,7 +11006,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -8272,7 +11026,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -8285,7 +11046,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -8298,7 +11066,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -8311,7 +11086,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -8324,7 +11106,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -8337,7 +11126,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -8350,7 +11146,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -8363,7 +11166,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -8400,7 +11210,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -8413,7 +11230,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -8426,7 +11250,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -8439,7 +11270,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -8452,7 +11290,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -8465,7 +11310,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -8478,7 +11330,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -8491,7 +11350,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -8504,7 +11370,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -8517,7 +11390,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -8530,7 +11410,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -8543,7 +11430,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -8556,7 +11450,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -8569,7 +11470,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -8582,7 +11490,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -8595,7 +11510,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -8608,7 +11530,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -8621,7 +11550,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -8634,7 +11570,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -8647,7 +11590,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -8660,7 +11610,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -8673,7 +11630,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -8686,7 +11650,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -8699,7 +11670,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -8740,7 +11718,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -8753,7 +11738,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -8766,7 +11758,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -8779,7 +11778,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -8792,7 +11798,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -8805,7 +11818,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -8818,7 +11838,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -8831,7 +11858,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -8844,7 +11878,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -8857,7 +11898,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -8870,7 +11918,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -8883,7 +11938,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -8896,7 +11958,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -8909,7 +11978,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -8922,7 +11998,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -8935,7 +12018,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -8948,7 +12038,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -8961,7 +12058,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -8974,7 +12078,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -8987,7 +12098,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -9000,7 +12118,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -9013,7 +12138,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -9026,7 +12158,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -9039,7 +12178,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -9052,7 +12198,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -9065,7 +12218,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -9078,7 +12238,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -9091,7 +12258,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -9104,7 +12278,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -9117,7 +12298,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -9130,7 +12318,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -9143,7 +12338,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -9156,7 +12358,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -9169,7 +12378,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -9182,7 +12398,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -9195,7 +12418,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -9208,7 +12438,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -9221,7 +12458,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -9234,7 +12478,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -9247,7 +12498,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -9260,7 +12518,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -9273,7 +12538,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -9286,7 +12558,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -9299,7 +12578,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -9312,7 +12598,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -9325,7 +12618,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -9338,7 +12638,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -9351,7 +12658,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -9364,7 +12678,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -9377,7 +12698,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -9390,7 +12718,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -9403,7 +12738,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -9416,7 +12758,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -9429,7 +12778,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -9446,7 +12802,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -9459,7 +12822,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -9472,7 +12842,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -9485,7 +12862,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -9498,7 +12882,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -9511,7 +12902,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -9524,7 +12922,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -9537,7 +12942,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -9550,7 +12962,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -9563,7 +12982,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -9576,7 +13002,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -9589,7 +13022,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -9602,7 +13042,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -9615,7 +13062,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -9628,7 +13082,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -9641,7 +13102,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -9654,7 +13122,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -9667,7 +13142,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -9680,7 +13162,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -9693,7 +13182,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -9706,7 +13202,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -9719,7 +13222,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -9732,7 +13242,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -9745,7 +13262,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -9758,7 +13282,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -9771,7 +13302,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -9784,7 +13322,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -9797,7 +13342,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -9810,7 +13362,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -9823,7 +13382,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -9836,7 +13402,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -9849,7 +13422,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -9862,7 +13442,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -9875,7 +13462,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -9888,7 +13482,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -9901,7 +13502,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -9914,7 +13522,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -9927,7 +13542,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -9940,7 +13562,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -9953,7 +13582,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -9994,7 +13630,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":45,/"line_end/":68,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -10007,7 +13650,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":94,/"line_end/":103,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -10020,7 +13670,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":35,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -10033,7 +13690,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":36,/"line_end/":44,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -10046,7 +13710,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":104,/"line_end/":119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -10059,7 +13730,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":145,/"line_end/":158,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -10072,7 +13750,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":159,/"line_end/":166,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -10085,7 +13770,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":167,/"line_end/":179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -10098,7 +13790,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":180,/"line_end/":188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -10111,7 +13810,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":189,/"line_end/":201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -10124,7 +13830,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":202,/"line_end/":207,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -10137,7 +13850,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":208,/"line_end/":213,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -10174,7 +13894,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -10187,7 +13914,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":324,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -10200,7 +13934,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -10213,7 +13954,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":391,/"line_end/":403,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -10226,7 +13974,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":404,/"line_end/":430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -10239,7 +13994,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":454,/"line_end/":479,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -10252,7 +14014,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":480,/"line_end/":496,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -10265,7 +14034,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":497,/"line_end/":503,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -10278,7 +14054,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":526,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -10291,7 +14074,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":504,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -10304,7 +14094,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":527,/"line_end/":543,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -10317,7 +14114,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":544,/"line_end/":553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -10330,7 +14134,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":554,/"line_end/":569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -10343,7 +14154,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":570,/"line_end/":576,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -10356,7 +14174,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":577,/"line_end/":585,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -10369,7 +14194,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":586,/"line_end/":592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -10382,7 +14214,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":593,/"line_end/":603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -10395,7 +14234,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":604,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -10408,7 +14254,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":625,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -10421,7 +14274,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":626,/"line_end/":642,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -10434,7 +14294,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":643,/"line_end/":655,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -10447,7 +14314,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":656,/"line_end/":662,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -10460,7 +14334,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":663,/"line_end/":669,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -10473,7 +14354,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":670,/"line_end/":684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -10514,7 +14402,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":69,/"line_end/":86,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -10527,7 +14422,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":695,/"line_end/":701,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -10540,7 +14442,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":702,/"line_end/":713,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -10553,7 +14462,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":714,/"line_end/":726,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -10566,7 +14482,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":727,/"line_end/":739,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -10579,7 +14502,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":797,/"line_end/":809,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -10592,7 +14522,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":840,/"line_end/":856,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -10605,7 +14542,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":810,/"line_end/":821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -10618,7 +14562,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":740,/"line_end/":796,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -10631,7 +14582,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":874,/"line_end/":891,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -10644,7 +14602,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":892,/"line_end/":904,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -10657,7 +14622,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":915,/"line_end/":926,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -10670,7 +14642,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":936,/"line_end/":944,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -10683,7 +14662,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":857,/"line_end/":866,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -10696,7 +14682,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":945,/"line_end/":954,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -10709,7 +14702,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":955,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -10722,7 +14722,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -10735,7 +14742,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":990,/"line_end/":996,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -10748,7 +14762,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":997,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -10761,7 +14782,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1012,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -10774,7 +14802,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1013,/"line_end/":1025,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -10787,7 +14822,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1026,/"line_end/":1037,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -10800,7 +14842,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1038,/"line_end/":1054,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -10813,7 +14862,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1055,/"line_end/":1069,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -10826,7 +14882,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1070,/"line_end/":1076,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -10839,7 +14902,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1077,/"line_end/":1083,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -10852,7 +14922,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":989,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -10865,7 +14942,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1106,/"line_end/":1118,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -10878,7 +14962,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1084,/"line_end/":1105,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -10891,7 +14982,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1119,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -10904,7 +15002,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1154,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -10917,7 +15022,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1155,/"line_end/":1160,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -10930,7 +15042,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1161,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -10943,7 +15062,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -10956,7 +15082,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1180,/"line_end/":1196,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -10969,7 +15102,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1197,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -10982,7 +15122,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1218,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -10995,7 +15142,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1219,/"line_end/":1225,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -11008,7 +15162,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1226,/"line_end/":1234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -11021,7 +15182,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1235,/"line_end/":1246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -11034,7 +15202,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1247,/"line_end/":1255,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -11047,7 +15222,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1256,/"line_end/":1265,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -11060,7 +15242,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1266,/"line_end/":1272,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -11073,7 +15262,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1273,/"line_end/":1285,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -11086,7 +15282,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1286,/"line_end/":1292,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -11099,7 +15302,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1293,/"line_end/":1299,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -11112,7 +15322,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1300,/"line_end/":1306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -11125,7 +15342,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1307,/"line_end/":1316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -11138,7 +15362,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1317,/"line_end/":1330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -11151,7 +15382,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1331,/"line_end/":1346,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -11164,7 +15402,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1347,/"line_end/":1353,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -11177,7 +15422,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1354,/"line_end/":1362,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -11190,7 +15442,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1363,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -11203,7 +15462,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1388,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -11220,7 +15486,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1389,/"line_end/":1395,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -11233,7 +15506,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":87,/"line_end/":93,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -11246,7 +15526,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1403,/"line_end/":1408,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -11259,7 +15546,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1396,/"line_end/":1402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -11272,7 +15566,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1409,/"line_end/":1418,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -11285,7 +15586,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1419,/"line_end/":1436,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -11298,7 +15606,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1437,/"line_end/":1452,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -11311,7 +15626,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1453,/"line_end/":1468,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -11324,7 +15646,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1469,/"line_end/":1481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -11337,7 +15666,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1482,/"line_end/":1491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -11350,7 +15686,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1492,/"line_end/":1501,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -11363,7 +15706,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1502,/"line_end/":1511,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -11376,7 +15726,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1512,/"line_end/":1520,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -11389,7 +15746,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1521,/"line_end/":1532,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -11402,7 +15766,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1533,/"line_end/":1542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -11415,7 +15786,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1543,/"line_end/":1552,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -11428,7 +15806,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1553,/"line_end/":1572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -11441,7 +15826,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1573,/"line_end/":1582,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -11454,7 +15846,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1583,/"line_end/":1592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -11467,7 +15866,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1593,/"line_end/":1609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -11480,7 +15886,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1610,/"line_end/":1632,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -11493,7 +15906,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1633,/"line_end/":1644,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -11506,7 +15926,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1645,/"line_end/":1657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -11519,7 +15946,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1658,/"line_end/":1667,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -11532,7 +15966,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1668,/"line_end/":1676,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -11545,7 +15986,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1677,/"line_end/":1689,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -11558,7 +16006,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1690,/"line_end/":1702,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -11571,7 +16026,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1703,/"line_end/":1715,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -11584,7 +16046,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1716,/"line_end/":1722,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -11597,7 +16066,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1723,/"line_end/":1734,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -11610,7 +16086,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1735,/"line_end/":1740,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -11623,7 +16106,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1741,/"line_end/":1755,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -11636,7 +16126,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1756,/"line_end/":1768,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -11649,7 +16146,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1769,/"line_end/":1781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -11662,7 +16166,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1782,/"line_end/":1795,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -11675,7 +16186,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1796,/"line_end/":1805,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -11688,7 +16206,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1806,/"line_end/":1821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -11701,7 +16226,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1822,/"line_end/":1831,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -11714,7 +16246,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1832,/"line_end/":1838,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -11727,7 +16266,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1839,/"line_end/":1851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -11752,7 +16298,6 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
 | Java       | Gradle          | gradle/verification-metadata.xml |
 | Java       | Maven           | maven_install.json               |
 | Java       | Maven           | pom.xml                          |
-| Javascript | Bun             | bun.lock                         |
 | Javascript | NPM             | package-lock.json                |
 | Javascript | Pnpm            | pnpm-lock.yaml                   |
 | Javascript | Yarn            | yarn.lock                        |
@@ -11804,7 +16349,14 @@ Warning: `parsers` exists as both a subcommand of datadog-sbom-generator and as 
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"nested/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -11870,7 +16422,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -11911,7 +16470,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -12027,7 +16593,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NuGet"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":5,/"line_end/":10,/"column_start/":7,/"column_end/":8}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pom.xml",
@@ -12171,7 +16744,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/aws/aws-sdk-php@3.317.2",
@@ -12236,7 +16816,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dflydev/dot-access-data@v3.0.3",
@@ -12249,7 +16836,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/doctrine/inflector@2.0.10",
@@ -12286,7 +16880,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
@@ -12399,7 +17000,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/guzzle@7.9.2",
@@ -12436,7 +17044,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/psr7@2.7.0",
@@ -12449,7 +17064,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
@@ -12490,7 +17112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/collections@v11.19.0",
@@ -12503,7 +17132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/conditionable@v11.19.0",
@@ -12516,7 +17152,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/contracts@v11.19.0",
@@ -12529,7 +17172,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/macroable@v11.19.0",
@@ -12542,7 +17192,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/laravel/prompts@v0.1.24",
@@ -12627,7 +17284,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
@@ -12672,7 +17336,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
@@ -12745,7 +17416,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/mime-type-detection@1.15.0",
@@ -12762,7 +17440,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/mockery/mockery@1.6.12",
@@ -12831,7 +17516,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/myclabs/deep-copy@1.12.0",
@@ -12848,7 +17540,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nesbot/carbon@3.7.0",
@@ -12885,7 +17584,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nette/utils@v4.0.4",
@@ -12898,7 +17604,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nikic/php-parser@v5.1.0",
@@ -12915,7 +17628,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nunomaduro/termwind@v2.0.1",
@@ -13012,7 +17732,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phar-io/version@3.2.1",
@@ -13029,7 +17756,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpoption/phpoption@1.9.3",
@@ -13042,7 +17776,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpstan/phpstan@1.11.9",
@@ -13087,7 +17828,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-file-iterator@5.0.1",
@@ -13104,7 +17852,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-invoker@5.0.1",
@@ -13121,7 +17876,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-text-template@4.0.1",
@@ -13138,7 +17900,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-timer@7.0.1",
@@ -13155,7 +17924,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/phpunit@11.3.0",
@@ -13228,7 +18004,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/clock@1.0.0",
@@ -13241,7 +18024,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/container@2.0.2",
@@ -13278,7 +18068,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-client@1.0.3",
@@ -13291,7 +18088,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-factory@1.1.0",
@@ -13304,7 +18108,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-message@2.0",
@@ -13317,7 +18128,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/log@3.0.0",
@@ -13378,7 +18196,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/collection@2.0.0",
@@ -13391,7 +18216,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/uuid@4.7.6",
@@ -13460,7 +18292,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/cli-parser@3.0.2",
@@ -13477,7 +18316,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
@@ -13494,7 +18340,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit@3.0.1",
@@ -13511,7 +18364,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/comparator@6.0.1",
@@ -13528,7 +18388,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/complexity@4.0.1",
@@ -13545,7 +18412,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/diff@6.0.2",
@@ -13562,7 +18436,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/environment@7.2.0",
@@ -13579,7 +18460,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/exporter@6.1.3",
@@ -13596,7 +18484,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/global-state@7.0.2",
@@ -13613,7 +18508,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/lines-of-code@3.0.1",
@@ -13630,7 +18532,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-enumerator@6.0.1",
@@ -13647,7 +18556,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-reflector@4.0.1",
@@ -13664,7 +18580,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/recursion-context@6.0.2",
@@ -13681,7 +18604,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/type@5.0.1",
@@ -13698,7 +18628,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/version@5.0.1",
@@ -13715,7 +18652,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache-contracts@v3.5.0",
@@ -13732,7 +18676,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache@v7.1.3",
@@ -13773,7 +18724,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/console@v7.1.3",
@@ -13810,7 +18768,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
@@ -13823,7 +18788,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/error-handler@v7.1.3",
@@ -13860,7 +18832,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/event-dispatcher@v7.1.1",
@@ -13873,7 +18852,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/finder@v7.1.3",
@@ -13914,7 +18900,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/http-client@v7.1.3",
@@ -14051,7 +19044,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
@@ -14064,7 +19064,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
@@ -14077,7 +19084,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
@@ -14090,7 +19104,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
@@ -14103,7 +19124,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php72@v1.30.0",
@@ -14116,7 +19144,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php80@v1.30.0",
@@ -14129,7 +19164,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php83@v1.30.0",
@@ -14166,7 +19208,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/process@v7.1.3",
@@ -14255,7 +19304,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/string@v7.1.3",
@@ -14268,7 +19324,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation-contracts@v3.5.0",
@@ -14281,7 +19344,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation@v7.1.3",
@@ -14294,7 +19364,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/uid@v7.1.1",
@@ -14359,7 +19436,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/theseer/tokenizer@1.2.3",
@@ -14376,7 +19460,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
@@ -14461,7 +19552,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:conan/zlib@1.2.11",
@@ -14474,7 +19572,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Conan"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"conan.lock/",/"line_start/":13,/"line_end/":19,/"column_start/":7,/"column_end/":8}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/RedCloth@4.2.9",
@@ -14511,7 +19616,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailbox@7.1.2",
@@ -14524,7 +19636,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailer@7.1.2",
@@ -14537,7 +19656,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionpack@7.1.2",
@@ -14550,7 +19676,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actiontext@7.1.2",
@@ -14563,7 +19696,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionview@7.1.2",
@@ -14576,7 +19716,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activejob@7.1.2",
@@ -14589,7 +19736,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activemodel@7.1.2",
@@ -14602,7 +19756,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activerecord@7.1.2",
@@ -14615,7 +19776,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activestorage@7.1.2",
@@ -14628,7 +19796,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activesupport@7.1.2",
@@ -14641,7 +19816,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/addressable@2.8.7",
@@ -14654,7 +19836,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/base64@0.2.0",
@@ -14667,7 +19856,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/bigdecimal@3.1.8",
@@ -14680,7 +19876,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/builder@3.3.0",
@@ -14693,7 +19896,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/capybara@3.39.2",
@@ -14706,7 +19916,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/childprocess@5.0.0",
@@ -14719,7 +19936,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/chronic@0.10.2",
@@ -14780,7 +20004,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/connection_pool@2.4.1",
@@ -14793,7 +20024,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/crass@1.0.6",
@@ -14806,7 +20044,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-ci-environment@10.0.1",
@@ -14819,7 +20064,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-core@13.0.3",
@@ -14832,7 +20084,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
@@ -14845,7 +20104,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-gherkin@27.0.0",
@@ -14858,7 +20124,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-html-formatter@21.4.1",
@@ -14871,7 +20144,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-messages@22.0.0",
@@ -14884,7 +20164,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-rails@1.4.0",
@@ -14925,7 +20212,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-websteps@0.10.0",
@@ -14966,7 +20260,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-active_record@2.2.0",
@@ -14979,7 +20280,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-core@2.0.1",
@@ -14992,7 +20300,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner@2.0.2",
@@ -15033,7 +20348,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/diff-lcs@1.5.1",
@@ -15046,7 +20368,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/drb@2.2.1",
@@ -15059,7 +20388,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/erubi@1.13.0",
@@ -15072,7 +20408,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/factory_girl@4.9.0",
@@ -15113,7 +20456,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/globalid@1.2.1",
@@ -15126,7 +20476,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/i18n@1.14.5",
@@ -15139,7 +20496,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/io-console@0.7.2",
@@ -15152,7 +20516,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/irb@1.14.0",
@@ -15165,7 +20536,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/jquery-rails@4.6.0",
@@ -15202,7 +20580,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/loofah@2.22.0",
@@ -15215,7 +20600,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mail@2.8.1",
@@ -15228,7 +20620,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/marcel@1.0.4",
@@ -15241,7 +20640,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/matrix@0.4.2",
@@ -15254,7 +20660,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_mime@1.1.5",
@@ -15267,7 +20680,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_portile2@2.8.7",
@@ -15280,7 +20700,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/minitest@5.24.1",
@@ -15293,7 +20720,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/multi_test@1.1.0",
@@ -15306,7 +20740,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mutex_m@0.2.0",
@@ -15319,7 +20760,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-imap@0.4.14",
@@ -15332,7 +20780,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-pop@0.1.2",
@@ -15345,7 +20800,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-protocol@0.2.2",
@@ -15358,7 +20820,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-smtp@0.5.0",
@@ -15371,7 +20840,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nio4r@2.7.3",
@@ -15384,7 +20860,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nokogiri@1.15.6",
@@ -15397,7 +20880,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/psych@5.1.2",
@@ -15410,7 +20900,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/public_suffix@5.1.1",
@@ -15423,7 +20920,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/racc@1.8.1",
@@ -15436,7 +20940,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-openid@1.4.2",
@@ -15473,7 +20984,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-test@2.1.0",
@@ -15486,7 +21004,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack@3.1.7",
@@ -15499,7 +21024,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rackup@2.1.0",
@@ -15512,7 +21044,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-dom-testing@2.2.0",
@@ -15525,7 +21064,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-html-sanitizer@1.6.0",
@@ -15538,7 +21084,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails@7.1.2",
@@ -15575,7 +21128,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rake@13.2.1",
@@ -15588,7 +21148,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rdoc@6.7.0",
@@ -15601,7 +21168,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/regexp_parser@2.9.2",
@@ -15614,7 +21188,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/reline@0.5.9",
@@ -15627,7 +21208,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-activemodel-mocks@1.2.0",
@@ -15696,7 +21284,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-expectations@3.13.1",
@@ -15709,7 +21304,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-mocks@3.13.1",
@@ -15722,7 +21324,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-support@3.13.1",
@@ -15735,7 +21344,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec@3.13.0",
@@ -15824,7 +21440,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/sys-uname@1.3.0",
@@ -15837,7 +21460,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/thor@1.3.1",
@@ -15850,7 +21480,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/timeout@0.4.1",
@@ -15863,7 +21500,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/tzinfo@2.0.6",
@@ -15876,7 +21520,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/webrick@1.8.1",
@@ -15889,7 +21540,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-driver@0.7.6",
@@ -15902,7 +21560,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-extensions@0.1.5",
@@ -15915,7 +21580,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/will_paginate@3.0.12",
@@ -15952,7 +21624,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/zeitwerk@2.6.17",
@@ -15965,7 +21644,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
@@ -16073,7 +21759,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Hex"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"mix.lock/",/"line_start/":2,/"line_end/":2,/"column_start/":1,/"column_end/":421}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
@@ -16174,7 +21867,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
@@ -16191,7 +21891,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
@@ -16358,7 +22065,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm/pnpm-lock.yaml/",/"line_start/":21,/"line_end/":25,/"column_start/":3,/"column_end/":14}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.6.9",
@@ -16407,7 +22121,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash@4.17.20",
@@ -16424,7 +22145,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.0.0",
@@ -16441,7 +22169,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.2",
@@ -16458,7 +22193,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -16663,7 +22405,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pub"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pubspec.lock/",/"line_start/":4,/"line_end/":10,/"column_start/":3,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:pypi/beautifulsoup4@4.9.3",
@@ -17063,7 +22812,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/aws/aws-sdk-php@3.317.2",
@@ -17128,7 +22884,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dflydev/dot-access-data@v3.0.3",
@@ -17141,7 +22904,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/doctrine/inflector@2.0.10",
@@ -17178,7 +22948,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
@@ -17291,7 +23068,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/guzzle@7.9.2",
@@ -17328,7 +23112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/psr7@2.7.0",
@@ -17341,7 +23132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
@@ -17382,7 +23180,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/collections@v11.19.0",
@@ -17395,7 +23200,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/conditionable@v11.19.0",
@@ -17408,7 +23220,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/contracts@v11.19.0",
@@ -17421,7 +23240,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/macroable@v11.19.0",
@@ -17434,7 +23260,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/laravel/prompts@v0.1.24",
@@ -17519,7 +23352,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
@@ -17564,7 +23404,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
@@ -17637,7 +23484,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/mime-type-detection@1.15.0",
@@ -17654,7 +23508,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/mockery/mockery@1.6.12",
@@ -17723,7 +23584,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/myclabs/deep-copy@1.12.0",
@@ -17740,7 +23608,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nesbot/carbon@3.7.0",
@@ -17777,7 +23652,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nette/utils@v4.0.4",
@@ -17790,7 +23672,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nikic/php-parser@v5.1.0",
@@ -17807,7 +23696,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nunomaduro/termwind@v2.0.1",
@@ -17904,7 +23800,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phar-io/version@3.2.1",
@@ -17921,7 +23824,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpoption/phpoption@1.9.3",
@@ -17934,7 +23844,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpstan/phpstan@1.11.9",
@@ -17979,7 +23896,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-file-iterator@5.0.1",
@@ -17996,7 +23920,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-invoker@5.0.1",
@@ -18013,7 +23944,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-text-template@4.0.1",
@@ -18030,7 +23968,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-timer@7.0.1",
@@ -18047,7 +23992,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/phpunit@11.3.0",
@@ -18120,7 +24072,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/clock@1.0.0",
@@ -18133,7 +24092,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/container@2.0.2",
@@ -18170,7 +24136,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-client@1.0.3",
@@ -18183,7 +24156,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-factory@1.1.0",
@@ -18196,7 +24176,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-message@2.0",
@@ -18209,7 +24196,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/log@3.0.0",
@@ -18270,7 +24264,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/collection@2.0.0",
@@ -18283,7 +24284,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/uuid@4.7.6",
@@ -18352,7 +24360,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/cli-parser@3.0.2",
@@ -18369,7 +24384,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
@@ -18386,7 +24408,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit@3.0.1",
@@ -18403,7 +24432,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/comparator@6.0.1",
@@ -18420,7 +24456,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/complexity@4.0.1",
@@ -18437,7 +24480,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/diff@6.0.2",
@@ -18454,7 +24504,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/environment@7.2.0",
@@ -18471,7 +24528,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/exporter@6.1.3",
@@ -18488,7 +24552,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/global-state@7.0.2",
@@ -18505,7 +24576,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/lines-of-code@3.0.1",
@@ -18522,7 +24600,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-enumerator@6.0.1",
@@ -18539,7 +24624,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-reflector@4.0.1",
@@ -18556,7 +24648,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/recursion-context@6.0.2",
@@ -18573,7 +24672,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/type@5.0.1",
@@ -18590,7 +24696,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/version@5.0.1",
@@ -18607,7 +24720,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache-contracts@v3.5.0",
@@ -18624,7 +24744,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache@v7.1.3",
@@ -18665,7 +24792,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/console@v7.1.3",
@@ -18702,7 +24836,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
@@ -18715,7 +24856,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/error-handler@v7.1.3",
@@ -18752,7 +24900,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/event-dispatcher@v7.1.1",
@@ -18765,7 +24920,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/finder@v7.1.3",
@@ -18806,7 +24968,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/http-client@v7.1.3",
@@ -18943,7 +25112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
@@ -18956,7 +25132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
@@ -18969,7 +25152,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
@@ -18982,7 +25172,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
@@ -18995,7 +25192,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php72@v1.30.0",
@@ -19008,7 +25212,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php80@v1.30.0",
@@ -19021,7 +25232,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php83@v1.30.0",
@@ -19058,7 +25276,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/process@v7.1.3",
@@ -19147,7 +25372,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/string@v7.1.3",
@@ -19160,7 +25392,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation-contracts@v3.5.0",
@@ -19173,7 +25412,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation@v7.1.3",
@@ -19186,7 +25432,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/uid@v7.1.1",
@@ -19251,7 +25504,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/theseer/tokenizer@1.2.3",
@@ -19268,7 +25528,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
@@ -19353,7 +25620,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:conan/zlib@1.2.11",
@@ -19366,7 +25640,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Conan"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"conan.lock/",/"line_start/":13,/"line_end/":19,/"column_start/":7,/"column_end/":8}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/RedCloth@4.2.9",
@@ -19403,7 +25684,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailbox@7.1.2",
@@ -19416,7 +25704,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailer@7.1.2",
@@ -19429,7 +25724,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionpack@7.1.2",
@@ -19442,7 +25744,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actiontext@7.1.2",
@@ -19455,7 +25764,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionview@7.1.2",
@@ -19468,7 +25784,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activejob@7.1.2",
@@ -19481,7 +25804,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activemodel@7.1.2",
@@ -19494,7 +25824,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activerecord@7.1.2",
@@ -19507,7 +25844,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activestorage@7.1.2",
@@ -19520,7 +25864,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activesupport@7.1.2",
@@ -19533,7 +25884,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/addressable@2.8.7",
@@ -19546,7 +25904,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/base64@0.2.0",
@@ -19559,7 +25924,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/bigdecimal@3.1.8",
@@ -19572,7 +25944,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/builder@3.3.0",
@@ -19585,7 +25964,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/capybara@3.39.2",
@@ -19598,7 +25984,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/childprocess@5.0.0",
@@ -19611,7 +26004,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/chronic@0.10.2",
@@ -19672,7 +26072,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/connection_pool@2.4.1",
@@ -19685,7 +26092,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/crass@1.0.6",
@@ -19698,7 +26112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-ci-environment@10.0.1",
@@ -19711,7 +26132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-core@13.0.3",
@@ -19724,7 +26152,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
@@ -19737,7 +26172,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-gherkin@27.0.0",
@@ -19750,7 +26192,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-html-formatter@21.4.1",
@@ -19763,7 +26212,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-messages@22.0.0",
@@ -19776,7 +26232,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-rails@1.4.0",
@@ -19817,7 +26280,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-websteps@0.10.0",
@@ -19858,7 +26328,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-active_record@2.2.0",
@@ -19871,7 +26348,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-core@2.0.1",
@@ -19884,7 +26368,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner@2.0.2",
@@ -19925,7 +26416,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/diff-lcs@1.5.1",
@@ -19938,7 +26436,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/drb@2.2.1",
@@ -19951,7 +26456,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/erubi@1.13.0",
@@ -19964,7 +26476,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/factory_girl@4.9.0",
@@ -20005,7 +26524,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/globalid@1.2.1",
@@ -20018,7 +26544,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/i18n@1.14.5",
@@ -20031,7 +26564,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/io-console@0.7.2",
@@ -20044,7 +26584,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/irb@1.14.0",
@@ -20057,7 +26604,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/jquery-rails@4.6.0",
@@ -20094,7 +26648,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/loofah@2.22.0",
@@ -20107,7 +26668,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mail@2.8.1",
@@ -20120,7 +26688,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/marcel@1.0.4",
@@ -20133,7 +26708,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/matrix@0.4.2",
@@ -20146,7 +26728,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_mime@1.1.5",
@@ -20159,7 +26748,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_portile2@2.8.7",
@@ -20172,7 +26768,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/minitest@5.24.1",
@@ -20185,7 +26788,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/multi_test@1.1.0",
@@ -20198,7 +26808,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mutex_m@0.2.0",
@@ -20211,7 +26828,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-imap@0.4.14",
@@ -20224,7 +26848,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-pop@0.1.2",
@@ -20237,7 +26868,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-protocol@0.2.2",
@@ -20250,7 +26888,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-smtp@0.5.0",
@@ -20263,7 +26908,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nio4r@2.7.3",
@@ -20276,7 +26928,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nokogiri@1.15.6",
@@ -20289,7 +26948,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/psych@5.1.2",
@@ -20302,7 +26968,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/public_suffix@5.1.1",
@@ -20315,7 +26988,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/racc@1.8.1",
@@ -20328,7 +27008,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-openid@1.4.2",
@@ -20365,7 +27052,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-test@2.1.0",
@@ -20378,7 +27072,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack@3.1.7",
@@ -20391,7 +27092,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rackup@2.1.0",
@@ -20404,7 +27112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-dom-testing@2.2.0",
@@ -20417,7 +27132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-html-sanitizer@1.6.0",
@@ -20430,7 +27152,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails@7.1.2",
@@ -20467,7 +27196,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rake@13.2.1",
@@ -20480,7 +27216,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rdoc@6.7.0",
@@ -20493,7 +27236,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/regexp_parser@2.9.2",
@@ -20506,7 +27256,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/reline@0.5.9",
@@ -20519,7 +27276,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-activemodel-mocks@1.2.0",
@@ -20588,7 +27352,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-expectations@3.13.1",
@@ -20601,7 +27372,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-mocks@3.13.1",
@@ -20614,7 +27392,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-support@3.13.1",
@@ -20627,7 +27412,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec@3.13.0",
@@ -20716,7 +27508,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/sys-uname@1.3.0",
@@ -20729,7 +27528,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/thor@1.3.1",
@@ -20742,7 +27548,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/timeout@0.4.1",
@@ -20755,7 +27568,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/tzinfo@2.0.6",
@@ -20768,7 +27588,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/webrick@1.8.1",
@@ -20781,7 +27608,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-driver@0.7.6",
@@ -20794,7 +27628,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-extensions@0.1.5",
@@ -20807,7 +27648,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/will_paginate@3.0.12",
@@ -20844,7 +27692,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/zeitwerk@2.6.17",
@@ -20857,7 +27712,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
@@ -20918,7 +27780,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Hex"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"mix.lock/",/"line_start/":2,/"line_end/":2,/"column_start/":1,/"column_end/":421}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
@@ -21019,7 +27888,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
@@ -21036,7 +27912,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
@@ -21231,7 +28114,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash@4.17.20",
@@ -21248,7 +28138,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.0.0",
@@ -21265,7 +28162,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.2",
@@ -21282,7 +28186,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -21487,7 +28398,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pub"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pubspec.lock/",/"line_start/":4,/"line_end/":10,/"column_start/":3,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:pypi/beautifulsoup4@4.9.3",
@@ -21887,7 +28805,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/aws/aws-sdk-php@3.317.2",
@@ -21952,7 +28877,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dflydev/dot-access-data@v3.0.3",
@@ -21965,7 +28897,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/doctrine/inflector@2.0.10",
@@ -22002,7 +28941,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
@@ -22115,7 +29061,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/guzzle@7.9.2",
@@ -22152,7 +29105,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/psr7@2.7.0",
@@ -22165,7 +29125,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
@@ -22206,7 +29173,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/collections@v11.19.0",
@@ -22219,7 +29193,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/conditionable@v11.19.0",
@@ -22232,7 +29213,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/contracts@v11.19.0",
@@ -22245,7 +29233,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/macroable@v11.19.0",
@@ -22258,7 +29253,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/laravel/prompts@v0.1.24",
@@ -22343,7 +29345,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
@@ -22388,7 +29397,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
@@ -22461,7 +29477,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/mime-type-detection@1.15.0",
@@ -22478,7 +29501,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/mockery/mockery@1.6.12",
@@ -22547,7 +29577,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/myclabs/deep-copy@1.12.0",
@@ -22564,7 +29601,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nesbot/carbon@3.7.0",
@@ -22601,7 +29645,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nette/utils@v4.0.4",
@@ -22614,7 +29665,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nikic/php-parser@v5.1.0",
@@ -22631,7 +29689,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nunomaduro/termwind@v2.0.1",
@@ -22728,7 +29793,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phar-io/version@3.2.1",
@@ -22745,7 +29817,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpoption/phpoption@1.9.3",
@@ -22758,7 +29837,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpstan/phpstan@1.11.9",
@@ -22803,7 +29889,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-file-iterator@5.0.1",
@@ -22820,7 +29913,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-invoker@5.0.1",
@@ -22837,7 +29937,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-text-template@4.0.1",
@@ -22854,7 +29961,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-timer@7.0.1",
@@ -22871,7 +29985,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/phpunit@11.3.0",
@@ -22944,7 +30065,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/clock@1.0.0",
@@ -22957,7 +30085,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/container@2.0.2",
@@ -22994,7 +30129,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-client@1.0.3",
@@ -23007,7 +30149,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-factory@1.1.0",
@@ -23020,7 +30169,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-message@2.0",
@@ -23033,7 +30189,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/log@3.0.0",
@@ -23094,7 +30257,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/collection@2.0.0",
@@ -23107,7 +30277,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/uuid@4.7.6",
@@ -23176,7 +30353,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/cli-parser@3.0.2",
@@ -23193,7 +30377,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
@@ -23210,7 +30401,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit@3.0.1",
@@ -23227,7 +30425,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/comparator@6.0.1",
@@ -23244,7 +30449,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/complexity@4.0.1",
@@ -23261,7 +30473,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/diff@6.0.2",
@@ -23278,7 +30497,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/environment@7.2.0",
@@ -23295,7 +30521,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/exporter@6.1.3",
@@ -23312,7 +30545,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/global-state@7.0.2",
@@ -23329,7 +30569,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/lines-of-code@3.0.1",
@@ -23346,7 +30593,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-enumerator@6.0.1",
@@ -23363,7 +30617,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-reflector@4.0.1",
@@ -23380,7 +30641,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/recursion-context@6.0.2",
@@ -23397,7 +30665,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/type@5.0.1",
@@ -23414,7 +30689,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/version@5.0.1",
@@ -23431,7 +30713,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache-contracts@v3.5.0",
@@ -23448,7 +30737,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache@v7.1.3",
@@ -23489,7 +30785,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/console@v7.1.3",
@@ -23526,7 +30829,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
@@ -23539,7 +30849,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/error-handler@v7.1.3",
@@ -23576,7 +30893,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/event-dispatcher@v7.1.1",
@@ -23589,7 +30913,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/finder@v7.1.3",
@@ -23630,7 +30961,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/http-client@v7.1.3",
@@ -23767,7 +31105,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
@@ -23780,7 +31125,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
@@ -23793,7 +31145,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
@@ -23806,7 +31165,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
@@ -23819,7 +31185,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php72@v1.30.0",
@@ -23832,7 +31205,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php80@v1.30.0",
@@ -23845,7 +31225,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php83@v1.30.0",
@@ -23882,7 +31269,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/process@v7.1.3",
@@ -23971,7 +31365,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/string@v7.1.3",
@@ -23984,7 +31385,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation-contracts@v3.5.0",
@@ -23997,7 +31405,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation@v7.1.3",
@@ -24010,7 +31425,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/uid@v7.1.1",
@@ -24075,7 +31497,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/theseer/tokenizer@1.2.3",
@@ -24092,7 +31521,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
@@ -24177,7 +31613,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:conan/zlib@1.2.11",
@@ -24190,7 +31633,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Conan"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"conan.lock/",/"line_start/":13,/"line_end/":19,/"column_start/":7,/"column_end/":8}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/RedCloth@4.2.9",
@@ -24227,7 +31677,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailbox@7.1.2",
@@ -24240,7 +31697,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailer@7.1.2",
@@ -24253,7 +31717,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionpack@7.1.2",
@@ -24266,7 +31737,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actiontext@7.1.2",
@@ -24279,7 +31757,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionview@7.1.2",
@@ -24292,7 +31777,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activejob@7.1.2",
@@ -24305,7 +31797,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activemodel@7.1.2",
@@ -24318,7 +31817,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activerecord@7.1.2",
@@ -24331,7 +31837,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activestorage@7.1.2",
@@ -24344,7 +31857,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activesupport@7.1.2",
@@ -24357,7 +31877,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/addressable@2.8.7",
@@ -24370,7 +31897,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/base64@0.2.0",
@@ -24383,7 +31917,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/bigdecimal@3.1.8",
@@ -24396,7 +31937,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/builder@3.3.0",
@@ -24409,7 +31957,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/capybara@3.39.2",
@@ -24422,7 +31977,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/childprocess@5.0.0",
@@ -24435,7 +31997,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/chronic@0.10.2",
@@ -24496,7 +32065,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/connection_pool@2.4.1",
@@ -24509,7 +32085,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/crass@1.0.6",
@@ -24522,7 +32105,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-ci-environment@10.0.1",
@@ -24535,7 +32125,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-core@13.0.3",
@@ -24548,7 +32145,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
@@ -24561,7 +32165,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-gherkin@27.0.0",
@@ -24574,7 +32185,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-html-formatter@21.4.1",
@@ -24587,7 +32205,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-messages@22.0.0",
@@ -24600,7 +32225,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-rails@1.4.0",
@@ -24641,7 +32273,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-websteps@0.10.0",
@@ -24682,7 +32321,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-active_record@2.2.0",
@@ -24695,7 +32341,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-core@2.0.1",
@@ -24708,7 +32361,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner@2.0.2",
@@ -24749,7 +32409,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/diff-lcs@1.5.1",
@@ -24762,7 +32429,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/drb@2.2.1",
@@ -24775,7 +32449,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/erubi@1.13.0",
@@ -24788,7 +32469,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/factory_girl@4.9.0",
@@ -24829,7 +32517,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/globalid@1.2.1",
@@ -24842,7 +32537,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/i18n@1.14.5",
@@ -24855,7 +32557,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/io-console@0.7.2",
@@ -24868,7 +32577,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/irb@1.14.0",
@@ -24881,7 +32597,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/jquery-rails@4.6.0",
@@ -24918,7 +32641,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/loofah@2.22.0",
@@ -24931,7 +32661,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mail@2.8.1",
@@ -24944,7 +32681,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/marcel@1.0.4",
@@ -24957,7 +32701,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/matrix@0.4.2",
@@ -24970,7 +32721,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_mime@1.1.5",
@@ -24983,7 +32741,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_portile2@2.8.7",
@@ -24996,7 +32761,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/minitest@5.24.1",
@@ -25009,7 +32781,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/multi_test@1.1.0",
@@ -25022,7 +32801,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mutex_m@0.2.0",
@@ -25035,7 +32821,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-imap@0.4.14",
@@ -25048,7 +32841,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-pop@0.1.2",
@@ -25061,7 +32861,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-protocol@0.2.2",
@@ -25074,7 +32881,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-smtp@0.5.0",
@@ -25087,7 +32901,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nio4r@2.7.3",
@@ -25100,7 +32921,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nokogiri@1.15.6",
@@ -25113,7 +32941,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/psych@5.1.2",
@@ -25126,7 +32961,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/public_suffix@5.1.1",
@@ -25139,7 +32981,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/racc@1.8.1",
@@ -25152,7 +33001,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-openid@1.4.2",
@@ -25189,7 +33045,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-test@2.1.0",
@@ -25202,7 +33065,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack@3.1.7",
@@ -25215,7 +33085,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rackup@2.1.0",
@@ -25228,7 +33105,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-dom-testing@2.2.0",
@@ -25241,7 +33125,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-html-sanitizer@1.6.0",
@@ -25254,7 +33145,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails@7.1.2",
@@ -25291,7 +33189,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rake@13.2.1",
@@ -25304,7 +33209,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rdoc@6.7.0",
@@ -25317,7 +33229,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/regexp_parser@2.9.2",
@@ -25330,7 +33249,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/reline@0.5.9",
@@ -25343,7 +33269,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-activemodel-mocks@1.2.0",
@@ -25412,7 +33345,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-expectations@3.13.1",
@@ -25425,7 +33365,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-mocks@3.13.1",
@@ -25438,7 +33385,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-support@3.13.1",
@@ -25451,7 +33405,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec@3.13.0",
@@ -25540,7 +33501,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/sys-uname@1.3.0",
@@ -25553,7 +33521,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/thor@1.3.1",
@@ -25566,7 +33541,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/timeout@0.4.1",
@@ -25579,7 +33561,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/tzinfo@2.0.6",
@@ -25592,7 +33581,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/webrick@1.8.1",
@@ -25605,7 +33601,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-driver@0.7.6",
@@ -25618,7 +33621,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-extensions@0.1.5",
@@ -25631,7 +33641,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/will_paginate@3.0.12",
@@ -25668,7 +33685,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/zeitwerk@2.6.17",
@@ -25681,7 +33705,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
@@ -25742,7 +33773,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Hex"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"mix.lock/",/"line_start/":2,/"line_end/":2,/"column_start/":1,/"column_end/":421}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
@@ -25843,7 +33881,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
@@ -25860,7 +33905,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
@@ -26055,7 +34107,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash@4.17.20",
@@ -26072,7 +34131,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.0.0",
@@ -26089,7 +34155,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.2",
@@ -26106,7 +34179,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -26311,7 +34391,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pub"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pubspec.lock/",/"line_start/":4,/"line_end/":10,/"column_start/":3,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:pypi/beautifulsoup4@4.9.3",
@@ -26773,7 +34860,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -26790,7 +34884,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -26831,7 +34932,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":5,/"line_end/":10,/"column_start/":1,/"column_end/":33}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -26844,7 +34952,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":12,/"line_end/":15,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -26857,7 +34972,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":17,/"line_end/":23,/"column_start/":1,/"column_end/":26}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -26870,7 +34992,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":25,/"line_end/":28,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -26883,7 +35012,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":30,/"line_end/":36,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -26896,7 +35032,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":38,/"line_end/":41,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -26909,7 +35052,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":46,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -26946,7 +35096,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":64,/"line_end/":70,/"column_start/":1,/"column_end/":47}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -26959,7 +35116,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":72,/"line_end/":80,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -26972,7 +35136,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":82,/"line_end/":85,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -26985,7 +35156,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":87,/"line_end/":98,/"column_start/":1,/"column_end/":22}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -26998,7 +35176,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":100,/"line_end/":112,/"column_start/":1,/"column_end/":20}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -27011,7 +35196,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":114,/"line_end/":120,/"column_start/":1,/"column_end/":33}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -27024,7 +35216,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":122,/"line_end/":125,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -27037,7 +35236,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":132,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -27059,6 +35265,9 @@ No package sources found. Use the 'parsers list' command to view supported lockf
         "occurrences": [
           {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":134,/"line_end/":139,/"column_start/":1,/"column_end/":16}}"
           }
         ]
       }
@@ -27074,7 +35283,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":141,/"line_end/":146,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -27087,7 +35303,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":148,/"line_end/":154,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -27100,7 +35323,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":156,/"line_end/":159,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -27113,7 +35343,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":166,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -27126,7 +35363,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":168,/"line_end/":171,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -27139,7 +35383,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":173,/"line_end/":176,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.2",
@@ -27152,7 +35403,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":187,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -27165,7 +35423,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -27178,7 +35443,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":196,/"line_end/":201,/"column_start/":1,/"column_end/":28}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -27191,7 +35463,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":203,/"line_end/":208,/"column_start/":1,/"column_end/":21}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -27204,7 +35483,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":210,/"line_end/":220,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -27217,7 +35503,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":222,/"line_end/":225,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -27230,7 +35523,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":227,/"line_end/":230,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -27243,7 +35543,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":235,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -27256,7 +35563,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":237,/"line_end/":242,/"column_start/":1,/"column_end/":24}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -27269,7 +35583,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":244,/"line_end/":247,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -27282,7 +35603,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":249,/"line_end/":252,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -27295,7 +35623,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":254,/"line_end/":260,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -27308,7 +35643,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":262,/"line_end/":265,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -27321,7 +35663,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":270,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -27334,7 +35683,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":272,/"line_end/":275,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -27347,7 +35703,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":277,/"line_end/":280,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -27360,7 +35723,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":282,/"line_end/":285,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -27373,7 +35743,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":287,/"line_end/":290,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -27386,7 +35763,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":292,/"line_end/":297,/"column_start/":1,/"column_end/":29}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -27399,7 +35783,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":299,/"line_end/":302,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -27412,7 +35803,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":304,/"line_end/":307,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -27425,7 +35823,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":23}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -27438,7 +35843,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":319,/"column_start/":1,/"column_end/":108}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -27451,7 +35863,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":321,/"line_end/":326,/"column_start/":1,/"column_end/":19}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -27492,7 +35911,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -27505,7 +35931,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -27518,7 +35951,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -27531,7 +35971,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -27544,7 +35991,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -27557,7 +36011,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -27570,7 +36031,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":65,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -27607,7 +36075,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":91,/"line_end/":99,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -27620,7 +36095,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":101,/"line_end/":116,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -27633,7 +36115,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":118,/"line_end/":123,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -27646,7 +36135,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":125,/"line_end/":141,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -27659,7 +36155,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":143,/"line_end/":159,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -27672,7 +36175,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":169,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -27685,7 +36195,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":171,/"line_end/":176,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -27698,7 +36215,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":185,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -27720,6 +36244,9 @@ No package sources found. Use the 'parsers list' command to view supported lockf
         "occurrences": [
           {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":187,/"line_end/":197,/"column_start/":1,/"column_end/":17}}"
           }
         ]
       }
@@ -27735,7 +36262,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":199,/"line_end/":206,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -27748,7 +36282,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":208,/"line_end/":216,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -27761,7 +36302,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":218,/"line_end/":223,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -27774,7 +36322,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":225,/"line_end/":232,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -27787,7 +36342,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":234,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -27800,7 +36362,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":246,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.2",
@@ -27813,7 +36382,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":248,/"line_end/":259,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -27826,7 +36402,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":261,/"line_end/":268,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -27839,7 +36422,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":270,/"line_end/":277,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -27852,7 +36442,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":279,/"line_end/":286,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -27865,7 +36462,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":288,/"line_end/":300,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -27878,7 +36482,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":302,/"line_end/":307,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -27891,7 +36502,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -27904,7 +36522,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":321,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -27917,7 +36542,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":323,/"line_end/":330,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -27930,7 +36562,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":332,/"line_end/":337,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -27943,7 +36582,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":339,/"line_end/":344,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -27956,7 +36602,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":346,/"line_end/":354,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -27969,7 +36622,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":356,/"line_end/":361,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -27982,7 +36642,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":363,/"line_end/":368,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -27995,7 +36662,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":370,/"line_end/":375,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -28008,7 +36682,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":377,/"line_end/":382,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -28021,7 +36702,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":384,/"line_end/":389,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -28034,7 +36722,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":391,/"line_end/":396,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -28047,7 +36742,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":398,/"line_end/":405,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -28060,7 +36762,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":407,/"line_end/":414,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -28073,7 +36782,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":416,/"line_end/":421,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -28086,7 +36802,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":432,/"line_end/":439,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -28099,7 +36822,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":441,/"line_end/":446,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -28112,7 +36842,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":448,/"line_end/":457,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -28153,7 +36890,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -28166,7 +36910,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -28179,7 +36930,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -28192,7 +36950,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -28205,7 +36970,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -28218,7 +36990,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -28231,7 +37010,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":65,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -28268,7 +37054,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":91,/"line_end/":99,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -28281,7 +37074,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":101,/"line_end/":116,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -28294,7 +37094,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":118,/"line_end/":123,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -28307,7 +37114,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":125,/"line_end/":141,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -28320,7 +37134,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":143,/"line_end/":159,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -28333,7 +37154,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":169,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -28346,7 +37174,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":171,/"line_end/":176,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -28359,7 +37194,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":185,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -28381,6 +37223,9 @@ No package sources found. Use the 'parsers list' command to view supported lockf
         "occurrences": [
           {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":187,/"line_end/":197,/"column_start/":1,/"column_end/":17}}"
           }
         ]
       }
@@ -28396,7 +37241,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":199,/"line_end/":206,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -28409,7 +37261,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":208,/"line_end/":216,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -28422,7 +37281,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":218,/"line_end/":223,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -28435,7 +37301,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":225,/"line_end/":232,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -28448,7 +37321,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":234,/"line_end/":239,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -28461,7 +37341,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":246,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.2",
@@ -28474,7 +37361,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":248,/"line_end/":259,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -28487,7 +37381,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":261,/"line_end/":268,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -28500,7 +37401,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":270,/"line_end/":277,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -28513,7 +37421,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":279,/"line_end/":286,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -28526,7 +37441,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":288,/"line_end/":300,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -28539,7 +37461,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":302,/"line_end/":307,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -28552,7 +37481,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -28565,7 +37501,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":321,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -28578,7 +37521,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":323,/"line_end/":330,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -28591,7 +37541,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":332,/"line_end/":337,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -28604,7 +37561,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":339,/"line_end/":344,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -28617,7 +37581,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":346,/"line_end/":354,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -28630,7 +37601,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":356,/"line_end/":361,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -28643,7 +37621,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":363,/"line_end/":368,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -28656,7 +37641,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":370,/"line_end/":375,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -28669,7 +37661,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":377,/"line_end/":382,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -28682,7 +37681,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":384,/"line_end/":389,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -28695,7 +37701,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":391,/"line_end/":396,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -28708,7 +37721,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":398,/"line_end/":405,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -28721,7 +37741,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":407,/"line_end/":414,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -28734,7 +37761,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":416,/"line_end/":421,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -28747,7 +37781,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":432,/"line_end/":439,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -28760,7 +37801,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":441,/"line_end/":446,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -28773,7 +37821,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":448,/"line_end/":457,/"column_start/":1,/"column_end/":17}}"
+          }
+        ]
+      }
     }
   ]
 }

--- a/pkg/lockfile/cpp/parse-conan-lock-v1-revisions_test.go
+++ b/pkg/lockfile/cpp/parse-conan-lock-v1-revisions_test.go
@@ -2,7 +2,10 @@ package cpp_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/cpp"
@@ -49,7 +52,7 @@ func TestParseConanLock_v1_revisions_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -68,7 +71,7 @@ func TestParseConanLock_v1_revisions_NoName(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -87,7 +90,7 @@ func TestParseConanLock_v1_revisions_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -112,7 +115,7 @@ func TestParseConanLock_v1_revisions_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.13",
@@ -155,7 +158,7 @@ func TestParseConanLock_v1_revisions_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ninja",
 			Version:        "1.11.1",
@@ -163,4 +166,40 @@ func TestParseConanLock_v1_revisions_OnePackageDev(t *testing.T) {
 			Ecosystem:      models.EcosystemConanCenter,
 		},
 	})
+}
+
+func TestParseConanLock_v1_revisions_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := cpp.ParseConanLock("../fixtures/conan/two-packages.v1.revisions.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/conan/two-packages.v1.revisions.json")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// Node "1": zlib, lines 14-20, column 7-8
+	zlibPkg := packagesByName["zlib"]
+	assert.Equal(t, absoluteLockfilePath, zlibPkg.BlockLocation.Filename)
+	assert.Equal(t, 14, zlibPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 20, zlibPkg.BlockLocation.Line.End)
+	assert.Equal(t, 7, zlibPkg.BlockLocation.Column.Start)
+	assert.Equal(t, 8, zlibPkg.BlockLocation.Column.End)
+
+	// Node "2": bzip2, lines 21-27, column 7-8
+	bzip2Pkg := packagesByName["bzip2"]
+	assert.Equal(t, absoluteLockfilePath, bzip2Pkg.BlockLocation.Filename)
+	assert.Equal(t, 21, bzip2Pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 27, bzip2Pkg.BlockLocation.Line.End)
+	assert.Equal(t, 7, bzip2Pkg.BlockLocation.Column.Start)
+	assert.Equal(t, 8, bzip2Pkg.BlockLocation.Column.End)
 }

--- a/pkg/lockfile/cpp/parse-conan-lock-v1_test.go
+++ b/pkg/lockfile/cpp/parse-conan-lock-v1_test.go
@@ -2,7 +2,10 @@ package cpp_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/cpp"
@@ -49,7 +52,7 @@ func TestParseConanLock_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -68,7 +71,7 @@ func TestParseConanLock_v1_NoName(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -87,7 +90,7 @@ func TestParseConanLock_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -112,7 +115,7 @@ func TestParseConanLock_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.13",
@@ -155,7 +158,7 @@ func TestParseConanLock_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ninja",
 			Version:        "1.11.1",
@@ -174,7 +177,7 @@ func TestParseConanLock_v1_OldFormat00(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -193,7 +196,7 @@ func TestParseConanLock_v1_OldFormat01(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -212,7 +215,7 @@ func TestParseConanLock_v1_OldFormat02(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -231,7 +234,7 @@ func TestParseConanLock_v1_OldFormat03(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -239,4 +242,40 @@ func TestParseConanLock_v1_OldFormat03(t *testing.T) {
 			Ecosystem:      models.EcosystemConanCenter,
 		},
 	})
+}
+
+func TestParseConanLock_v1_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := cpp.ParseConanLock("../fixtures/conan/two-packages.v1.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/conan/two-packages.v1.json")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// Node "1": zlib, lines 14-20, column 7-8
+	zlibPkg := packagesByName["zlib"]
+	assert.Equal(t, absoluteLockfilePath, zlibPkg.BlockLocation.Filename)
+	assert.Equal(t, 14, zlibPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 20, zlibPkg.BlockLocation.Line.End)
+	assert.Equal(t, 7, zlibPkg.BlockLocation.Column.Start)
+	assert.Equal(t, 8, zlibPkg.BlockLocation.Column.End)
+
+	// Node "2": bzip2, lines 21-27, column 7-8
+	bzip2Pkg := packagesByName["bzip2"]
+	assert.Equal(t, absoluteLockfilePath, bzip2Pkg.BlockLocation.Filename)
+	assert.Equal(t, 21, bzip2Pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 27, bzip2Pkg.BlockLocation.Line.End)
+	assert.Equal(t, 7, bzip2Pkg.BlockLocation.Column.Start)
+	assert.Equal(t, 8, bzip2Pkg.BlockLocation.Column.End)
 }

--- a/pkg/lockfile/cpp/parse-conan-lock-v2_test.go
+++ b/pkg/lockfile/cpp/parse-conan-lock-v2_test.go
@@ -2,7 +2,10 @@ package cpp_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/cpp"
@@ -49,7 +52,7 @@ func TestParseConanLock_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -69,7 +72,7 @@ func TestParseConanLock_v2_NoName(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -89,7 +92,7 @@ func TestParseConanLock_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -116,7 +119,7 @@ func TestParseConanLock_v2_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.13",
@@ -164,7 +167,7 @@ func TestParseConanLock_v2_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ninja",
 			Version:        "1.11.1",
@@ -173,4 +176,36 @@ func TestParseConanLock_v2_OnePackageDev(t *testing.T) {
 			DepGroups:      []string{"build-requires"},
 		},
 	})
+}
+
+func TestParseConanLock_v2_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := cpp.ParseConanLock("../fixtures/conan/two-packages.v2.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/conan/two-packages.v2.json")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// zlib on line 4: "zlib/1.2.11#ffa77daf83a57094149707928bdce823%1667396813.184"
+	zlibPkg := packagesByName["zlib"]
+	assert.Equal(t, absoluteLockfilePath, zlibPkg.BlockLocation.Filename)
+	assert.Equal(t, 4, zlibPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 4, zlibPkg.BlockLocation.Line.End)
+
+	// bzip2 on line 5: "bzip2/1.0.8#464be69744fa6d48ed01928cfe470008%1666580345.213"
+	bzip2Pkg := packagesByName["bzip2"]
+	assert.Equal(t, absoluteLockfilePath, bzip2Pkg.BlockLocation.Filename)
+	assert.Equal(t, 5, bzip2Pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 5, bzip2Pkg.BlockLocation.Line.End)
 }

--- a/pkg/lockfile/cpp/parse-conan-lock.go
+++ b/pkg/lockfile/cpp/parse-conan-lock.go
@@ -1,11 +1,14 @@
 package cpp
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -103,11 +106,11 @@ func parseConanRenference(ref string) ConanReference {
 	return reference
 }
 
-func parseConanV1Lock(sourceFile ConanLockFile) []lockfile.PackageDetails {
+func parseConanV1Lock(sourceFile ConanLockFile, positions map[string]*models.FilePosition, filePath string) []lockfile.PackageDetails {
 	var reference ConanReference
 	packages := make([]lockfile.PackageDetails, 0, len(sourceFile.GraphLock.Nodes))
 
-	for _, node := range sourceFile.GraphLock.Nodes {
+	for nodeID, node := range sourceFile.GraphLock.Nodes {
 		if node.Path != "" {
 			// a local "conanfile.txt", skip
 			continue
@@ -126,18 +129,27 @@ func parseConanV1Lock(sourceFile ConanLockFile) []lockfile.PackageDetails {
 		if reference.Name == "" {
 			continue
 		}
-		packages = append(packages, lockfile.PackageDetails{
+
+		pkg := lockfile.PackageDetails{
 			Name:           reference.Name,
 			Version:        reference.Version,
 			PackageManager: conanPackageManager,
 			Ecosystem:      models.EcosystemConanCenter,
-		})
+		}
+
+		if pos, ok := positions[nodeID]; ok {
+			blockLocation := *pos
+			blockLocation.Filename = filePath
+			pkg.BlockLocation = blockLocation
+		}
+
+		packages = append(packages, pkg)
 	}
 
 	return packages
 }
 
-func parseConanRequires(packages *[]lockfile.PackageDetails, requires []string, group string) {
+func parseConanRequires(packages *[]lockfile.PackageDetails, requires []string, group string, lines []string, filePath string) {
 	for _, ref := range requires {
 		reference := parseConanRenference(ref)
 		// skip entries with no name, they are most likely consumer's conanfiles
@@ -146,36 +158,52 @@ func parseConanRequires(packages *[]lockfile.PackageDetails, requires []string, 
 			continue
 		}
 
-		*packages = append(*packages, lockfile.PackageDetails{
+		pkg := lockfile.PackageDetails{
 			Name:           reference.Name,
 			Version:        reference.Version,
 			PackageManager: conanPackageManager,
 			Ecosystem:      models.EcosystemConanCenter,
 			DepGroups:      []string{group},
-		})
+		}
+
+		// Find the line containing this exact reference string
+		pos := fileposition.ExtractDelimitedStringPositionInBlock(lines, ref, 1, "\"", "\"")
+		if pos != nil {
+			pos.Filename = filePath
+			pkg.BlockLocation = *pos
+		}
+
+		*packages = append(*packages, pkg)
 	}
 }
 
-func parseConanV2Lock(sourceFile ConanLockFile) []lockfile.PackageDetails {
+func parseConanV2Lock(sourceFile ConanLockFile, lines []string, filePath string) []lockfile.PackageDetails {
 	packages := make(
 		[]lockfile.PackageDetails,
 		0,
 		uint64(len(sourceFile.Requires))+uint64(len(sourceFile.BuildRequires))+uint64(len(sourceFile.PythonRequires)),
 	)
 
-	parseConanRequires(&packages, sourceFile.Requires, "requires")
-	parseConanRequires(&packages, sourceFile.BuildRequires, "build-requires")
-	parseConanRequires(&packages, sourceFile.PythonRequires, "python-requires")
+	parseConanRequires(&packages, sourceFile.Requires, "requires", lines, filePath)
+	parseConanRequires(&packages, sourceFile.BuildRequires, "build-requires", lines, filePath)
+	parseConanRequires(&packages, sourceFile.PythonRequires, "python-requires", lines, filePath)
 
 	return packages
 }
 
-func parseConanLock(lockfile ConanLockFile) []lockfile.PackageDetails {
+func parseConanLock(lockfile ConanLockFile, lines []string, filePath string) []lockfile.PackageDetails {
 	if lockfile.GraphLock.Nodes != nil {
-		return parseConanV1Lock(lockfile)
+		positions := make(map[string]*models.FilePosition, len(lockfile.GraphLock.Nodes))
+		for nodeID := range lockfile.GraphLock.Nodes {
+			positions[nodeID] = &models.FilePosition{}
+		}
+
+		fileposition.InJSON("nodes", positions, lines, 0)
+
+		return parseConanV1Lock(lockfile, positions, filePath)
 	}
 
-	return parseConanV2Lock(lockfile)
+	return parseConanV2Lock(lockfile, lines, filePath)
 }
 
 type ConanLockExtractor struct{}
@@ -195,12 +223,19 @@ func (e ConanLockExtractor) PackageManager() models.PackageManager {
 func (e ConanLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *ConanLockFile
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
-	return parseConanLock(*parsedLockfile), nil
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	return parseConanLock(*parsedLockfile, lines, f.Path()), nil
 }
 
 var _ lockfile.Extractor = ConanLockExtractor{}

--- a/pkg/lockfile/dart/parse-pubspec-lock.go
+++ b/pkg/lockfile/dart/parse-pubspec-lock.go
@@ -1,12 +1,14 @@
 package dart
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -86,10 +88,108 @@ func (e PubspecLockExtractor) PackageManager() models.PackageManager {
 	return pubsecPackageManager
 }
 
+// extractPubspecPackagePositions scans YAML lines for package entries under "packages:".
+// Package names appear at 2-space indent (e.g. "  shelf:"), and their blocks extend
+// until the next entry at the same or lesser indent level.
+func extractPubspecPackagePositions(lines []string) map[string]models.FilePosition {
+	positions := make(map[string]models.FilePosition)
+
+	inPackages := false
+	var currentName string
+	var startLine int
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		// Detect the "packages:" top-level key
+		if strings.TrimSpace(line) == "packages:" {
+			inPackages = true
+
+			continue
+		}
+
+		if !inPackages {
+			continue
+		}
+
+		// Check if we've left the packages section (non-indented, non-empty line)
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// A line with no leading spaces means we've exited the packages block
+		if len(line) > 0 && line[0] != ' ' {
+			// Close current package if any
+			if currentName != "" {
+				pos := positions[currentName]
+				pos.Line.End = i // previous line (1-indexed)
+				pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[i-1])
+				positions[currentName] = pos
+				currentName = ""
+			}
+
+			inPackages = false
+
+			continue
+		}
+
+		// 2-space indent: package name (e.g. "  shelf:")
+		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' && strings.HasSuffix(trimmed, ":") {
+			// Close previous package
+			if currentName != "" {
+				pos := positions[currentName]
+				pos.Line.End = i // previous line (1-indexed)
+				pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[i-1])
+				positions[currentName] = pos
+			}
+
+			pkgName := strings.TrimSuffix(trimmed, ":")
+			currentName = pkgName
+			startLine = lineNum
+
+			colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+
+			positions[currentName] = models.FilePosition{
+				Line:   models.Position{Start: startLine, End: 0}, // End will be set when block closes
+				Column: models.Position{Start: colStart, End: 0},
+			}
+
+			continue
+		}
+	}
+
+	// Close last package if file ended within packages section
+	if currentName != "" {
+		pos := positions[currentName]
+		lastIdx := len(lines) - 1
+		// Find last non-empty line
+		for lastIdx >= 0 && strings.TrimSpace(lines[lastIdx]) == "" {
+			lastIdx--
+		}
+
+		if lastIdx >= 0 {
+			pos.Line.End = lastIdx + 1
+			pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastIdx])
+		} else {
+			pos.Line.End = pos.Line.Start
+		}
+
+		positions[currentName] = pos
+	}
+
+	return positions
+}
+
 func (e PubspecLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PubspecLockfile
 
-	err := yaml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = yaml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil && !errors.Is(err, io.EOF) {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -97,6 +197,9 @@ func (e PubspecLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanC
 	if parsedLockfile == nil {
 		return []lockfile.PackageDetails{}, nil
 	}
+
+	lines := fileposition.BytesToLines(content)
+	positions := extractPubspecPackagePositions(lines)
 
 	packages := make([]lockfile.PackageDetails, 0, len(parsedLockfile.Packages))
 
@@ -114,6 +217,12 @@ func (e PubspecLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanC
 				break
 			}
 		}
+
+		if pos, ok := positions[name]; ok {
+			pos.Filename = f.Path()
+			pkgDetails.BlockLocation = pos
+		}
+
 		packages = append(packages, pkgDetails)
 	}
 

--- a/pkg/lockfile/dart/parse-pubspec-lock_test.go
+++ b/pkg/lockfile/dart/parse-pubspec-lock_test.go
@@ -2,7 +2,10 @@ package dart_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/dart"
@@ -112,7 +115,7 @@ func TestParsePubspecLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "back_button_interceptor",
 			Version:        "6.0.1",
@@ -131,7 +134,7 @@ func TestParsePubspecLock_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "build_runner",
 			Version:        "2.2.1",
@@ -151,7 +154,7 @@ func TestParsePubspecLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "shelf",
 			Version:        "1.3.2",
@@ -176,7 +179,7 @@ func TestParsePubspecLock_MixedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "back_button_interceptor",
 			Version:        "6.0.1",
@@ -214,7 +217,7 @@ func TestParsePubspecLock_PackageWithGitSource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "flutter_rust_bridge",
 			Version:        "1.32.0",
@@ -262,7 +265,7 @@ func TestParsePubspecLock_PackageWithSdkSource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "flutter_web_plugins",
 			Version:        "0.0.0",
@@ -282,7 +285,7 @@ func TestParsePubspecLock_PackageWithPathSource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "maa_core",
 			Version:        "0.0.1",
@@ -291,4 +294,36 @@ func TestParsePubspecLock_PackageWithPathSource(t *testing.T) {
 			Commit:         "",
 		},
 	})
+}
+
+func TestParsePubspecLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := dart.ParsePubspecLock("../fixtures/pub/two-packages.lock")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/pub/two-packages.lock")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// shelf: lines 4-10
+	shelfPkg := packagesByName["shelf"]
+	assert.Equal(t, absoluteLockfilePath, shelfPkg.BlockLocation.Filename)
+	assert.Equal(t, 4, shelfPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 10, shelfPkg.BlockLocation.Line.End)
+
+	// shelf_web_socket: lines 11-17
+	swsPkg := packagesByName["shelf_web_socket"]
+	assert.Equal(t, absoluteLockfilePath, swsPkg.BlockLocation.Filename)
+	assert.Equal(t, 11, swsPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 17, swsPkg.BlockLocation.Line.End)
 }

--- a/pkg/lockfile/dotnet/parse-nuget-lock-v1_test.go
+++ b/pkg/lockfile/dotnet/parse-nuget-lock-v1_test.go
@@ -390,6 +390,7 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 				Column:   models.Position{Start: 7, End: 8},
 				Filename: absoluteLockfilePath,
 			},
+			LocationRole: models.LocationRoleLockfile,
 		},
 		{
 			Name:             "Newtonsoft.Json",
@@ -427,6 +428,7 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 				Column:   models.Position{Start: 7, End: 8},
 				Filename: absoluteLockfilePath,
 			},
+			LocationRole: models.LocationRoleLockfile,
 		},
 	})
 }

--- a/pkg/lockfile/dotnet/parse-nuget-lock-v1_test.go
+++ b/pkg/lockfile/dotnet/parse-nuget-lock-v1_test.go
@@ -55,7 +55,7 @@ func TestParseNuGetLock_v1_OneFramework_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -74,7 +74,7 @@ func TestParseNuGetLock_v1_OneFramework_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -92,6 +92,36 @@ func TestParseNuGetLock_v1_OneFramework_TwoPackages(t *testing.T) {
 	})
 }
 
+func TestParseNuGetLock_v1_OneFramework_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := dotnet.ParseNuGetLock("../fixtures/nuget/one-framework-two-packages/packages.lock.json")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	// Test.Core block: lines 5-10 within "net6.0" framework
+	testCore := packagesByName["Test.Core"]
+	assert.Equal(t, 5, testCore.BlockLocation.Line.Start)
+	assert.Equal(t, 10, testCore.BlockLocation.Line.End)
+	assert.Equal(t, 7, testCore.BlockLocation.Column.Start)
+	assert.Equal(t, 8, testCore.BlockLocation.Column.End)
+	assert.Contains(t, testCore.BlockLocation.Filename, "one-framework-two-packages")
+
+	// Test.System block: lines 11-19 within "net6.0" framework
+	testSystem := packagesByName["Test.System"]
+	assert.Equal(t, 11, testSystem.BlockLocation.Line.Start)
+	assert.Equal(t, 19, testSystem.BlockLocation.Line.End)
+	assert.Equal(t, 7, testSystem.BlockLocation.Column.Start)
+	assert.Equal(t, 8, testSystem.BlockLocation.Column.End)
+	assert.Contains(t, testSystem.BlockLocation.Filename, "one-framework-two-packages")
+}
+
 func TestParseNuGetLock_v1_TwoFrameworks_MixedPackages(t *testing.T) {
 	t.Parallel()
 
@@ -100,7 +130,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_MixedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -133,7 +163,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_DifferentPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -159,7 +189,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_DuplicatePackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -202,7 +232,7 @@ func TestParseNuGetLock_v1_OneFramework_OnePackage_MatchedFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -318,6 +348,11 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/nuget/multiple-versions-with-lockfile/packages.lock.json")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
 	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:             "Newtonsoft.Json",
@@ -350,7 +385,11 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      models.EcosystemNuGet,
 			IsDirect:       true,
-			BlockLocation:  models.FilePosition{},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 5, End: 13},
+				Column:   models.Position{Start: 7, End: 8},
+				Filename: absoluteLockfilePath,
+			},
 		},
 		{
 			Name:             "Newtonsoft.Json",
@@ -383,7 +422,11 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      models.EcosystemNuGet,
 			IsDirect:       false,
-			BlockLocation:  models.FilePosition{},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 20, End: 24},
+				Column:   models.Position{Start: 7, End: 8},
+				Filename: absoluteLockfilePath,
+			},
 		},
 	})
 }

--- a/pkg/lockfile/dotnet/parse-nuget-lock.go
+++ b/pkg/lockfile/dotnet/parse-nuget-lock.go
@@ -1,45 +1,74 @@
 package dotnet
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"maps"
 )
 
-func parseNuGetLockDependencies(dependencies map[string]NuGetLockPackage) map[string]lockfile.PackageDetails {
+func parseNuGetLockDependencies(
+	dependencies map[string]NuGetLockPackage,
+	positions map[string]*models.FilePosition,
+	filePath string,
+) map[string]lockfile.PackageDetails {
 	details := map[string]lockfile.PackageDetails{}
 
 	for name, dependency := range dependencies {
 		if strings.EqualFold(dependency.Type, projectDependencyType) {
 			continue
 		}
-		details[name+"@"+dependency.Resolved] = lockfile.PackageDetails{
+		pkgDetails := lockfile.PackageDetails{
 			Name:           name,
 			Version:        dependency.Resolved,
 			PackageManager: nugetPackageManager,
 			Ecosystem:      models.EcosystemNuGet,
 			IsDirect:       dependency.Type == "Direct",
 		}
+		if pos, ok := positions[name]; ok {
+			blockLocation := *pos
+			blockLocation.Filename = filePath
+			pkgDetails.BlockLocation = blockLocation
+		}
+		details[name+"@"+dependency.Resolved] = pkgDetails
 	}
 
 	return details
 }
 
-func parseNuGetLock(file NuGetLockfile) ([]lockfile.PackageDetails, error) {
+func parseNuGetLock(
+	file NuGetLockfile,
+	lines []string,
+	filePath string,
+) ([]lockfile.PackageDetails, error) {
 	details := map[string]lockfile.PackageDetails{}
 
 	// go through the dependencies for each framework, e.g. `net6.0` and parse
 	// its dependencies, there might be different or duplicate dependencies
-	// between frameworks
-	for _, dependencies := range file.Dependencies {
-		maps.Copy(details, parseNuGetLockDependencies(dependencies))
+	// between frameworks.
+	// Sort framework names so that when the same package appears in multiple
+	// frameworks, the first framework alphabetically wins (deterministic output).
+	frameworkNames := slices.Sorted(maps.Keys(file.Dependencies))
+	for _, frameworkName := range frameworkNames {
+		dependencies := file.Dependencies[frameworkName]
+		// Build position map for this framework's packages
+		positions := make(map[string]*models.FilePosition, len(dependencies))
+		for name := range dependencies {
+			positions[name] = &models.FilePosition{}
+		}
+
+		fileposition.InJSON(frameworkName, positions, lines, 0)
+
+		maps.Copy(details, parseNuGetLockDependencies(dependencies, positions, filePath))
 	}
 
 	return slices.Collect(maps.Values(details)), nil
@@ -60,7 +89,12 @@ func (e NuGetLockExtractor) PackageManager() models.PackageManager {
 func (e NuGetLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *NuGetLockfile
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
@@ -69,7 +103,9 @@ func (e NuGetLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCon
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract: unsupported lock file version %d", parsedLockfile.Version)
 	}
 
-	return parseNuGetLock(*parsedLockfile)
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	return parseNuGetLock(*parsedLockfile, lines, f.Path())
 }
 
 var NuGetExtractor = NuGetLockExtractor{

--- a/pkg/lockfile/dotnet/parse-nuget-lock.go
+++ b/pkg/lockfile/dotnet/parse-nuget-lock.go
@@ -38,6 +38,7 @@ func parseNuGetLockDependencies(
 			blockLocation := *pos
 			blockLocation.Filename = filePath
 			pkgDetails.BlockLocation = blockLocation
+			pkgDetails.LocationRole = models.LocationRoleLockfile
 		}
 		details[name+"@"+dependency.Resolved] = pkgDetails
 	}

--- a/pkg/lockfile/elixir/parse-mix-lock.go
+++ b/pkg/lockfile/elixir/parse-mix-lock.go
@@ -34,10 +34,12 @@ func (e MixLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 	re := cachedregexp.MustCompile(`^ +"(\w+)": \{.+,$`)
 
 	scanner := bufio.NewScanner(f)
+	lineNumber := 0
 
 	var packages []lockfile.PackageDetails
 
 	for scanner.Scan() {
+		lineNumber++
 		line := scanner.Text()
 
 		match := re.FindStringSubmatch(line)
@@ -79,6 +81,11 @@ func (e MixLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 			PackageManager: mixPackageManager,
 			Ecosystem:      models.EcosystemHex,
 			Commit:         commit,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: lineNumber, End: lineNumber},
+				Column:   models.Position{Start: 1, End: len(line) + 1},
+				Filename: f.Path(),
+			},
 		})
 	}
 

--- a/pkg/lockfile/elixir/parse-mix-lock_test.go
+++ b/pkg/lockfile/elixir/parse-mix-lock_test.go
@@ -122,13 +122,13 @@ func TestParseMixLock_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
 			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.End,
 			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
 			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.End,
 			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
 		assert.NotEmpty(t, pkg.BlockLocation.Filename,
 			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)

--- a/pkg/lockfile/elixir/parse-mix-lock_test.go
+++ b/pkg/lockfile/elixir/parse-mix-lock_test.go
@@ -2,6 +2,8 @@ package elixir_test
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/elixir"
@@ -10,6 +12,8 @@ import (
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMixLockExtractor_ShouldExtract(t *testing.T) {
@@ -93,7 +97,7 @@ func TestParseMixLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "plug",
 			Version:        "1.11.1",
@@ -102,6 +106,33 @@ func TestParseMixLock_OnePackage(t *testing.T) {
 			Commit:         "f2992bac66fdae679453c9e86134a4201f6f43a687d8ff1cd1b2862d53c80259",
 		},
 	})
+}
+
+func TestParseMixLock_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/mix/one-package.lock"))
+	packages, err := elixir.ParseMixLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
 }
 
 func TestParseMixLock_TwoPackages(t *testing.T) {
@@ -113,7 +144,7 @@ func TestParseMixLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "plug",
 			Version:        "1.11.1",
@@ -140,7 +171,7 @@ func TestParseMixLock_Many(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "backoff",
 			Version:        "1.1.6",
@@ -300,7 +331,7 @@ func TestParseMixLock_GitPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "foe",
 			Version:        "",

--- a/pkg/lockfile/java/parse-gradle-lock.go
+++ b/pkg/lockfile/java/parse-gradle-lock.go
@@ -82,6 +82,7 @@ func (e GradleLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCo
 			Column:   models.Position{Start: 1, End: len(scanner.Text()) + 1},
 			Filename: f.Path(),
 		}
+		pkg.LocationRole = models.LocationRoleLockfile
 
 		pkgs = append(pkgs, pkg)
 	}

--- a/pkg/lockfile/java/parse-gradle-lock.go
+++ b/pkg/lockfile/java/parse-gradle-lock.go
@@ -63,8 +63,10 @@ func (e GradleLockExtractor) PackageManager() models.PackageManager {
 func (e GradleLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	pkgs := make([]lockfile.PackageDetails, 0)
 	scanner := bufio.NewScanner(f)
+	lineNumber := 0
 
 	for scanner.Scan() {
+		lineNumber++
 		lockLine := strings.TrimSpace(scanner.Text())
 		if !isGradleLockFileDepLine(lockLine) {
 			continue
@@ -73,6 +75,12 @@ func (e GradleLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCo
 		pkg, err := parseToGradlePackageDetail(lockLine)
 		if err != nil {
 			continue
+		}
+
+		pkg.BlockLocation = models.FilePosition{
+			Line:     models.Position{Start: lineNumber, End: lineNumber},
+			Column:   models.Position{Start: 1, End: len(scanner.Text()) + 1},
+			Filename: f.Path(),
 		}
 
 		pkgs = append(pkgs, pkg)

--- a/pkg/lockfile/java/parse-gradle-lock_test.go
+++ b/pkg/lockfile/java/parse-gradle-lock_test.go
@@ -152,6 +152,34 @@ func TestParseGradleLock_OnePackage(t *testing.T) {
 }
 
 //nolint:paralleltest
+func TestParseGradleLock_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/gradle-lockfile/one-pkg"))
+	packages, err := java.ParseGradleLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
+}
+
+//nolint:paralleltest
 func TestParseGradleLock_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/pkg/lockfile/java/parse-gradle-lock_test.go
+++ b/pkg/lockfile/java/parse-gradle-lock_test.go
@@ -151,7 +151,6 @@ func TestParseGradleLock_OnePackage(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest
 func TestParseGradleLock_OnePackage_BlockLocation(t *testing.T) {
 	t.Parallel()
 	dir, err := os.Getwd()
@@ -166,13 +165,13 @@ func TestParseGradleLock_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
 			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.End,
 			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
 			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.End,
 			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
 		assert.NotEmpty(t, pkg.BlockLocation.Filename,
 			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)

--- a/pkg/lockfile/java/parse-gradle-verification-metadata.go
+++ b/pkg/lockfile/java/parse-gradle-verification-metadata.go
@@ -111,6 +111,7 @@ func (e GradleVerificationMetadataExtractor) Extract(f lockfile.DepFile, context
 				pos := posList[idx]
 				pos.Filename = f.Path()
 				pkg.BlockLocation = pos
+				pkg.LocationRole = models.LocationRoleLockfile
 				consumed[key] = idx + 1
 			}
 		}

--- a/pkg/lockfile/java/parse-gradle-verification-metadata.go
+++ b/pkg/lockfile/java/parse-gradle-verification-metadata.go
@@ -1,10 +1,15 @@
 package java
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -21,24 +26,96 @@ func (e GradleVerificationMetadataExtractor) PackageManager() models.PackageMana
 	return gradleVerificationPackageManager
 }
 
+// componentKey builds a unique key from a component's attributes for position lookup.
+func componentKey(group, name, version string) string {
+	return group + ":" + name + ":" + version
+}
+
+var componentStartRe = cachedregexp.MustCompile(`<component\s+group="([^"]+)"\s+name="([^"]+)"\s+version="([^"]+)"`)
+
+// extractComponentPositions scans lines for <component> blocks and returns positions keyed by group:name:version.
+// When the same group:name:version appears multiple times (multiple versions scenario),
+// we store positions in order and consume them sequentially.
+func extractComponentPositions(lines []string) map[string][]models.FilePosition {
+	positions := make(map[string][]models.FilePosition)
+
+	for i, line := range lines {
+		matches := componentStartRe.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		group, name, version := matches[1], matches[2], matches[3]
+		key := componentKey(group, name, version)
+		lineNum := i + 1 // 1-indexed
+
+		colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+		colEnd := fileposition.GetLastNonEmptyCharacterIndexInLine(line)
+
+		// Find the end of this component block (</component> or self-closing />)
+		endLine := lineNum
+		if !strings.Contains(line, "/>") {
+			for j := i + 1; j < len(lines); j++ {
+				if strings.Contains(lines[j], "</component>") {
+					endLine = j + 1
+					colEnd = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[j])
+
+					break
+				}
+			}
+		}
+
+		positions[key] = append(positions[key], models.FilePosition{
+			Line:   models.Position{Start: lineNum, End: endLine},
+			Column: models.Position{Start: colStart, End: colEnd},
+		})
+	}
+
+	return positions
+}
+
 func (e GradleVerificationMetadataExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *GradleVerificationMetadataFile
 
-	err := xml.NewDecoder(f).Decode(&parsedLockfile)
-
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
+	err = xml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	lines := fileposition.BytesToLines(content)
+	positions := extractComponentPositions(lines)
+
+	// Track consumption index per key for duplicate group:name:version entries
+	consumed := make(map[string]int)
+
 	pkgs := make([]lockfile.PackageDetails, 0, len(parsedLockfile.Components))
 
 	for _, component := range parsedLockfile.Components {
-		pkgs = append(pkgs, lockfile.PackageDetails{
+		key := componentKey(component.Group, component.Name, component.Version)
+
+		pkg := lockfile.PackageDetails{
 			Name:           component.Group + ":" + component.Name,
 			Version:        component.Version,
 			PackageManager: gradleVerificationPackageManager,
 			Ecosystem:      models.EcosystemMaven,
-		})
+		}
+
+		if posList, ok := positions[key]; ok {
+			idx := consumed[key]
+			if idx < len(posList) {
+				pos := posList[idx]
+				pos.Filename = f.Path()
+				pkg.BlockLocation = pos
+				consumed[key] = idx + 1
+			}
+		}
+
+		pkgs = append(pkgs, pkg)
 	}
 
 	return pkgs, nil

--- a/pkg/lockfile/java/parse-gradle-verification-metadata_test.go
+++ b/pkg/lockfile/java/parse-gradle-verification-metadata_test.go
@@ -133,7 +133,7 @@ func TestParseGradleVerificationMetadata_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "org.apache.pdfbox:pdfbox",
 			Version:        "2.0.17",
@@ -200,7 +200,7 @@ func TestParseGradleVerificationMetadata_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "org.apache.pdfbox:pdfbox",
 			Version:        "2.0.17",
@@ -225,7 +225,7 @@ func TestParseGradleVerificationMetadata_MultipleVersions(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "androidx.activity:activity",
 			Version:        "1.2.1",
@@ -346,7 +346,7 @@ func TestParseGradleVerificationMetadata_Complex(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "com.google:google",
 			Version:        "1",
@@ -744,4 +744,36 @@ func TestParseGradleVerificationMetadata_Complex(t *testing.T) {
 			Ecosystem:      models.EcosystemMaven,
 		},
 	})
+}
+
+func TestParseGradleVerificationMetadata_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := java.ParseGradleVerificationMetadata("../fixtures/gradle-verification-metadata/two-packages.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/gradle-verification-metadata/two-packages.xml")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// pdfbox: <component> on line 10, </component> on line 17
+	pdfboxPkg := packagesByName["org.apache.pdfbox:pdfbox"]
+	assert.Equal(t, absoluteLockfilePath, pdfboxPkg.BlockLocation.Filename)
+	assert.Equal(t, 10, pdfboxPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 17, pdfboxPkg.BlockLocation.Line.End)
+
+	// javaparser-core: <component> on line 18, </component> on line 22
+	javaparserPkg := packagesByName["com.github.javaparser:javaparser-core"]
+	assert.Equal(t, absoluteLockfilePath, javaparserPkg.BlockLocation.Filename)
+	assert.Equal(t, 18, javaparserPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 22, javaparserPkg.BlockLocation.Line.End)
 }

--- a/pkg/lockfile/java/parse-maven-install.go
+++ b/pkg/lockfile/java/parse-maven-install.go
@@ -65,7 +65,7 @@ func extractMavenInstallArtifacts(installFile mavenInstallLockfile, contentBytes
 		return []lockfile.PackageDetails{}, err
 	}
 
-	lines := strings.Split(string(contentBytes), "\n")
+	lines := strings.Split(strings.ReplaceAll(string(contentBytes), "\r\n", "\n"), "\n")
 	fileposition.InJSON("artifacts", installFile.Artifacts, lines, 0)
 
 	artifactNames := make([]string, 0, len(installFile.Artifacts))

--- a/pkg/lockfile/javascript/match-package-json.go
+++ b/pkg/lockfile/javascript/match-package-json.go
@@ -11,6 +11,7 @@ import (
 
 	jsonUtils "github.com/DataDog/datadog-sbom-generator/internal/json"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/bmatcuk/doublestar/v4"
 )
 
@@ -63,8 +64,8 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 			depGroup = "optional"
 		}
 
-		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.BlockLocation.Line.Start != 0 {
-			// If it is a dev or optional dependency definition and we already found a package location,
+		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.LocationRole == models.LocationRoleManifest {
+			// If it is a dev or optional dependency definition and we already found a manifest location,
 			// we skip it to prioritize non-dev dependencies
 			pkgIndexes = []int{}
 		}

--- a/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
+++ b/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
@@ -396,10 +396,10 @@ func TestParsePnpmLock_v9_MixedGroups_BlockLocation(t *testing.T) {
 
 	// All packages should have BlockLocation set
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
 		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
 	}
 }
@@ -915,10 +915,10 @@ func TestParsePnpmLock_Legacy_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	pkg := packages[0]
-	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0")
 	assert.Equal(t, path, pkg.BlockLocation.Filename)
 
 	// /acorn/8.7.0 is at lines 11-15 in one-package.yaml
@@ -942,10 +942,10 @@ func TestParsePnpmLock_Legacy_MultiplePackages_BlockLocation(t *testing.T) {
 
 	// All packages should have BlockLocation set
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
 		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
 	}
 }

--- a/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
+++ b/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/javascript"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParsePnpmLock_v9_NoPackages(t *testing.T) {
@@ -41,6 +43,46 @@ func TestParsePnpmLock_v9_OnePackage(t *testing.T) {
 			DepGroups:      []string{"prod"},
 		},
 	})
+}
+
+func TestParsePnpmLock_v9_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/one-package.v9.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	if pkg.BlockLocation.Line.Start == 0 {
+		t.Errorf("Expected BlockLocation.Line.Start > 0 for %s, got 0", pkg.Name)
+	}
+	if pkg.BlockLocation.Line.End == 0 {
+		t.Errorf("Expected BlockLocation.Line.End > 0 for %s, got 0", pkg.Name)
+	}
+	if pkg.BlockLocation.Column.Start == 0 {
+		t.Errorf("Expected BlockLocation.Column.Start > 0 for %s, got 0", pkg.Name)
+	}
+	if pkg.BlockLocation.Column.End == 0 {
+		t.Errorf("Expected BlockLocation.Column.End > 0 for %s, got 0", pkg.Name)
+	}
+	if pkg.BlockLocation.Filename != path {
+		t.Errorf("Expected BlockLocation.Filename = %s, got %s", path, pkg.BlockLocation.Filename)
+	}
+
+	// acorn@8.11.3 is at lines 17-20 in one-package.v9.yaml (last non-empty line before "snapshots:")
+	assert.Equal(t, 17, pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 20, pkg.BlockLocation.Line.End)
 }
 
 func TestParsePnpmLock_v9_OnePackageDev(t *testing.T) {
@@ -313,6 +355,90 @@ func TestParsePnpmLock_v9_Commits(t *testing.T) {
 	})
 }
 
+// TestParsePnpmLock_v9_Commits_BlockLocation verifies that git/tarball dependencies
+// (whose packages: key uses a full URL like "ansi-regex@https://codeload.github.com/...")
+// correctly resolve their BlockLocation even though lookupPnpmPosition receives a cleaned
+// semver version, not the raw URL.
+func TestParsePnpmLock_v9_Commits_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/commits.v9.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
+func TestParsePnpmLock_v9_MixedGroups_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/mixed-groups.v9.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// All packages should have BlockLocation set
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
+// TestParsePnpmLock_v9_PeerDependenciesAdvanced_BlockLocation verifies that scoped packages
+// (whose YAML keys are surrounded by single quotes, e.g. '@scope/pkg@1.0.0':) get their
+// BlockLocation correctly populated. This is a regression test for the bug where the single
+// quotes were stored as part of the position map key, causing lookups to miss.
+func TestParsePnpmLock_v9_PeerDependenciesAdvanced_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/peer-dependencies-advanced.v9.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// Packages that appear in the packages: section should all have BlockLocation set.
+	// chalk@4.1.2 only appears in snapshots: (not packages:) so it is the only exception.
+	packagesWithoutPosition := map[string]bool{
+		"chalk@4.1.2": true,
+	}
+
+	for _, pkg := range packages {
+		key := pkg.Name + "@" + pkg.Version
+		if packagesWithoutPosition[key] {
+			continue
+		}
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
 func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 	t.Parallel()
 
@@ -573,6 +699,7 @@ func TestParsePnpmLock_v9_WorkspacesComplex(t *testing.T) {
 	}
 
 	rootPath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/package.json"))
+	lockfilePath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/pnpm-lock.yaml"))
 	workspace1Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/workspace-1/package.json"))
 	workspace2Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/nested/workspace-2/package.json"))
 	workspace3Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/workspace-3/package.json"))
@@ -608,9 +735,13 @@ func TestParsePnpmLock_v9_WorkspacesComplex(t *testing.T) {
 			Version:        "1.4.0",
 			PackageManager: models.Pnpm,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 45, End: 47},
+				Column:   models.Position{Start: 3, End: 32},
+				Filename: lockfilePath,
+			},
+			IsDirect:  false, // is a dependency of group-dependencies@0.0.11
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:           "semver",
@@ -763,4 +894,58 @@ func TestParsePnpmLock_v9_WorkspacesComplex(t *testing.T) {
 			DepGroups: []string{"prod", "prod"},
 		},
 	})
+}
+
+func TestParsePnpmLock_Legacy_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/one-package.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Equal(t, path, pkg.BlockLocation.Filename)
+
+	// /acorn/8.7.0 is at lines 11-15 in one-package.yaml
+	assert.Equal(t, 11, pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 15, pkg.BlockLocation.Line.End)
+}
+
+func TestParsePnpmLock_Legacy_MultiplePackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/multiple-packages.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// All packages should have BlockLocation set
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
 }

--- a/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
+++ b/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
@@ -740,8 +740,9 @@ func TestParsePnpmLock_v9_WorkspacesComplex(t *testing.T) {
 				Column:   models.Position{Start: 3, End: 32},
 				Filename: lockfilePath,
 			},
-			IsDirect:  false, // is a dependency of group-dependencies@0.0.11
-			DepGroups: []string{"dev"},
+			LocationRole: models.LocationRoleLockfile,
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-pnpm-v9-lock.go
+++ b/pkg/lockfile/javascript/parse-pnpm-v9-lock.go
@@ -1,6 +1,7 @@
 package javascript
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"maps"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -74,7 +76,7 @@ func addDependencyToPackageDetails(dependency lockfile.PackageDetails, packageId
 	return deps
 }
 
-func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, targetedKey string, deps map[string]lockfile.PackageDetails) map[string]lockfile.PackageDetails {
+func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, targetedKey string, deps map[string]lockfile.PackageDetails, positions map[string]models.FilePosition, filePath string) map[string]lockfile.PackageDetails {
 	// Need to look at dependencies
 	visitedSnapshots := make(map[string]bool)
 	snapshotQueue := make([]string, 0)
@@ -96,14 +98,16 @@ func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, t
 		}
 
 		for depName, depVersion := range snapshot.Dependencies {
+			version := getCleanedVersion(sourceFile, depName, depVersion)
 			transitiveDep := lockfile.PackageDetails{
 				Name:           depName,
-				Version:        getCleanedVersion(sourceFile, depName, depVersion),
+				Version:        version,
 				Commit:         getCommitFromVersion(depVersion),
 				Ecosystem:      models.EcosystemNPM,
 				DepGroups:      root.Pkg.DepGroups,
 				PackageManager: models.Pnpm,
 				IsDirect:       false,
+				BlockLocation:  lookupPnpmPosition(depName, version, depVersion, filePath, positions),
 			}
 			addDependencyToPackageDetails(transitiveDep, getPnpmDependencyKey(transitiveDep), deps)
 			childKey := depName + "@" + depVersion
@@ -111,14 +115,16 @@ func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, t
 		}
 
 		for depName, depVersion := range snapshot.OptionalDependencies {
+			version := getCleanedVersion(sourceFile, depName, depVersion)
 			transitiveDep := lockfile.PackageDetails{
 				Name:           depName,
-				Version:        getCleanedVersion(sourceFile, depName, depVersion),
+				Version:        version,
 				Commit:         getCommitFromVersion(depVersion),
 				Ecosystem:      models.EcosystemNPM,
 				DepGroups:      root.Pkg.DepGroups,
 				PackageManager: models.Pnpm,
 				IsDirect:       false,
+				BlockLocation:  lookupPnpmPosition(depName, version, depVersion, filePath, positions),
 			}
 			addDependencyToPackageDetails(transitiveDep, getPnpmDependencyKey(transitiveDep), deps)
 			childKey := depName + "@" + depVersion
@@ -129,17 +135,19 @@ func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, t
 	return deps
 }
 
-func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDependency, dependencies PnpmDependencies, depGroup string, workspacePath string) []PnpmDirectDependency {
+func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDependency, dependencies PnpmDependencies, depGroup string, workspacePath string, positions map[string]models.FilePosition, filePath string) []PnpmDirectDependency {
 	for dependencyName, dependency := range dependencies {
 		var nameLocation *models.FilePosition
 		if workspacePath != "" && workspacePath != "." {
 			nameLocation = &models.FilePosition{Filename: workspacePath}
 		}
 
+		version := getCleanedVersion(sourceFile, dependencyName, dependency.Version)
+
 		roots = append(roots, PnpmDirectDependency{
 			Pkg: lockfile.PackageDetails{
 				Name:           dependencyName,
-				Version:        getCleanedVersion(sourceFile, dependencyName, dependency.Version),
+				Version:        version,
 				Commit:         getCommitFromVersion(dependency.Version),
 				TargetVersions: []string{dependency.Specifier},
 				Ecosystem:      models.EcosystemNPM,
@@ -147,6 +155,7 @@ func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDepend
 				PackageManager: models.Pnpm,
 				IsDirect:       true,
 				NameLocation:   nameLocation,
+				BlockLocation:  lookupPnpmPosition(dependencyName, version, dependency.Version, filePath, positions),
 			},
 			Dep:           dependency,
 			WorkspacePath: workspacePath,
@@ -156,7 +165,51 @@ func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDepend
 	return roots
 }
 
-func parsePnpmLock(sourceFile PnpmLockfile) []lockfile.PackageDetails {
+// lookupPnpmPosition resolves the FilePosition for a package in the positions map.
+// It tries, in order:
+//  1. Exact key "name@version" (common case).
+//  2. Raw version key "name@rawVersion" for git/tarball deps where the packages: section
+//     stores the full URL (e.g. "ansi-regex@https://codeload.github.com/...") but the
+//     caller has already cleaned the version to a semver.
+//  3. Prefix match "name@version(" for peer-suffixed keys (e.g. "tsutils@3.21.0(typescript@4.9.5)").
+//     When multiple peer variants exist for the same base version, picks the earliest by line number.
+func lookupPnpmPosition(name, version, rawVersion, filePath string, positions map[string]models.FilePosition) models.FilePosition {
+	key := name + "@" + version
+	if pos, ok := positions[key]; ok {
+		pos.Filename = filePath
+		return pos
+	}
+
+	// Fallback for git/tarball deps: try the raw (pre-cleaning) version.
+	if rawVersion != version {
+		rawKey := name + "@" + rawVersion
+		if pos, ok := positions[rawKey]; ok {
+			pos.Filename = filePath
+			return pos
+		}
+	}
+
+	// Fallback for peer-suffixed keys (e.g. "tsutils@3.21.0(typescript@4.9.5)").
+	// When multiple peer variants exist for the same base version, pick the earliest by line number.
+	prefix := key + "("
+	var best *models.FilePosition
+	for k, pos := range positions {
+		if strings.HasPrefix(k, prefix) {
+			p := pos
+			if best == nil || p.Line.Start < best.Line.Start {
+				best = &p
+			}
+		}
+	}
+	if best != nil {
+		best.Filename = filePath
+		return *best
+	}
+
+	return models.FilePosition{}
+}
+
+func parsePnpmLock(sourceFile PnpmLockfile, positions map[string]models.FilePosition, filePath string) []lockfile.PackageDetails {
 	// First create the deps tree
 	// To do so, first look at the packages list, for each package, look into the importers
 	// If present in the importers => its direct and we know its scope
@@ -165,15 +218,15 @@ func parsePnpmLock(sourceFile PnpmLockfile) []lockfile.PackageDetails {
 	// Going through the importers to get a direct (prod or dev), then finding the transitives in the snapshot
 	directDependencies := make([]PnpmDirectDependency, 0)
 	for workspacePath, importer := range sourceFile.Importers {
-		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.Dependencies, "prod", workspacePath)
-		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.OptionalDependencies, "optional", workspacePath)
-		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.DevDependencies, "dev", workspacePath)
+		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.Dependencies, "prod", workspacePath, positions, filePath)
+		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.OptionalDependencies, "optional", workspacePath, positions, filePath)
+		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.DevDependencies, "dev", workspacePath, positions, filePath)
 	}
 
 	packages := make(map[string]lockfile.PackageDetails)
 	for _, direct := range directDependencies {
 		packages = addDependencyToPackageDetails(direct.Pkg, getPnpmWorkspaceDependencyKey(direct), packages)
-		packages = extractTransitiveDeps(sourceFile, direct, direct.Pkg.Name+"@"+direct.Dep.Version, packages)
+		packages = extractTransitiveDeps(sourceFile, direct, direct.Pkg.Name+"@"+direct.Dep.Version, packages, positions, filePath)
 	}
 
 	return slices.Collect(maps.Values(packages))
@@ -187,10 +240,120 @@ func getPnpmDependencyKey(pkg lockfile.PackageDetails) string {
 	return getWorkspaceDependencyKey(pkg.Name, pkg.Version, "") // this has no workspace path
 }
 
+// closePnpmBlock closes a package block by finding the last non-empty line before index i.
+func closePnpmBlock(positions map[string]models.FilePosition, key string, beforeIndex int, lines []string) {
+	pos := positions[key]
+	// Find last non-empty line before beforeIndex
+	lastNonEmpty := beforeIndex - 1
+	for lastNonEmpty >= 0 && strings.TrimSpace(lines[lastNonEmpty]) == "" {
+		lastNonEmpty--
+	}
+
+	if lastNonEmpty >= 0 {
+		pos.Line.End = lastNonEmpty + 1 // 1-indexed
+		pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastNonEmpty])
+	} else {
+		pos.Line.End = pos.Line.Start
+	}
+
+	positions[key] = pos
+}
+
+// extractPnpmV9PackagePositions scans YAML lines for package entries under "packages:".
+// Package keys appear at 2-space indent (e.g. "  acorn@8.11.3:"), and their blocks extend
+// until the next entry at the same indent or end of the packages section.
+func extractPnpmV9PackagePositions(lines []string) map[string]models.FilePosition {
+	positions := make(map[string]models.FilePosition)
+
+	inPackages := false
+	var currentKey string
+	var startLine int
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// Detect the "packages:" top-level key
+		if trimmed == "packages:" {
+			inPackages = true
+
+			continue
+		}
+
+		if !inPackages {
+			continue
+		}
+
+		// A line with no leading spaces means we've exited the packages block
+		if len(line) > 0 && line[0] != ' ' {
+			if currentKey != "" {
+				closePnpmBlock(positions, currentKey, i, lines)
+				currentKey = ""
+			}
+
+			inPackages = false
+
+			continue
+		}
+
+		// 2-space indent: package entry (e.g. "  acorn@8.11.3:")
+		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' && strings.HasSuffix(trimmed, ":") {
+			// Close previous package
+			if currentKey != "" {
+				closePnpmBlock(positions, currentKey, i, lines)
+			}
+
+			// Strip trailing ":" and surrounding single quotes (YAML quotes scoped package
+			// names starting with "@", e.g. "'@scope/pkg@1.0.0':" → "@scope/pkg@1.0.0").
+			pkgKey := strings.Trim(strings.TrimSuffix(trimmed, ":"), "'")
+			currentKey = pkgKey
+			startLine = lineNum
+
+			colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+
+			positions[currentKey] = models.FilePosition{
+				Line:   models.Position{Start: startLine, End: 0},
+				Column: models.Position{Start: colStart, End: 0},
+			}
+
+			continue
+		}
+	}
+
+	// Close last package if file ended within packages section
+	if currentKey != "" {
+		pos := positions[currentKey]
+		lastIdx := len(lines) - 1
+		for lastIdx >= 0 && strings.TrimSpace(lines[lastIdx]) == "" {
+			lastIdx--
+		}
+
+		if lastIdx >= 0 {
+			pos.Line.End = lastIdx + 1
+			pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastIdx])
+		} else {
+			pos.Line.End = pos.Line.Start
+		}
+
+		positions[currentKey] = pos
+	}
+
+	return positions
+}
+
 func (e PnpmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PnpmLockfile
 
-	err := yaml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = yaml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil && !errors.Is(err, io.EOF) {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -213,7 +376,10 @@ func (e PnpmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCont
 		return e.extractLegacyPnpm(file)
 	}
 
-	return parsePnpmLock(*parsedLockfile), nil
+	lines := fileposition.BytesToLines(content)
+	positions := extractPnpmV9PackagePositions(lines)
+
+	return parsePnpmLock(*parsedLockfile, positions, f.Path()), nil
 }
 
 var PnpmExtractor = PnpmLockExtractor{

--- a/pkg/lockfile/javascript/parse-pnpm-v9-lock.go
+++ b/pkg/lockfile/javascript/parse-pnpm-v9-lock.go
@@ -108,6 +108,7 @@ func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, t
 				PackageManager: models.Pnpm,
 				IsDirect:       false,
 				BlockLocation:  lookupPnpmPosition(depName, version, depVersion, filePath, positions),
+				LocationRole:   models.LocationRoleLockfile,
 			}
 			addDependencyToPackageDetails(transitiveDep, getPnpmDependencyKey(transitiveDep), deps)
 			childKey := depName + "@" + depVersion
@@ -125,6 +126,7 @@ func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, t
 				PackageManager: models.Pnpm,
 				IsDirect:       false,
 				BlockLocation:  lookupPnpmPosition(depName, version, depVersion, filePath, positions),
+				LocationRole:   models.LocationRoleLockfile,
 			}
 			addDependencyToPackageDetails(transitiveDep, getPnpmDependencyKey(transitiveDep), deps)
 			childKey := depName + "@" + depVersion
@@ -156,6 +158,7 @@ func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDepend
 				IsDirect:       true,
 				NameLocation:   nameLocation,
 				BlockLocation:  lookupPnpmPosition(dependencyName, version, dependency.Version, filePath, positions),
+				LocationRole:   models.LocationRoleLockfile,
 			},
 			Dep:           dependency,
 			WorkspacePath: workspacePath,

--- a/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
@@ -1171,6 +1171,7 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 						Column:   models.Position{Start: 1, End: 108},
 						Filename: lockfilePath,
 					},
+					LocationRole: models.LocationRoleLockfile,
 					Dependencies: make([]*lockfile.PackageDetails, 0),
 				},
 			},
@@ -1186,6 +1187,7 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 				Column:   models.Position{Start: 1, End: 108},
 				Filename: lockfilePath,
 			},
+			LocationRole: models.LocationRoleLockfile,
 			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
 			DepGroups:    []string{"dev"},
 			Dependencies: make([]*lockfile.PackageDetails, 0),

--- a/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
@@ -80,10 +80,10 @@ func TestParseYarnLock_v1_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	pkg := packages[0]
-	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0")
 	assert.Equal(t, path, pkg.BlockLocation.Filename)
 
 	// balanced-match@^1.0.0 block is at lines 5-8 in one-package.v1.lock
@@ -105,10 +105,10 @@ func TestParseYarnLock_v1_TwoPackages_BlockLocation(t *testing.T) {
 	}
 
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
 		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
 	}
 }

--- a/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
@@ -62,6 +62,57 @@ func TestParseYarnLock_v1_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseYarnLock_v1_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/yarn/one-package.v1.lock"))
+	packages, err := javascript.ParseYarnLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Equal(t, path, pkg.BlockLocation.Filename)
+
+	// balanced-match@^1.0.0 block is at lines 5-8 in one-package.v1.lock
+	assert.Equal(t, 5, pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 8, pkg.BlockLocation.Line.End)
+}
+
+func TestParseYarnLock_v1_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/yarn/two-packages.v1.lock"))
+	packages, err := javascript.ParseYarnLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
 //nolint:paralleltest
 func TestParseYarnLock_v1_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()
@@ -1076,6 +1127,7 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
+	lockfilePath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/yarn-v1.lock"))
 	rootPath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/package.json"))
 	workspace1Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/workspace-1/package.json"))
 	workspace2Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/nested/workspace-2/package.json"))
@@ -1114,7 +1166,12 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 					PackageManager: models.Yarn,
 					Ecosystem:      models.EcosystemNPM,
 					DepGroups:      []string{"dev"},
-					Dependencies:   make([]*lockfile.PackageDetails, 0),
+					BlockLocation: models.FilePosition{
+						Line:     models.Position{Start: 5, End: 8},
+						Column:   models.Position{Start: 1, End: 108},
+						Filename: lockfilePath,
+					},
+					Dependencies: make([]*lockfile.PackageDetails, 0),
 				},
 			},
 		},
@@ -1124,10 +1181,14 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 			TargetVersions: []string{"^1.4.0"},
 			PackageManager: models.Yarn,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
-			Dependencies:   make([]*lockfile.PackageDetails, 0),
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 5, End: 8},
+				Column:   models.Position{Start: 1, End: 108},
+				Filename: lockfilePath,
+			},
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
+			Dependencies: make([]*lockfile.PackageDetails, 0),
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
@@ -915,6 +915,7 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 						Column:   models.Position{Start: 1, End: 17},
 						Filename: lockfilePath,
 					},
+					LocationRole: models.LocationRoleLockfile,
 					Dependencies: make([]*lockfile.PackageDetails, 0),
 				},
 			},
@@ -930,6 +931,7 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 				Column:   models.Position{Start: 1, End: 17},
 				Filename: lockfilePath,
 			},
+			LocationRole: models.LocationRoleLockfile,
 			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
 			DepGroups:    []string{"dev"},
 			Dependencies: make([]*lockfile.PackageDetails, 0),

--- a/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
@@ -80,10 +80,10 @@ func TestParseYarnLock_v2_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	pkg := packages[0]
-	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0")
 	assert.Equal(t, path, pkg.BlockLocation.Filename)
 
 	// "balanced-match@npm:^1.0.0" block is at lines 8-13 in one-package.v2.lock
@@ -105,10 +105,10 @@ func TestParseYarnLock_v2_TwoPackages_BlockLocation(t *testing.T) {
 	}
 
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
 		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
 	}
 }

--- a/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
@@ -62,6 +62,57 @@ func TestParseYarnLock_v2_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseYarnLock_v2_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/yarn/one-package.v2.lock"))
+	packages, err := javascript.ParseYarnLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Equal(t, path, pkg.BlockLocation.Filename)
+
+	// "balanced-match@npm:^1.0.0" block is at lines 8-13 in one-package.v2.lock
+	assert.Equal(t, 8, pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 13, pkg.BlockLocation.Line.End)
+}
+
+func TestParseYarnLock_v2_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/yarn/two-packages.v2.lock"))
+	packages, err := javascript.ParseYarnLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
 //nolint:paralleltest
 func TestParseYarnLock_v2_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()
@@ -820,6 +871,7 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
+	lockfilePath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/yarn.lock"))
 	rootPath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/package.json"))
 	workspace1Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/workspace-1/package.json"))
 	workspace2Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/nested/workspace-2/package.json"))
@@ -858,7 +910,12 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 					PackageManager: models.Yarn,
 					Ecosystem:      models.EcosystemNPM,
 					DepGroups:      []string{"dev"},
-					Dependencies:   make([]*lockfile.PackageDetails, 0),
+					BlockLocation: models.FilePosition{
+						Line:     models.Position{Start: 8, End: 13},
+						Column:   models.Position{Start: 1, End: 17},
+						Filename: lockfilePath,
+					},
+					Dependencies: make([]*lockfile.PackageDetails, 0),
 				},
 			},
 		},
@@ -868,10 +925,14 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 			TargetVersions: []string{"^1.4.0"},
 			PackageManager: models.Yarn,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
-			Dependencies:   make([]*lockfile.PackageDetails, 0),
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 8, End: 13},
+				Column:   models.Position{Start: 1, End: 17},
+				Filename: lockfilePath,
+			},
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
+			Dependencies: make([]*lockfile.PackageDetails, 0),
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-yarn-lock.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock.go
@@ -402,6 +402,7 @@ func parseYarnPackage(dependency YarnPackage, filePath string) lockfile.PackageD
 		Commit:         tryExtractCommit(dependency.Resolution),
 		NameLocation:   nameLocation,
 		BlockLocation:  blockLocation,
+		LocationRole:   models.LocationRoleLockfile,
 	}
 }
 

--- a/pkg/lockfile/javascript/parse-yarn-lock.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock.go
@@ -3,7 +3,6 @@ package javascript
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -12,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -53,12 +53,42 @@ func parseYarnPackageBlock(block []string) []YarnPackage {
 	return packages
 }
 
-func groupYarnPackageLines(scanner *bufio.Scanner) []YarnPackage {
+// findLastNonEmptyLineInRange finds the 1-indexed line number of the last non-empty line
+// within the 0-indexed range [startIdx, endIdx].
+func findLastNonEmptyLineInRange(lines []string, startIdx, endIdx int) int {
+	if endIdx >= len(lines) {
+		endIdx = len(lines) - 1
+	}
+
+	for i := endIdx; i >= startIdx; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return i + 1 // 1-indexed
+		}
+	}
+
+	return startIdx + 1
+}
+
+// buildYarnBlockPosition creates a FilePosition from 1-indexed start and end line numbers.
+func buildYarnBlockPosition(lines []string, startLine, endLine int) models.FilePosition {
+	colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(lines[startLine-1])
+	colEnd := fileposition.GetLastNonEmptyCharacterIndexInLine(lines[endLine-1])
+
+	return models.FilePosition{
+		Line:   models.Position{Start: startLine, End: endLine},
+		Column: models.Position{Start: colStart, End: colEnd},
+	}
+}
+
+func groupYarnPackageLines(scanner *bufio.Scanner, lines []string) []YarnPackage {
 	var groups []YarnPackage
 	var group []string
+	var blockStartLine int // 1-indexed line number of block start
 
+	lineNum := 0
 	var line string
 	for scanner.Scan() {
+		lineNum++
 		line = scanner.Text()
 
 		if shouldSkipYarnLine(line) {
@@ -69,9 +99,15 @@ func groupYarnPackageLines(scanner *bufio.Scanner) []YarnPackage {
 		if !strings.HasPrefix(line, " ") {
 			if len(group) > 0 {
 				packages := parseYarnPackageBlock(group)
+				// Set BlockLocation on each package
+				blockEndLine := findLastNonEmptyLineInRange(lines, blockStartLine-1, lineNum-2)
+				for i := range packages {
+					packages[i].BlockLocation = buildYarnBlockPosition(lines, blockStartLine, blockEndLine)
+				}
 				groups = append(groups, packages...)
 			}
 			group = make([]string, 0)
+			blockStartLine = lineNum
 		}
 
 		group = append(group, line)
@@ -79,6 +115,10 @@ func groupYarnPackageLines(scanner *bufio.Scanner) []YarnPackage {
 
 	if len(group) > 0 {
 		packages := parseYarnPackageBlock(group)
+		blockEndLine := findLastNonEmptyLineInRange(lines, blockStartLine-1, len(lines)-1)
+		for i := range packages {
+			packages[i].BlockLocation = buildYarnBlockPosition(lines, blockStartLine, blockEndLine)
+		}
 		groups = append(groups, packages...)
 	}
 
@@ -336,7 +376,7 @@ func buildDependencyTree(rootPkgName, rootPkgTargetVersion, rootPkgRegistry stri
 	return results
 }
 
-func parseYarnPackage(dependency YarnPackage) lockfile.PackageDetails {
+func parseYarnPackage(dependency YarnPackage, filePath string) lockfile.PackageDetails {
 	if dependency.Version == "" {
 		_, _ = fmt.Fprintf(
 			os.Stderr,
@@ -350,6 +390,9 @@ func parseYarnPackage(dependency YarnPackage) lockfile.PackageDetails {
 		nameLocation = &models.FilePosition{Filename: dependency.WorkspacePath}
 	}
 
+	blockLocation := dependency.BlockLocation
+	blockLocation.Filename = filePath
+
 	return lockfile.PackageDetails{
 		Name:           dependency.Name,
 		Version:        dependency.Version,
@@ -358,6 +401,7 @@ func parseYarnPackage(dependency YarnPackage) lockfile.PackageDetails {
 		Ecosystem:      models.EcosystemNPM,
 		Commit:         tryExtractCommit(dependency.Resolution),
 		NameLocation:   nameLocation,
+		BlockLocation:  blockLocation,
 	}
 }
 
@@ -450,12 +494,110 @@ func isJSONFormat(content []byte) bool {
 //
 // Returns a slice of YarnPackage structs compatible with the existing YAML parser output,
 // allowing the rest of the extraction logic to work identically for both formats.
-func parseYarnBerryJSON(content []byte) ([]YarnPackage, error) {
+// extractYarnBerryJSONPositions scans JSON lines for entry keys within the "entries" object.
+// Entry keys appear as "    \"package@npm:^1.0.0\": {" at 4-space indent inside "entries".
+func extractYarnBerryJSONPositions(lines []string) map[string]models.FilePosition {
+	positions := make(map[string]models.FilePosition)
+
+	inEntries := false
+	var currentKey string
+	braceDepth := 0
+
+	for i, line := range lines {
+		lineNum := i + 1
+		trimmed := strings.TrimSpace(line)
+
+		// Detect "entries": {
+		if !inEntries && strings.Contains(trimmed, `"entries"`) && strings.HasSuffix(trimmed, "{") {
+			inEntries = true
+			braceDepth = 1
+
+			continue
+		}
+
+		if !inEntries {
+			continue
+		}
+
+		// Track brace depth
+		for _, ch := range trimmed {
+			if ch == '{' {
+				braceDepth++
+			} else if ch == '}' {
+				braceDepth--
+			}
+		}
+
+		if braceDepth <= 0 {
+			// Close last entry
+			if currentKey != "" {
+				closeBerryEntry(positions, currentKey, i, lines)
+				currentKey = ""
+			}
+
+			inEntries = false
+
+			continue
+		}
+
+		// Entry key at depth 1 (exactly 4-space indent, opens an object): "    \"package@npm:^1.0.0\": {"
+		// Require HasSuffix("{") to avoid false positives on internal fields like "checksum": "..."
+		// which also sit at depth 2 but do not open a new brace.
+		if braceDepth == 2 && strings.HasSuffix(trimmed, "{") && strings.HasPrefix(line, "    ") {
+			// This is a new entry key
+			if currentKey != "" {
+				closeBerryEntry(positions, currentKey, i, lines)
+			}
+
+			// Extract the key between quotes
+			firstQuote := strings.Index(trimmed, `"`)
+			lastQuote := strings.Index(trimmed[firstQuote+1:], `"`)
+
+			if firstQuote >= 0 && lastQuote >= 0 {
+				key := trimmed[firstQuote+1 : firstQuote+1+lastQuote]
+				currentKey = key
+
+				colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+
+				positions[currentKey] = models.FilePosition{
+					Line:   models.Position{Start: lineNum, End: 0},
+					Column: models.Position{Start: colStart, End: 0},
+				}
+			}
+		}
+	}
+
+	if currentKey != "" {
+		closeBerryEntry(positions, currentKey, len(lines), lines)
+	}
+
+	return positions
+}
+
+func closeBerryEntry(positions map[string]models.FilePosition, key string, beforeIndex int, lines []string) {
+	pos := positions[key]
+	lastNonEmpty := beforeIndex - 1
+	for lastNonEmpty >= 0 && strings.TrimSpace(lines[lastNonEmpty]) == "" {
+		lastNonEmpty--
+	}
+
+	if lastNonEmpty >= 0 {
+		pos.Line.End = lastNonEmpty + 1
+		pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastNonEmpty])
+	} else {
+		pos.Line.End = pos.Line.Start
+	}
+
+	positions[key] = pos
+}
+
+func parseYarnBerryJSON(content []byte, lines []string) ([]YarnPackage, error) {
 	var berryJSON YarnBerryJSON
 	if err := json.Unmarshal(content, &berryJSON); err != nil {
 		return nil, fmt.Errorf("failed to parse yarn.lock JSON: %w", err)
 	}
 
+	positions := extractYarnBerryJSONPositions(lines)
 	packages := make([]YarnPackage, 0, len(berryJSON.Entries))
 
 	for entryKey, entry := range berryJSON.Entries {
@@ -484,6 +626,12 @@ func parseYarnBerryJSON(content []byte) ([]YarnPackage, error) {
 			})
 		}
 
+		// Look up position by entry key
+		var blockPos models.FilePosition
+		if pos, ok := positions[entryKey]; ok {
+			blockPos = pos
+		}
+
 		// Create one YarnPackage per target version
 		for _, targetVersion := range targetVersions {
 			packages = append(packages, YarnPackage{
@@ -493,6 +641,7 @@ func parseYarnBerryJSON(content []byte) ([]YarnPackage, error) {
 				Resolution:    resolution,
 				Dependencies:  dependencies,
 				WorkspacePath: workspacePath,
+				BlockLocation: blockPos,
 			})
 		}
 	}
@@ -501,41 +650,24 @@ func parseYarnBerryJSON(content []byte) ([]YarnPackage, error) {
 }
 
 func (e YarnLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
-	// Peek first bytes to detect format without loading entire file into memory
-	buf := make([]byte, 200)
-	n, err := f.Read(buf)
-	if err != nil && !errors.Is(err, io.EOF) {
+	content, err := io.ReadAll(f)
+	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("error reading yarn.lock: %w", err)
 	}
 
-	// Try to reset file position for streaming
-	var reader io.Reader = f
-	if seeker, ok := f.(io.Seeker); ok {
-		if _, err := seeker.Seek(0, 0); err != nil {
-			return []lockfile.PackageDetails{}, fmt.Errorf("error seeking yarn.lock: %w", err)
-		}
-	} else {
-		// If we can't seek, prepend the peeked bytes back to the reader
-		reader = io.MultiReader(strings.NewReader(string(buf[:n])), f)
-	}
+	lines := fileposition.BytesToLines(content)
 
 	var yarnPackages []YarnPackage
-	if isJSONFormat(buf[:n]) {
+	if isJSONFormat(content) {
 		// Parse JSON format (Yarn v4+)
-		// JSON requires loading entire file into memory for parsing
-		content, err := io.ReadAll(reader)
-		if err != nil {
-			return []lockfile.PackageDetails{}, fmt.Errorf("error reading yarn.lock JSON: %w", err)
-		}
-		yarnPackages, err = parseYarnBerryJSON(content)
+		yarnPackages, err = parseYarnBerryJSON(content, lines)
 		if err != nil {
 			return []lockfile.PackageDetails{}, err
 		}
 	} else {
-		// Parse YAML format (Yarn v1-3) using streaming scanner
-		// This avoids loading the entire file into memory
-		scanner := bufio.NewScanner(reader)
-		yarnPackages = groupYarnPackageLines(scanner)
+		// Parse YAML-like format (Yarn v1-3)
+		scanner := bufio.NewScanner(strings.NewReader(string(content)))
+		yarnPackages = groupYarnPackageLines(scanner, lines)
 
 		if err := scanner.Err(); err != nil {
 			return []lockfile.PackageDetails{}, fmt.Errorf("error while scanning %s: %w", f.Path(), err)
@@ -561,7 +693,7 @@ func (e YarnLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCont
 	}
 
 	dependencyWorkspaces := createDependencyWorkspaceMap(workspaces, allResolvedPackages)
-	packages := createPackageDetails(allResolvedPackages, dependencyWorkspaces)
+	packages := createPackageDetails(allResolvedPackages, dependencyWorkspaces, f.Path())
 
 	pkgIndex := indexByNameAndVersions(packages)
 	for index, pkg := range packages {
@@ -608,12 +740,12 @@ func createDependencyWorkspaceMap(workspaces []YarnPackage, allResolvedPackages 
 	return dependencyWorkspaces
 }
 
-func createPackageDetails(allResolvedPackages []YarnPackage, dependencyWorkspaces map[string][]string) []lockfile.PackageDetails {
+func createPackageDetails(allResolvedPackages []YarnPackage, dependencyWorkspaces map[string][]string, filePath string) []lockfile.PackageDetails {
 	packages := make([]lockfile.PackageDetails, 0, len(allResolvedPackages))
 
 	// Create lockfile.PackageDetails for regular packages, with workspace information where applicable
 	for _, yarnPackage := range allResolvedPackages {
-		basePackage := parseYarnPackage(yarnPackage)
+		basePackage := parseYarnPackage(yarnPackage, filePath)
 		depKey := getWorkspaceDependencyKey(yarnPackage.Name, yarnPackage.Version, yarnPackage.TargetVersion)
 
 		if workspacePaths, exists := dependencyWorkspaces[depKey]; exists {

--- a/pkg/lockfile/javascript/pnpm-legacy-lock.go
+++ b/pkg/lockfile/javascript/pnpm-legacy-lock.go
@@ -1,6 +1,7 @@
 package javascript
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -104,7 +106,92 @@ func getVersionInfo(name string, maps ...map[string]PnpmLegacyLockDependency) (s
 	return "", "", false
 }
 
-func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile) []lockfile.PackageDetails {
+// extractPnpmLegacyPackagePositions scans YAML lines for package entries under "packages:".
+// Legacy pnpm package keys appear at 2-space indent (e.g. "  /acorn/8.7.0:").
+func extractPnpmLegacyPackagePositions(lines []string) map[string]models.FilePosition {
+	positions := make(map[string]models.FilePosition)
+
+	inPackages := false
+	var currentKey string
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// Detect the "packages:" top-level key
+		if trimmed == "packages:" {
+			inPackages = true
+
+			continue
+		}
+
+		if !inPackages {
+			continue
+		}
+
+		// A line with no leading spaces means we've exited the packages block
+		if len(line) > 0 && line[0] != ' ' {
+			if currentKey != "" {
+				closePnpmBlock(positions, currentKey, i, lines)
+				currentKey = ""
+			}
+
+			inPackages = false
+
+			continue
+		}
+
+		// 2-space indent: package entry (e.g. "  /acorn/8.7.0:")
+		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' && strings.HasSuffix(trimmed, ":") {
+			// Close previous package
+			if currentKey != "" {
+				closePnpmBlock(positions, currentKey, i, lines)
+			}
+
+			// Strip trailing ":" and normalize YAML quoting: single-quoted keys like
+			// 'https://...' are stored with quotes in the raw text but decoded without
+			// quotes by the YAML parser. Stripping surrounding quotes makes the positions
+			// map key match what sourceFile.Packages uses for lookup.
+			pkgKey := strings.Trim(strings.TrimSuffix(trimmed, ":"), "'\"")
+			currentKey = pkgKey
+
+			colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+
+			positions[currentKey] = models.FilePosition{
+				Line:   models.Position{Start: lineNum, End: 0},
+				Column: models.Position{Start: colStart, End: 0},
+			}
+
+			continue
+		}
+	}
+
+	// Close last package if file ended within packages section
+	if currentKey != "" {
+		pos := positions[currentKey]
+		lastIdx := len(lines) - 1
+		for lastIdx >= 0 && strings.TrimSpace(lines[lastIdx]) == "" {
+			lastIdx--
+		}
+
+		if lastIdx >= 0 {
+			pos.Line.End = lastIdx + 1
+			pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastIdx])
+		} else {
+			pos.Line.End = pos.Line.Start
+		}
+
+		positions[currentKey] = pos
+	}
+
+	return positions
+}
+
+func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile, positions map[string]models.FilePosition, filePath string) []lockfile.PackageDetails {
 	packages := make([]lockfile.PackageDetails, 0, len(sourceFile.Packages))
 
 	for s, pkg := range sourceFile.Packages {
@@ -186,6 +273,12 @@ func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile) []lockfile.PackageDetail
 			targetVersions = []string{targetVersion}
 		}
 
+		blockLocation := models.FilePosition{}
+		if pos, ok := positions[s]; ok {
+			pos.Filename = filePath
+			blockLocation = pos
+		}
+
 		packages = append(packages, lockfile.PackageDetails{
 			Name:           name,
 			Version:        version,
@@ -195,6 +288,7 @@ func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile) []lockfile.PackageDetail
 			Commit:         commit,
 			DepGroups:      depGroups,
 			IsDirect:       isDirect,
+			BlockLocation:  blockLocation,
 		})
 	}
 
@@ -216,7 +310,12 @@ func (e PnpmLockExtractor) PackageManager() models.PackageManager {
 func (e PnpmLockExtractor) extractLegacyPnpm(f lockfile.DepFile) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PnpmLegacyLockfile
 
-	err := yaml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = yaml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil && !errors.Is(err, io.EOF) {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -227,5 +326,8 @@ func (e PnpmLockExtractor) extractLegacyPnpm(f lockfile.DepFile) ([]lockfile.Pac
 		parsedLockfile = &PnpmLegacyLockfile{}
 	}
 
-	return parsePnpmLegacyLock(*parsedLockfile), nil
+	lines := fileposition.BytesToLines(content)
+	positions := extractPnpmLegacyPackagePositions(lines)
+
+	return parsePnpmLegacyLock(*parsedLockfile, positions, f.Path()), nil
 }

--- a/pkg/lockfile/javascript/pnpm-legacy-lock.go
+++ b/pkg/lockfile/javascript/pnpm-legacy-lock.go
@@ -289,6 +289,7 @@ func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile, positions map[string]mod
 			DepGroups:      depGroups,
 			IsDirect:       isDirect,
 			BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 		})
 	}
 

--- a/pkg/lockfile/javascript/types.go
+++ b/pkg/lockfile/javascript/types.go
@@ -248,6 +248,7 @@ type YarnPackage struct {
 	Resolution    string
 	Dependencies  []YarnDependency
 	WorkspacePath string
+	BlockLocation models.FilePosition
 }
 
 type YarnLockExtractor struct {

--- a/pkg/lockfile/php/parse-composer-lock.go
+++ b/pkg/lockfile/php/parse-composer-lock.go
@@ -1,10 +1,14 @@
 package php
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -43,13 +47,73 @@ func (e ComposerLockExtractor) PackageManager() models.PackageManager {
 	return composerPackageManager
 }
 
+// computeComposerBlockPositions scans JSON lines to find the start/end
+// positions of each object in the "packages" and "packages-dev" arrays.
+// Returns positions in order: packages first, then packages-dev.
+func computeComposerBlockPositions(lines []string) []models.FilePosition {
+	var positions []models.FilePosition
+
+	packagesKeyRe := cachedregexp.MustCompile(`^\s*"packages(-dev)?"\s*:\s*\[`)
+	inArray := false
+	braceDepth := 0
+	var currentStart int
+
+	for i, line := range lines {
+		lineNum := i + 1 // 1-indexed
+
+		if !inArray {
+			if packagesKeyRe.MatchString(line) {
+				inArray = true
+				braceDepth = 0
+			}
+
+			continue
+		}
+
+		// Count braces on this line
+		for _, ch := range line {
+			switch ch {
+			case '{':
+				braceDepth++
+				if braceDepth == 1 {
+					currentStart = lineNum
+				}
+			case '}':
+				if braceDepth == 1 {
+					positions = append(positions, models.FilePosition{
+						Line:   models.Position{Start: currentStart, End: lineNum},
+						Column: models.Position{Start: strings.IndexByte(lines[currentStart-1], '{') + 1, End: strings.IndexByte(line, '}') + 2},
+					})
+				}
+				braceDepth--
+			}
+		}
+
+		// Check if array is closed (line has ']' at depth 0)
+		if braceDepth == 0 && strings.Contains(line, "]") {
+			inArray = false
+		}
+	}
+
+	return positions
+}
+
 func (e ComposerLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *ComposerLock
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
+
+	// Compute block positions for all packages in both arrays
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	blockPositions := computeComposerBlockPositions(lines)
 
 	packages := make(
 		[]lockfile.PackageDetails,
@@ -58,25 +122,38 @@ func (e ComposerLockExtractor) Extract(f lockfile.DepFile, context lockfile.Scan
 		uint64(len(parsedLockfile.Packages))+uint64(len(parsedLockfile.PackagesDev)),
 	)
 
+	posIdx := 0
 	for _, composerPackage := range parsedLockfile.Packages {
-		packages = append(packages, lockfile.PackageDetails{
+		pkg := lockfile.PackageDetails{
 			Name:           composerPackage.Name,
 			Version:        composerPackage.Version,
 			Commit:         composerPackage.Dist.Reference,
 			PackageManager: composerPackageManager,
 			Ecosystem:      models.EcosystemPackagist,
-		})
+		}
+		if posIdx < len(blockPositions) {
+			pkg.BlockLocation = blockPositions[posIdx]
+			pkg.BlockLocation.Filename = f.Path()
+			posIdx++
+		}
+		packages = append(packages, pkg)
 	}
 
 	for _, composerPackage := range parsedLockfile.PackagesDev {
-		packages = append(packages, lockfile.PackageDetails{
+		pkg := lockfile.PackageDetails{
 			Name:           composerPackage.Name,
 			Version:        composerPackage.Version,
 			Commit:         composerPackage.Dist.Reference,
 			PackageManager: composerPackageManager,
 			Ecosystem:      models.EcosystemPackagist,
 			DepGroups:      []string{"dev"},
-		})
+		}
+		if posIdx < len(blockPositions) {
+			pkg.BlockLocation = blockPositions[posIdx]
+			pkg.BlockLocation.Filename = f.Path()
+			posIdx++
+		}
+		packages = append(packages, pkg)
 	}
 
 	return packages, nil

--- a/pkg/lockfile/php/parse-composer-lock.go
+++ b/pkg/lockfile/php/parse-composer-lock.go
@@ -134,6 +134,7 @@ func (e ComposerLockExtractor) Extract(f lockfile.DepFile, context lockfile.Scan
 		if posIdx < len(blockPositions) {
 			pkg.BlockLocation = blockPositions[posIdx]
 			pkg.BlockLocation.Filename = f.Path()
+			pkg.LocationRole = models.LocationRoleLockfile
 			posIdx++
 		}
 		packages = append(packages, pkg)
@@ -151,6 +152,7 @@ func (e ComposerLockExtractor) Extract(f lockfile.DepFile, context lockfile.Scan
 		if posIdx < len(blockPositions) {
 			pkg.BlockLocation = blockPositions[posIdx]
 			pkg.BlockLocation.Filename = f.Path()
+			pkg.LocationRole = models.LocationRoleLockfile
 			posIdx++
 		}
 		packages = append(packages, pkg)

--- a/pkg/lockfile/php/parse-composer-lock_test.go
+++ b/pkg/lockfile/php/parse-composer-lock_test.go
@@ -202,7 +202,7 @@ func TestParseComposerLock_TwoPackages_BlockLocation(t *testing.T) {
 	// two-packages.json has:
 	// "packages" array with sentry/sdk at lines 9-39
 	// "packages-dev" array with theseer/tokenizer at lines 42-77
-	assert.Equal(t, 2, len(packages), "expected 2 packages")
+	assert.Len(t, packages, 2, "expected 2 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/php/parse-composer-lock_test.go
+++ b/pkg/lockfile/php/parse-composer-lock_test.go
@@ -2,7 +2,10 @@ package php_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/php"
 
@@ -99,7 +102,7 @@ func TestParseComposerLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "sentry/sdk",
 			Version:        "2.0.4",
@@ -118,7 +121,7 @@ func TestParseComposerLock_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "sentry/sdk",
 			Version:        "2.0.4",
@@ -138,7 +141,7 @@ func TestParseComposerLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "sentry/sdk",
 			Version:        "2.0.4",
@@ -165,7 +168,7 @@ func TestParseComposerLock_TwoPackagesAlt(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "sentry/sdk",
 			Version:        "2.0.4",
@@ -181,4 +184,49 @@ func TestParseComposerLock_TwoPackagesAlt(t *testing.T) {
 			Ecosystem:      models.EcosystemPackagist,
 		},
 	})
+}
+
+func TestParseComposerLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/composer/two-packages.json")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := php.ParseComposerLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// two-packages.json has:
+	// "packages" array with sentry/sdk at lines 9-39
+	// "packages-dev" array with theseer/tokenizer at lines 42-77
+	assert.Equal(t, 2, len(packages), "expected 2 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// sentry/sdk starts at line 9 (opening {) and ends at line 39 (closing })
+	assert.Equal(t, 9, pkgMap["sentry/sdk"].BlockLocation.Line.Start)
+	assert.Equal(t, 39, pkgMap["sentry/sdk"].BlockLocation.Line.End)
+
+	// theseer/tokenizer starts at line 42 and ends at line 77
+	assert.Equal(t, 42, pkgMap["theseer/tokenizer"].BlockLocation.Line.Start)
+	assert.Equal(t, 77, pkgMap["theseer/tokenizer"].BlockLocation.Line.End)
+
+	// Verify path is absolute
+	assert.True(t, filepath.IsAbs(path), "path should be absolute")
 }

--- a/pkg/lockfile/python/parse-pdm-lock.go
+++ b/pkg/lockfile/python/parse-pdm-lock.go
@@ -1,9 +1,13 @@
 package python
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -25,7 +29,12 @@ func (p PdmLockExtractor) PackageManager() models.PackageManager {
 func (p PdmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockFile *PdmLockFile
 
-	_, err := toml.NewDecoder(f).Decode(&parsedLockFile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	_, err = toml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockFile)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
@@ -57,6 +66,19 @@ func (p PdmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 		}
 
 		packages = append(packages, details)
+	}
+
+	// Set BlockLocation for each package using the InTOML utility
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	positions := make([]*models.FilePosition, len(packages))
+	for i := range packages {
+		positions[i] = &packages[i].BlockLocation
+	}
+
+	fileposition.InTOML("[[package]]", "", positions, lines)
+
+	for i := range packages {
+		packages[i].BlockLocation.Filename = f.Path()
 	}
 
 	return packages, nil

--- a/pkg/lockfile/python/parse-pdm-lock_test.go
+++ b/pkg/lockfile/python/parse-pdm-lock_test.go
@@ -238,7 +238,7 @@ func TestParsePdmLock_TwoPackages_BlockLocation(t *testing.T) {
 	// line 4: [metadata]
 	// line 10: [[package]] (six, lines 10-19)
 	// line 21: [[package]] (toml, lines 21-30)
-	assert.Equal(t, 2, len(packages), "expected 2 packages")
+	assert.Len(t, packages, 2, "expected 2 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/python/parse-pdm-lock_test.go
+++ b/pkg/lockfile/python/parse-pdm-lock_test.go
@@ -2,7 +2,10 @@ package python_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/python"
 
@@ -109,7 +112,7 @@ func TestParsePdmLock_SinglePackage(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/single-package.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -125,7 +128,7 @@ func TestParsePdmLock_TwoPackages(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/two-packages.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -147,7 +150,7 @@ func TestParsePdmLock_PackageWithDevDependencies(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/dev-dependency.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -177,7 +180,7 @@ func TestParsePdmLock_PackageWithOptionalDependency(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/optional-dependency.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -207,7 +210,7 @@ func TestParsePdmLock_PackageWithGitDependency(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/git-dependency.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -216,4 +219,48 @@ func TestParsePdmLock_PackageWithGitDependency(t *testing.T) {
 			Commit:         "65bab7582ce14c55cdeec2244c65ea23039c9e6f",
 		},
 	})
+}
+
+func TestParsePdmLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/pdm/two-packages.toml")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := python.ParsePdmLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// two-packages.toml has:
+	// line 4: [metadata]
+	// line 10: [[package]] (six, lines 10-19)
+	// line 21: [[package]] (toml, lines 21-30)
+	assert.Equal(t, 2, len(packages), "expected 2 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// six starts at line 10 ("[[package]]")
+	assert.Equal(t, 10, pkgMap["six"].BlockLocation.Line.Start)
+
+	// toml starts at line 21 ("[[package]]")
+	assert.Equal(t, 21, pkgMap["toml"].BlockLocation.Line.Start)
+
+	// Verify path is absolute
+	assert.True(t, filepath.IsAbs(path), "path should be absolute")
 }

--- a/pkg/lockfile/python/parse-pipenv-lock.go
+++ b/pkg/lockfile/python/parse-pipenv-lock.go
@@ -94,6 +94,7 @@ func addPkgDetails(
 				blockLocation := *pos
 				blockLocation.Filename = filePath
 				pkgDetails.BlockLocation = blockLocation
+				pkgDetails.LocationRole = models.LocationRoleLockfile
 			}
 			details[name+"@"+version] = pkgDetails
 		}

--- a/pkg/lockfile/python/parse-pipenv-lock.go
+++ b/pkg/lockfile/python/parse-pipenv-lock.go
@@ -1,11 +1,15 @@
 package python
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"slices"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -27,21 +31,48 @@ func (e PipenvLockExtractor) PackageManager() models.PackageManager {
 func (e PipenvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PipenvLock
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	// Build position maps for InJSON
+	defaultPositions := make(map[string]*models.FilePosition, len(parsedLockfile.Packages))
+	for name := range parsedLockfile.Packages {
+		defaultPositions[name] = &models.FilePosition{}
+	}
+
+	developPositions := make(map[string]*models.FilePosition, len(parsedLockfile.PackagesDev))
+	for name := range parsedLockfile.PackagesDev {
+		developPositions[name] = &models.FilePosition{}
+	}
+
+	fileposition.InJSON("default", defaultPositions, lines, 0)
+	fileposition.InJSON("develop", developPositions, lines, 0)
+
 	details := make(map[string]lockfile.PackageDetails)
 
-	addPkgDetails(details, parsedLockfile.Packages, "")
-	addPkgDetails(details, parsedLockfile.PackagesDev, "dev")
+	addPkgDetails(details, parsedLockfile.Packages, "", defaultPositions, f.Path())
+	addPkgDetails(details, parsedLockfile.PackagesDev, "dev", developPositions, f.Path())
 
 	return slices.Collect(maps.Values(details)), nil
 }
 
-func addPkgDetails(details map[string]lockfile.PackageDetails, packages map[string]PipenvPackage, group string) {
+func addPkgDetails(
+	details map[string]lockfile.PackageDetails,
+	packages map[string]PipenvPackage,
+	group string,
+	positions map[string]*models.FilePosition,
+	filePath string,
+) {
 	for name, pipenvPackage := range packages {
 		if pipenvPackage.Version == "" {
 			continue
@@ -58,6 +89,11 @@ func addPkgDetails(details map[string]lockfile.PackageDetails, packages map[stri
 			}
 			if group != "" {
 				pkgDetails.DepGroups = append(pkgDetails.DepGroups, group)
+			}
+			if pos, ok := positions[name]; ok {
+				blockLocation := *pos
+				blockLocation.Filename = filePath
+				pkgDetails.BlockLocation = blockLocation
 			}
 			details[name+"@"+version] = pkgDetails
 		}

--- a/pkg/lockfile/python/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/python/parse-pipenv-lock_test.go
@@ -112,7 +112,7 @@ func TestParsePipenvLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markupsafe",
 			Version:        "2.1.1",
@@ -157,7 +157,7 @@ func TestParsePipenvLock_OnePackage_MatcherFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markupsafe",
 			Version:        "2.1.1",
@@ -183,7 +183,7 @@ func TestParsePipenvLock_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markupsafe",
 			Version:        "2.1.1",
@@ -207,7 +207,7 @@ func TestParsePipenvLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "itsdangerous",
 			Version:        "2.1.2",
@@ -237,7 +237,7 @@ func TestParsePipenvLock_TwoPackagesAlt(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "itsdangerous",
 			Version:        "2.1.2",
@@ -266,7 +266,7 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "itsdangerous",
 			Version:        "2.1.2",
@@ -293,6 +293,41 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Ecosystem:      models.EcosystemPyPI,
 		},
 	})
+}
+
+func TestParsePipenvLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pipenv/two-packages.json"))
+	packages, err := python.ParsePipenvLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	// itsdangerous is in "default" section, lines 19-26
+	itsdangerous := packagesByName["itsdangerous"]
+	assert.Equal(t, 19, itsdangerous.BlockLocation.Line.Start)
+	assert.Equal(t, 26, itsdangerous.BlockLocation.Line.End)
+	assert.Equal(t, 7, itsdangerous.BlockLocation.Column.Start)
+	assert.Equal(t, 8, itsdangerous.BlockLocation.Column.End)
+	assert.Equal(t, path, itsdangerous.BlockLocation.Filename)
+
+	// markupsafe is in "develop" section, lines 29-74
+	markupsafe := packagesByName["markupsafe"]
+	assert.Equal(t, 29, markupsafe.BlockLocation.Line.Start)
+	assert.Equal(t, 74, markupsafe.BlockLocation.Line.End)
+	assert.Equal(t, 7, markupsafe.BlockLocation.Column.Start)
+	assert.Equal(t, 8, markupsafe.BlockLocation.Column.End)
+	assert.Equal(t, path, markupsafe.BlockLocation.Filename)
 }
 
 func TestParsePipenvLock_PackageWithoutVersion(t *testing.T) {

--- a/pkg/lockfile/python/parse-poetry-lock.go
+++ b/pkg/lockfile/python/parse-poetry-lock.go
@@ -1,9 +1,13 @@
 package python
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -25,7 +29,12 @@ func (e PoetryLockExtractor) PackageManager() models.PackageManager {
 func (e PoetryLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PoetryLockFile
 
-	_, err := toml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	_, err = toml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -45,6 +54,19 @@ func (e PoetryLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCo
 			pkgDetails.DepGroups = append(pkgDetails.DepGroups, "optional")
 		}
 		packages = append(packages, pkgDetails)
+	}
+
+	// Set BlockLocation for each package using the InTOML utility
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	positions := make([]*models.FilePosition, len(packages))
+	for i := range packages {
+		positions[i] = &packages[i].BlockLocation
+	}
+
+	fileposition.InTOML("[[package]]", "[metadata]", positions, lines)
+
+	for i := range packages {
+		packages[i].BlockLocation.Filename = f.Path()
 	}
 
 	return packages, nil

--- a/pkg/lockfile/python/parse-poetry-lock.go
+++ b/pkg/lockfile/python/parse-poetry-lock.go
@@ -67,6 +67,7 @@ func (e PoetryLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCo
 
 	for i := range packages {
 		packages[i].BlockLocation.Filename = f.Path()
+		packages[i].LocationRole = models.LocationRoleLockfile
 	}
 
 	return packages, nil

--- a/pkg/lockfile/python/parse-poetry-lock_test.go
+++ b/pkg/lockfile/python/parse-poetry-lock_test.go
@@ -311,7 +311,7 @@ func TestParsePoetryLock_TwoPackages_BlockLocation(t *testing.T) {
 	// line 1: "[[package]]"  (proto-plus block, lines 1-13)
 	// line 15: "[[package]]" (protobuf block, lines 15-21)
 	// line 23: "[metadata]"  (not a package)
-	assert.Equal(t, 2, len(packages), "expected 2 packages")
+	assert.Len(t, packages, 2, "expected 2 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/python/parse-poetry-lock_test.go
+++ b/pkg/lockfile/python/parse-poetry-lock_test.go
@@ -112,7 +112,7 @@ func TestParsePoetryLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "numpy",
 			Version:        "1.23.3",
@@ -157,7 +157,7 @@ func TestParsePoetryLock_OnePackage_MatcherFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "numpy",
 			Version:        "1.23.3",
@@ -183,7 +183,7 @@ func TestParsePoetryLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "proto-plus",
 			Version:        "1.22.0",
@@ -212,7 +212,7 @@ func TestParsePoetryLock_PackageWithMetadata(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "emoji",
 			Version:        "2.0.0",
@@ -235,7 +235,7 @@ func TestParsePoetryLock_PackageWithGitSource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ike",
 			Version:        "0.2.0",
@@ -259,7 +259,7 @@ func TestParsePoetryLock_PackageWithLegacySource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "appdirs",
 			Version:        "1.4.4",
@@ -283,7 +283,7 @@ func TestParsePoetryLock_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "numpy",
 			Version:        "1.23.3",
@@ -292,4 +292,48 @@ func TestParsePoetryLock_OptionalPackage(t *testing.T) {
 			DepGroups:      []string{"optional"},
 		},
 	})
+}
+
+func TestParsePoetryLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/poetry/two-packages.lock")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := python.ParsePoetryLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// two-packages.lock has:
+	// line 1: "[[package]]"  (proto-plus block, lines 1-13)
+	// line 15: "[[package]]" (protobuf block, lines 15-21)
+	// line 23: "[metadata]"  (not a package)
+	assert.Equal(t, 2, len(packages), "expected 2 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// proto-plus starts at line 1
+	assert.Equal(t, 1, pkgMap["proto-plus"].BlockLocation.Line.Start)
+
+	// protobuf starts at line 15
+	assert.Equal(t, 15, pkgMap["protobuf"].BlockLocation.Line.Start)
+
+	// Verify path is absolute
+	assert.True(t, filepath.IsAbs(path), "path should be absolute")
 }

--- a/pkg/lockfile/python/parse-uv-lock.go
+++ b/pkg/lockfile/python/parse-uv-lock.go
@@ -1,11 +1,14 @@
 package python
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -62,7 +65,12 @@ func findRootPackage(allPackages []*UvLockPackage) (*UvLockPackage, error) {
 func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *UvLockFile
 
-	_, err := toml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	_, err = toml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
@@ -71,6 +79,16 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 	if err != nil {
 		return []lockfile.PackageDetails{}, errors.New("error getting root package")
 	}
+
+	// Compute BlockLocation for ALL toml packages (including root) using InTOML
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	allPositions := make([]models.FilePosition, len(parsedLockfile.Packages))
+	positionPtrs := make([]*models.FilePosition, len(parsedLockfile.Packages))
+	for i := range allPositions {
+		positionPtrs[i] = &allPositions[i]
+	}
+
+	fileposition.InTOML("[[package]]", "", positionPtrs, lines)
 
 	// This will hold packages we will return
 	packages := make([]lockfile.PackageDetails, 0, len(parsedLockfile.Packages))
@@ -84,7 +102,7 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 			}
 		}
 
-		for _, lockPackage := range parsedLockfile.Packages {
+		for i, lockPackage := range parsedLockfile.Packages {
 			// Skip root package because root files describe what it depends on, but isn't itself a dependency
 			// https://docs.astral.sh/uv/concepts/projects/layout/
 			if isRoot(lockPackage) {
@@ -100,6 +118,9 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 				depGroups = append(depGroups, "dev")
 			}
 
+			blockLocation := allPositions[i]
+			blockLocation.Filename = f.Path()
+
 			pkgDetails := lockfile.PackageDetails{
 				Name:           lockPackage.Name,
 				Version:        lockPackage.Version,
@@ -107,6 +128,7 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 				PackageManager: uvPackageManager,
 				Ecosystem:      models.EcosystemPyPI,
 				IsDirect:       isDirect || isDevDependency,
+				BlockLocation:  blockLocation,
 			}
 
 			if len(depGroups) > 0 {

--- a/pkg/lockfile/python/parse-uv-lock_test.go
+++ b/pkg/lockfile/python/parse-uv-lock_test.go
@@ -248,7 +248,7 @@ func TestParseUvLock_SinglePackage_BlockLocation(t *testing.T) {
 	// line 5: certifi, line 14: charset-normalizer, line 36: idna,
 	// line 45: requests, line 60: urllib3, line 69: uv (root, skipped)
 	// Root package "uv" is skipped, so 5 packages returned.
-	assert.Equal(t, 5, len(packages), "expected 5 packages (root skipped)")
+	assert.Len(t, packages, 5, "expected 5 packages (root skipped)")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/python/parse-uv-lock_test.go
+++ b/pkg/lockfile/python/parse-uv-lock_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/python"
@@ -24,7 +26,7 @@ func TestParseUvLock_SinglePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "requests",
 			Version:        "2.32.3",
@@ -72,7 +74,7 @@ func TestParseUvLock_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseUvLock_MultiplePackage(t *testing.T) {
@@ -88,7 +90,7 @@ func TestParseUvLock_MultiplePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "bottle",
 			Version:        "0.13.3",
@@ -147,7 +149,7 @@ func TestParseUvLock_DevPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "requests",
 			Version:        "2.32.3",
@@ -227,4 +229,51 @@ func TestParseUvLock_DevPackage(t *testing.T) {
 			IsDirect:       false,
 		},
 	})
+}
+
+func TestParseUvLock_SinglePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/uv/single-package.lock")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := python.ParseUvLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// single-package.lock has 6 [[package]] sections:
+	// line 5: certifi, line 14: charset-normalizer, line 36: idna,
+	// line 45: requests, line 60: urllib3, line 69: uv (root, skipped)
+	// Root package "uv" is skipped, so 5 packages returned.
+	assert.Equal(t, 5, len(packages), "expected 5 packages (root skipped)")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// certifi starts at line 5
+	assert.Equal(t, 5, pkgMap["certifi"].BlockLocation.Line.Start)
+
+	// idna starts at line 36
+	assert.Equal(t, 36, pkgMap["idna"].BlockLocation.Line.Start)
+
+	// requests starts at line 45
+	assert.Equal(t, 45, pkgMap["requests"].BlockLocation.Line.Start)
+
+	// Verify path is absolute
+	assert.True(t, filepath.IsAbs(path), "path should be absolute")
 }

--- a/pkg/lockfile/renv/parse-renv-lock.go
+++ b/pkg/lockfile/renv/parse-renv-lock.go
@@ -1,10 +1,14 @@
 package renv
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -41,26 +45,47 @@ func (e RenvLockExtractor) PackageManager() models.PackageManager {
 func (e RenvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *RenvLockfile
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	// Build position map for InJSON keyed by package name
+	positions := make(map[string]*models.FilePosition, len(parsedLockfile.Packages))
+	for name := range parsedLockfile.Packages {
+		positions[name] = &models.FilePosition{}
+	}
+
+	fileposition.InJSON("Packages", positions, lines, 0)
+
 	packages := make([]lockfile.PackageDetails, 0, len(parsedLockfile.Packages))
 
-	for _, pkg := range parsedLockfile.Packages {
+	for name, pkg := range parsedLockfile.Packages {
 		// currently we only support CRAN
 		if pkg.Repository != string(models.EcosystemCRAN) {
 			continue
 		}
 
-		packages = append(packages, lockfile.PackageDetails{
+		pkgDetails := lockfile.PackageDetails{
 			Name:           pkg.Package,
 			Version:        pkg.Version,
 			PackageManager: renvPackageManager,
 			Ecosystem:      models.EcosystemCRAN,
-		})
+		}
+		if pos, ok := positions[name]; ok {
+			blockLocation := *pos
+			blockLocation.Filename = f.Path()
+			pkgDetails.BlockLocation = blockLocation
+		}
+		packages = append(packages, pkgDetails)
 	}
 
 	return packages, nil

--- a/pkg/lockfile/renv/parse-renv-lock_test.go
+++ b/pkg/lockfile/renv/parse-renv-lock_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseRenvLock_FileDoesNotExist(t *testing.T) {
@@ -50,7 +52,7 @@ func TestParseRenvLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "morning",
 			Version:        "0.1.0",
@@ -69,7 +71,7 @@ func TestParseRenvLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markdown",
 			Version:        "1.0",
@@ -94,7 +96,7 @@ func TestParseRenvLock_WithMixedSources(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markdown",
 			Version:        "1.0",
@@ -114,7 +116,7 @@ func TestParseRenvLock_WithBioconductor(t *testing.T) {
 	}
 
 	// currently Bioconductor is not supported
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "BH",
 			Version:        "1.75.0-0",
@@ -122,6 +124,37 @@ func TestParseRenvLock_WithBioconductor(t *testing.T) {
 			Ecosystem:      models.EcosystemCRAN,
 		},
 	})
+}
+
+func TestParseRenvLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := renv.ParseRenvLock("../fixtures/renv/two-packages.lock")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	// markdown block: lines 12-18 in "Packages" section
+	markdown := packagesByName["markdown"]
+	assert.Equal(t, 12, markdown.BlockLocation.Line.Start)
+	assert.Equal(t, 18, markdown.BlockLocation.Line.End)
+	assert.Equal(t, 5, markdown.BlockLocation.Column.Start)
+	assert.Equal(t, 6, markdown.BlockLocation.Column.End)
+	assert.Contains(t, markdown.BlockLocation.Filename, "two-packages.lock")
+
+	// mime block: lines 19-25 in "Packages" section
+	mime := packagesByName["mime"]
+	assert.Equal(t, 19, mime.BlockLocation.Line.Start)
+	assert.Equal(t, 25, mime.BlockLocation.Line.End)
+	assert.Equal(t, 5, mime.BlockLocation.Column.Start)
+	assert.Equal(t, 6, mime.BlockLocation.Column.End)
+	assert.Contains(t, mime.BlockLocation.Filename, "two-packages.lock")
 }
 
 func TestParseRenvLock_WithoutRepository(t *testing.T) {

--- a/pkg/lockfile/ruby/parse-gemfile-lock.go
+++ b/pkg/lockfile/ruby/parse-gemfile-lock.go
@@ -45,6 +45,7 @@ func (parser *gemfileLockfileParser) addDependency(name string, version string) 
 			Ecosystem:      models.EcosystemRubyGems,
 			Commit:         parser.currentGemCommit,
 			BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 		})
 
 		return
@@ -71,6 +72,7 @@ func (parser *gemfileLockfileParser) addDependency(name string, version string) 
 			Commit:         parser.currentGemCommit,
 			IsDirect:       true,
 			BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 		})
 	}
 }

--- a/pkg/lockfile/ruby/parse-gemfile-lock.go
+++ b/pkg/lockfile/ruby/parse-gemfile-lock.go
@@ -31,6 +31,12 @@ func (parser *gemfileLockfileParser) isSourceSection(line string) bool {
 }
 
 func (parser *gemfileLockfileParser) addDependency(name string, version string) {
+	blockLocation := models.FilePosition{
+		Line:     models.Position{Start: parser.lineNumber, End: parser.lineNumber},
+		Column:   models.Position{Start: 1, End: len(parser.currentLine) + 1},
+		Filename: parser.sourceFile,
+	}
+
 	if !parser.isInDepSection {
 		parser.dependencies = append(parser.dependencies, lockfile.PackageDetails{
 			Name:           name,
@@ -38,6 +44,7 @@ func (parser *gemfileLockfileParser) addDependency(name string, version string) 
 			PackageManager: gemfilePackageManager,
 			Ecosystem:      models.EcosystemRubyGems,
 			Commit:         parser.currentGemCommit,
+			BlockLocation:  blockLocation,
 		})
 
 		return
@@ -63,6 +70,7 @@ func (parser *gemfileLockfileParser) addDependency(name string, version string) 
 			Ecosystem:      models.EcosystemRubyGems,
 			Commit:         parser.currentGemCommit,
 			IsDirect:       true,
+			BlockLocation:  blockLocation,
 		})
 	}
 }
@@ -184,11 +192,15 @@ func (e GemfileLockExtractor) PackageManager() models.PackageManager {
 
 func (e GemfileLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parser gemfileLockfileParser
+	parser.sourceFile = f.Path()
 
 	scanner := bufio.NewScanner(f)
 
 	for scanner.Scan() {
-		parser.parse(scanner.Text())
+		parser.lineNumber++
+		line := scanner.Text()
+		parser.currentLine = line
+		parser.parse(line)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/pkg/lockfile/ruby/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/ruby/parse-gemfile-lock_test.go
@@ -2,7 +2,11 @@ package ruby_test
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/ruby"
 
@@ -112,7 +116,7 @@ func TestParseGemfileLock_OneGem(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ast",
 			Version:        "2.4.2",
@@ -131,7 +135,7 @@ func TestParseGemfileLock_SomeGems(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "coderay",
 			Version:        "1.1.3",
@@ -162,7 +166,7 @@ func TestParseGemfileLock_MultipleGems(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "bundler-audit",
 			Version:        "0.9.0.1",
@@ -213,7 +217,7 @@ func TestParseGemfileLock_Rails(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "actioncable",
 			Version:        "7.0.2.2",
@@ -502,7 +506,7 @@ func TestParseGemfileLock_Rubocop(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ast",
 			Version:        "2.4.2",
@@ -575,7 +579,7 @@ func TestParseGemfileLock_HasLocalGem(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "backbone-on-rails",
 			Version:        "1.2.0.0",
@@ -768,7 +772,7 @@ func TestParseGemfileLock_HasGitGem(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "hanami-controller",
 			Version:        "2.0.0.alpha1",
@@ -832,4 +836,56 @@ func TestParseGemfileLock_PlatformSpecificDependencyIsParsed(t *testing.T) {
 			IsDirect:       true,
 		},
 	})
+}
+
+func TestParseGemfileLock_SomeGems_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/bundler/some-gems.lock")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := ruby.ParseGemfileLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// some-gems.lock has:
+	// line 4: "    coderay (1.1.3)"
+	// line 5: "    method_source (1.0.0)"
+	// line 6: "    pry (0.14.1)"
+	assert.Equal(t, len(packages), 3, "expected 3 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific line numbers
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// coderay is at line 4: "    coderay (1.1.3)"
+	assert.Equal(t, 4, pkgMap["coderay"].BlockLocation.Line.Start)
+	assert.Equal(t, 4, pkgMap["coderay"].BlockLocation.Line.End)
+	assert.Equal(t, 1, pkgMap["coderay"].BlockLocation.Column.Start)
+
+	// method_source is at line 5: "    method_source (1.0.0)"
+	assert.Equal(t, 5, pkgMap["method_source"].BlockLocation.Line.Start)
+	assert.Equal(t, 5, pkgMap["method_source"].BlockLocation.Line.End)
+
+	// pry is at line 6: "    pry (0.14.1)"
+	assert.Equal(t, 6, pkgMap["pry"].BlockLocation.Line.Start)
+	assert.Equal(t, 6, pkgMap["pry"].BlockLocation.Line.End)
+
+	// Verify path is absolute (from lockfile, not relative)
+	assert.True(t, os.IsPathSeparator(path[0]) || filepath.IsAbs(path),
+		"path should be absolute")
 }

--- a/pkg/lockfile/ruby/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/ruby/parse-gemfile-lock_test.go
@@ -855,7 +855,7 @@ func TestParseGemfileLock_SomeGems_BlockLocation(t *testing.T) {
 	// line 4: "    coderay (1.1.3)"
 	// line 5: "    method_source (1.0.0)"
 	// line 6: "    pry (0.14.1)"
-	assert.Equal(t, len(packages), 3, "expected 3 packages")
+	assert.Len(t, packages, 3, "expected 3 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/ruby/types.go
+++ b/pkg/lockfile/ruby/types.go
@@ -67,6 +67,13 @@ type gemfileLockfileParser struct {
 
 	// whether or not the parser is in the `DEPENDENCIES` section
 	isInDepSection bool
+
+	// current line number being parsed (1-indexed)
+	lineNumber int
+	// current line text being parsed
+	currentLine string
+	// absolute path of the lockfile being parsed
+	sourceFile string
 }
 
 type GemfileLockExtractor struct {

--- a/pkg/lockfile/rust/parse-cargo-lock.go
+++ b/pkg/lockfile/rust/parse-cargo-lock.go
@@ -62,6 +62,7 @@ func (e CargoLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCon
 
 	for i := range packages {
 		packages[i].BlockLocation.Filename = f.Path()
+		packages[i].LocationRole = models.LocationRoleLockfile
 	}
 
 	return packages, nil

--- a/pkg/lockfile/rust/parse-cargo-lock.go
+++ b/pkg/lockfile/rust/parse-cargo-lock.go
@@ -1,9 +1,13 @@
 package rust
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -25,7 +29,12 @@ func (e CargoLockExtractor) PackageManager() models.PackageManager {
 func (e CargoLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *CargoLockFile
 
-	_, err := toml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	_, err = toml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -40,6 +49,19 @@ func (e CargoLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCon
 			PackageManager: cargoPackageManager,
 			Ecosystem:      models.EcosystemCratesIO,
 		})
+	}
+
+	// Set BlockLocation for each package using the InTOML utility
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	positions := make([]*models.FilePosition, len(packages))
+	for i := range packages {
+		positions[i] = &packages[i].BlockLocation
+	}
+
+	fileposition.InTOML("[[package]]", "", positions, lines)
+
+	for i := range packages {
+		packages[i].BlockLocation.Filename = f.Path()
 	}
 
 	return packages, nil

--- a/pkg/lockfile/rust/parse-cargo-lock_test.go
+++ b/pkg/lockfile/rust/parse-cargo-lock_test.go
@@ -2,7 +2,11 @@ package rust_test
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
@@ -100,7 +104,7 @@ func TestParseCargoLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "addr2line",
 			Version:        "0.15.2",
@@ -119,7 +123,7 @@ func TestParseCargoLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "addr2line",
 			Version:        "0.15.2",
@@ -144,7 +148,7 @@ func TestParseCargoLock_TwoPackagesWithLocal(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "addr2line",
 			Version:        "0.15.2",
@@ -169,7 +173,7 @@ func TestParseCargoLock_PackageWithBuildString(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wasi",
 			Version:        "0.10.2+wasi-snapshot-preview1",
@@ -177,4 +181,50 @@ func TestParseCargoLock_PackageWithBuildString(t *testing.T) {
 			Ecosystem:      models.EcosystemCratesIO,
 		},
 	})
+}
+
+func TestParseCargoLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/cargo/two-packages.lock")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := rust.ParseCargoLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// two-packages.lock has:
+	// line 5: "[[package]]"  (addr2line block, lines 5-12)
+	// line 14: "[[package]]" (syn block, lines 14-23)
+	assert.Equal(t, 2, len(packages), "expected 2 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// addr2line starts at line 5 ("[[package]]"), ends before the blank line at line 13
+	assert.Equal(t, 5, pkgMap["addr2line"].BlockLocation.Line.Start)
+	assert.Equal(t, 12, pkgMap["addr2line"].BlockLocation.Line.End)
+
+	// syn starts at line 14 ("[[package]]"), ends at line 24 (last package includes trailing content)
+	assert.Equal(t, 14, pkgMap["syn"].BlockLocation.Line.Start)
+	assert.Equal(t, 24, pkgMap["syn"].BlockLocation.Line.End)
+
+	// Verify path is absolute
+	assert.True(t, os.IsPathSeparator(path[0]) || filepath.IsAbs(path),
+		"path should be absolute")
 }

--- a/pkg/lockfile/rust/parse-cargo-lock_test.go
+++ b/pkg/lockfile/rust/parse-cargo-lock_test.go
@@ -199,7 +199,7 @@ func TestParseCargoLock_TwoPackages_BlockLocation(t *testing.T) {
 	// two-packages.lock has:
 	// line 5: "[[package]]"  (addr2line block, lines 5-12)
 	// line 14: "[[package]]" (syn block, lines 14-23)
-	assert.Equal(t, 2, len(packages), "expected 2 packages")
+	assert.Len(t, packages, 2, "expected 2 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/swift/parse-package-resolved.go
+++ b/pkg/lockfile/swift/parse-package-resolved.go
@@ -1,13 +1,16 @@
 package swift
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -35,9 +38,17 @@ func (e PackageResolvedExtractor) PackageManager() models.PackageManager {
 func (e PackageResolvedExtractor) Extract(f lockfile.DepFile, _ lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var resolved packageResolvedFile
 
-	if err := json.NewDecoder(f).Decode(&resolved); err != nil {
+	content, err := io.ReadAll(f)
+	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
+
+	if err := json.NewDecoder(bytes.NewReader(content)).Decode(&resolved); err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	positions := pinPositionsByIdentity(lines)
 
 	// Normalize pins from v1 or v2/v3 into a common representation.
 	type normalizedPin struct {
@@ -114,7 +125,7 @@ func (e PackageResolvedExtractor) Extract(f lockfile.DepFile, _ lockfile.ScanCon
 			version = pin.branch
 		}
 
-		packages = append(packages, lockfile.PackageDetails{
+		pkgDetails := lockfile.PackageDetails{
 			Name:           name,
 			Version:        version,
 			Commit:         pin.revision,
@@ -122,10 +133,81 @@ func (e PackageResolvedExtractor) Extract(f lockfile.DepFile, _ lockfile.ScanCon
 			Ecosystem:      models.EcosystemSwiftURL,
 			IsDirect:       false,
 			LocationRole:   models.LocationRoleLockfile,
-		})
+		}
+
+		if pos, ok := positions[pin.identity]; ok {
+			blockLocation := *pos
+			blockLocation.Filename = f.Path()
+			pkgDetails.BlockLocation = blockLocation
+		}
+
+		packages = append(packages, pkgDetails)
 	}
 
 	return packages, nil
+}
+
+// identityRegexp matches the "identity" key inside a pin object.
+var identityRegexp = cachedregexp.MustCompile(`"identity"\s*:\s*"([^"]+)"`)
+
+// pinPositionsByIdentity scans the raw JSON lines and returns a FilePosition for each
+// pin block, keyed by the pin's identity value.  Each block starts at the "{" line
+// that precedes the "identity" field and ends at the matching "}".
+func pinPositionsByIdentity(lines []string) map[string]*models.FilePosition {
+	positions := make(map[string]*models.FilePosition)
+
+	for i, line := range lines {
+		m := identityRegexp.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+
+		identity := m[1]
+
+		// Walk backwards to find the opening "{" of this pin block.
+		blockStart := i
+		for blockStart > 0 && !strings.Contains(lines[blockStart], "{") {
+			blockStart--
+		}
+
+		// Walk forward to find the matching closing "}".
+		depth := 0
+		blockEnd := blockStart
+
+		for blockEnd < len(lines) {
+			for _, ch := range lines[blockEnd] {
+				if ch == '{' {
+					depth++
+				} else if ch == '}' {
+					depth--
+				}
+			}
+
+			if depth <= 0 {
+				break
+			}
+
+			blockEnd++
+		}
+
+		colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(lines[blockStart])
+		colEnd := fileposition.GetLastNonEmptyCharacterIndexInLine(lines[blockEnd])
+
+		if colStart < 1 {
+			colStart = 1
+		}
+
+		if colEnd < 1 {
+			colEnd = 1
+		}
+
+		positions[identity] = &models.FilePosition{
+			Line:   models.Position{Start: blockStart + 1, End: blockEnd + 1},
+			Column: models.Position{Start: colStart, End: colEnd},
+		}
+	}
+
+	return positions
 }
 
 // nameFromRepoURL extracts a purl-compatible name from a repository URL.

--- a/pkg/lockfile/swift/parse-package-resolved_test.go
+++ b/pkg/lockfile/swift/parse-package-resolved_test.go
@@ -4,6 +4,8 @@ import (
 	"io/fs"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/swift"
@@ -112,7 +114,8 @@ func TestParsePackageResolved_OnePackageV1(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	// v1 pins have no "identity" field — BlockLocation is not set.
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "github.com/Alamofire/Alamofire",
 			Version:        "5.4.3",
@@ -134,7 +137,7 @@ func TestParsePackageResolved_OnePackageV2(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "github.com/Alamofire/Alamofire",
 			Version:        "5.6.1",
@@ -156,7 +159,7 @@ func TestParsePackageResolved_OnePackageV3(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "github.com/Alamofire/Alamofire",
 			Version:        "5.9.0",
@@ -178,7 +181,7 @@ func TestParsePackageResolved_TwoPackagesV2(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "github.com/Alamofire/Alamofire",
 			Version:        "5.6.1",
@@ -200,6 +203,29 @@ func TestParsePackageResolved_TwoPackagesV2(t *testing.T) {
 	})
 }
 
+func TestParsePackageResolved_TwoPackagesV2_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := swift.ParsePackageResolved("../fixtures/swift/two-packages-v2.json")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	alamofire := packages[0]
+	assert.Equal(t, 3, alamofire.BlockLocation.Line.Start)
+	assert.Equal(t, 11, alamofire.BlockLocation.Line.End)
+	assert.Equal(t, 5, alamofire.BlockLocation.Column.Start)
+	assert.Equal(t, 7, alamofire.BlockLocation.Column.End)
+	assert.Contains(t, alamofire.BlockLocation.Filename, "two-packages-v2.json")
+
+	parser := packages[1]
+	assert.Equal(t, 12, parser.BlockLocation.Line.Start)
+	assert.Equal(t, 20, parser.BlockLocation.Line.End)
+	assert.Equal(t, 5, parser.BlockLocation.Column.Start)
+	assert.Equal(t, 6, parser.BlockLocation.Column.End)
+	assert.Contains(t, parser.BlockLocation.Filename, "two-packages-v2.json")
+}
+
 func TestParsePackageResolved_MixedStatesV2(t *testing.T) {
 	t.Parallel()
 
@@ -209,7 +235,7 @@ func TestParsePackageResolved_MixedStatesV2(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "github.com/Alamofire/Alamofire",
 			Version:        "5.6.1",
@@ -240,7 +266,7 @@ func TestParsePackageResolved_SSHUrlV2(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "github.com/Alamofire/Alamofire",
 			Version:        "5.6.1",
@@ -262,7 +288,7 @@ func TestParsePackageResolved_RegistryPinV2(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "apple.swift-argument-parser",
 			Version:        "1.2.0",
@@ -284,7 +310,7 @@ func TestParsePackageResolved_LocalPackageSkipped(t *testing.T) {
 	}
 
 	// localSourceControl pins should be skipped
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "github.com/Alamofire/Alamofire",
 			Version:        "5.6.1",


### PR DESCRIPTION
## Summary

Transitive dependencies were previously reported without any lockfile position data, making it impossible to group them precisely relative to their direct dependency parents. This PR adds `BlockLocation` (lockfile position) to all 22 extractors so that every package — direct and transitive — carries its file position.

**Approach (backward compatible):**
- Direct dependencies: no change — matchers continue to overwrite lockfile positions with source-file positions (e.g., `package.json`, `Cargo.toml`). The lockfile position is set during extraction but replaced by the manifest position before the SBOM is emitted, so the reported occurrence always points to the manifest file.
- Transitive dependencies: now always carry their lockfile position (previously zero/empty). Since no matcher enriches them, the lockfile block is the only occurrence reported.

In short: lockfile positions are populated for every package, but only reach the final SBOM output for packages that have no manifest file to be matched against (i.e. transitives).

**Scope:**
- 16 extractors modified: npm-lock (gap fix), gradle-lock, mix-lock, gemfile-lock, cargo-lock, poetry-lock, pdm-lock, uv-lock, composer-lock, pipenv-lock, renv-lock, nuget-lock, conan-lock (v1+v2), gradle-verification-metadata, pubspec-lock, pnpm-lock, yarn-lock
- 6 extractors already correct: go-lock, requirements-txt, maven-install, maven-lock, nuget-csproj (+ npm-lock gap was confirmed and fixed)

**Implementation patterns used:**
- Line-based scanning (gradle-lock, mix-lock, gemfile-lock)
- TOML `[[package]]` via `InTOML` utility (cargo, poetry, pdm, uv)
- JSON map-keyed via `InJSON` utility (pipenv, renv, nuget-lock, conan)
- JSON array brace-depth tracking (composer-lock)
- YAML indent-based scanning (pubspec-lock, pnpm-lock)
- XML regex-based element scanning (gradle-verification-metadata)
- Dual-format handling (yarn-lock v1-3 + v4+, conan-lock v1+v2)

**Bonus fixes discovered during implementation:**
- Matcher de-duplication bug: `BlockLocation.Line.Start != 0` check in `match-package-json.go` and `match-composer.go` broke once extractors started populating `BlockLocation`. Fixed by comparing `BlockLocation.Filename == depMap.FilePath` instead.
- npm-lock non-determinism: `npmPackageDetailsMap.add()` now prefers the earlier (smaller line number) location when the same `name@version` appears at multiple `node_modules` paths.
- SBOM occurrence ordering: `cyclonedx.go` now sorts evidence occurrences by location string, making output deterministic when a package has both lockfile and source-file locations.

## Test plan

- [x] Each extractor has a dedicated `_BlockLocation` test asserting positions for all returned packages
- [x] Existing extractor tests updated (switched to `ExpectPackagesWithoutLocations` or updated with expected positions)
- [x] Integration snapshots updated to include new transitive dependency positions
- [x] Full test suite passes: `go test -count=1 ./...` — all 27 packages green
- [x] Lints pass: `./scripts/run_lints.sh`
- [x] Output stability verified: 10 consecutive runs without snapshot drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

The results of the generator were validated using software-conposition-analysis-tests, the results were manually reviewed, detecting that the lock files were being reported without any additional apparent change, then the results were analyzed using Claude producing the following summary of cases:

```
Summary of Findings: SBOM Generator Comparison Analysis

  Context

  Comparison between datadog-sbom-generator v1.10.0 (base) and a new local build (version string changed to "set at build time, see .goreleaser.yml ldflags section") across 92 test
  repositories covering multiple ecosystems (NuGet, npm/Yarn, Cargo, PyPI, PHP Composer, Go, Java/Maven, Ruby).

  ---
  Finding 1: Evidence/Occurrences field — EXPECTED, CORRECT ✅

  41 out of 92 repos show structural SBOM changes. In all 41 cases the change is identical: the new generator adds an evidence.occurrences block to every component, containing the
  exact file location(s) where the dependency was found.

  Example structure added:
  "evidence": {
    "occurrences": [
      {
        "location": "{\"block\":{\"file_name\":\"packages.lock.json\",\"line_start\":2024,\"line_end\":2038,\"column_start\":7,\"column_end\":8}}"
      }
    ]
  }

  Verification: 8 locations manually verified across 5 ecosystems (NuGet, Cargo, Yarn, npm, PyPI). Line numbers, column numbers, and file names are all accurate.

  PURLs: In 100% of repos, the PURL lists are identical between versions — no dependency was added or dropped.

  ---
  Finding 2: Version string change — EXPECTED ✅

  The datadog-sbom-generator metadata component inside the SBOM changed:
  - Before: "version": "1.10.0"
  - After: "version": "set at build time, see .goreleaser.yml ldflags section"

  Affects all 51 repos that showed only this change. Consistent with a development build.

  ---
  Finding 3: Bug fix in old generator — CORRECTED ✅

  Repos: sca-testing-jest, sca-testing-react

  The old generator was misattributing @babel/core file locations to the @babel/compat-data bom-ref. The new generator correctly drops these invalid entries.

  ┌───────┬───────────────────────────────────┬─────────────────────────────────────────┬─────────────────────────────────┐
  │ Repo  │           Wrong bom-ref           │       File with wrong attribution       │ Actual content at that location │
  ├───────┼───────────────────────────────────┼─────────────────────────────────────────┼─────────────────────────────────┤
  │ jest  │ pkg:npm/@babel/compat-data@7.26.5 │ packages/jest-transform/package.json:22 │ "@babel/core": "^7.11.6"        │
  ├───────┼───────────────────────────────────┼─────────────────────────────────────────┼─────────────────────────────────┤
  │ react │ pkg:npm/@babel/compat-data@7.26.3 │ package.json:9                          │ "@babel/core": "^7.11.1"        │
  └───────┴───────────────────────────────────┴─────────────────────────────────────────┴─────────────────────────────────┘

  The new generator does not emit these spurious locations. This is a correct fix.

  ---
  Finding 4: Regression — Root-level occurrences missing ⚠️ BUG

  Repo: sca-testing-OrchardCore

  The new generator drops the root-level package.json occurrence for two packages and does not replace it with the corresponding yarn.lock entry, despite the root yarn.lock existing
   and resolving those exact versions.

  Affected packages

  pkg:npm/@babel/core@7.26.9
  - Root package.json line 27: "@babel/core": "^7.22.11" → dropped, no replacement
  - Root yarn.lock lines 63–84: "@babel/core@npm:^7.22.11" resolving to 7.26.9 → also not added
  - What was added instead: yarn.lock line 86 (@babel/generator, a different package) — wrong entry

  pkg:npm/@babel/preset-env@7.26.9
  - Root package.json line 28: "@babel/preset-env": "^7.22.10" → dropped, no replacement
  - Root yarn.lock contains "@babel/preset-env@npm:^7.22.10" resolving to 7.26.9 → also not added

  Root cause hypothesis

  The new generator appears to process the root yarn.lock and correctly emits lock-file locations for most packages — but for @babel/core and @babel/preset-env specifically in
  OrchardCore, it skips both the package.json manifest entry and the yarn.lock resolved entry. A sub-module package.json entry (in src/OrchardCore.Modules/.../Assets/package.json)
  is retained, so the component does still have at least one occurrence, but the root-level origin is lost.

  This is particularly concerning because these are direct dependencies (declared in the root manifest), and losing that root-level occurrence means the direct-vs-transitive signal
  could be incorrect downstream.

  Reproduction path

  - Repo: sca-testing-OrchardCore (https://github.com/muh-nee/sca-testing-OrchardCore)
  - PURL 1: pkg:npm/%40babel%2Fcore@7.26.9
  - PURL 2: pkg:npm/%40babel%2Fpreset-env@7.26.9
  - Expected locations: root package.json lines 27–28 AND root yarn.lock lines 63–84 (for core) / equivalent range for preset-env
  - Actual locations in new SBOM: only src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Assets/package.json and multiple sub-lockfile entries

  ---
  Summary table

  ┌─────┬────────────────────────────────────────────────────────────────────────────────────────────┬────────────────┬─────────────────────────────────────────────┐
  │  #  │                                          Finding                                           │ Repos affected │                   Verdict                   │
  ├─────┼────────────────────────────────────────────────────────────────────────────────────────────┼────────────────┼─────────────────────────────────────────────┤
  │ 1   │ evidence.occurrences block added to all components                                         │ 41             │ ✅ Expected, verified correct               │
  ├─────┼────────────────────────────────────────────────────────────────────────────────────────────┼────────────────┼─────────────────────────────────────────────┤
  │ 2   │ Generator version string changed                                                           │ 51             │ ✅ Expected                                 │
  ├─────┼────────────────────────────────────────────────────────────────────────────────────────────┼────────────────┼─────────────────────────────────────────────┤
  │ 3   │ Old generator was emitting @babel/core locations under @babel/compat-data bom-ref          │ jest, react    │ ✅ Correctly fixed                          │
  ├─────┼────────────────────────────────────────────────────────────────────────────────────────────┼────────────────┼─────────────────────────────────────────────┤
  │ 4   │ Root package.json + root yarn.lock locations dropped for @babel/core and @babel/preset-env │ OrchardCore    │ ⚠️ Regression — root-level occurrences lost │
  └─────┴────────────────────────────────────────────────────────────────────────────────────────────┴────────────────┴─────────────────────────────────────────────┘

```

The locations were actually reviewed to verify that they were pointing to the right lines, finally a regression was detected, this regression was fixed to report the right line.

All codex issues were also reviewed and acted on them whenever needed