### PR TITLE
Set IsDirect=true on JAR pom.properties parser output

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -222,6 +222,10 @@ unsupported output format "unknown" - must be one of: json, cyclonedx-1-5
       "purl": "pkg:maven/com.example/my-lib@1.0.0",
       "properties": [
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:opaque",
           "value": "true"
         },

--- a/pkg/lockfile/java/parse-jar-pom-properties.go
+++ b/pkg/lockfile/java/parse-jar-pom-properties.go
@@ -82,6 +82,7 @@ func (e JarPomPropertiesExtractor) Extract(f lockfile.DepFile, context lockfile.
 			PackageManager: jarPomPropertiesPackageManager,
 			Ecosystem:      models.EcosystemMaven,
 			Opaque:         true,
+			IsDirect:       true,
 		})
 	}
 

--- a/pkg/lockfile/java/parse-jar-pom-properties_test.go
+++ b/pkg/lockfile/java/parse-jar-pom-properties_test.go
@@ -159,6 +159,7 @@ func TestParseJarPomProperties_OnePackage(t *testing.T) {
 			PackageManager: models.Maven,
 			Ecosystem:      models.EcosystemMaven,
 			Opaque:         true,
+			IsDirect:       true,
 		},
 	})
 }
@@ -184,6 +185,7 @@ func TestParseJarPomProperties_MultiplePackages(t *testing.T) {
 			PackageManager: models.Maven,
 			Ecosystem:      models.EcosystemMaven,
 			Opaque:         true,
+			IsDirect:       true,
 		},
 		{
 			Name:           "org.other:lib-b",
@@ -191,6 +193,7 @@ func TestParseJarPomProperties_MultiplePackages(t *testing.T) {
 			PackageManager: models.Maven,
 			Ecosystem:      models.EcosystemMaven,
 			Opaque:         true,
+			IsDirect:       true,
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- `IsDirect: true` is now set on all `PackageDetails` produced by the JAR pom.properties parser
- JARs are scanned directly (not resolved from a dependency tree), so all packages found should be marked as direct dependencies
- Mirrors the existing behavior of the pom.xml parser (`parse-maven-lock.go`)

## Changes

- `pkg/lockfile/java/parse-jar-pom-properties.go`: added `IsDirect: true` to the `PackageDetails` struct literal
- `pkg/lockfile/java/parse-jar-pom-properties_test.go`: updated test expectations for `OnePackage` and `MultiplePackages`
- `cmd/datadog-sbom-generator/__snapshots__/main_test.snap`: snapshot updated to reflect `datadog:is-direct: true` property in output

## Test plan

- [x] `TestParseJarPomProperties_OnePackage` passes
- [x] `TestParseJarPomProperties_MultiplePackages` passes
- [x] Full test suite passes (`go test ./...`)
- [x] Integration snapshot updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)