### PR TITLE
[K9VULN-13516] Add PEP 621 support 

### DIFF
--- a/pkg/lockfile/fixtures/pyproject-toml/pep621-one-package-dev/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml/pep621-one-package-dev/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "test-project"
+version = "0.1.0"
+requires-python = ">=3.8"
+description = "A test project"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "numpy>=1.24.0",
+]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/pkg/lockfile/fixtures/pyproject-toml/pep621-one-package/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml/pep621-one-package/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "test-project"
+version = "0.1.0"
+requires-python = ">=3.8"
+description = "A test project"
+dependencies = [
+  "numpy>=1.24.0",
+]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/pkg/lockfile/fixtures/pyproject-toml/pep621-transitive/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml/pep621-transitive/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-project"
+version = "0.1.0"
+requires-python = ">=3.8"
+description = "A test project"
+dependencies = [
+  "numpy>=1.24.0",
+  "proto-plus<2",
+]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/pkg/lockfile/python/match-pyproject-toml.go
+++ b/pkg/lockfile/python/match-pyproject-toml.go
@@ -1,14 +1,216 @@
 package python
 
-import "github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+import (
+	"io"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+)
 
 func (m PyprojectTOMLMatcher) GetSourceFile(lockfile lockfile.DepFile) (lockfile.DepFile, error) {
 	return lockfile.Open("pyproject.toml")
 }
 
 func (m PyprojectTOMLMatcher) Match(sourceFile lockfile.DepFile, packages []lockfile.PackageDetails, context lockfile.ScanContext) error {
-	// pyproject.toml format is almost the same as Pipfile format, we can reuse its matcher
-	return PipfileMatcher{}.Match(sourceFile, packages, context)
+	content, err := io.ReadAll(sourceFile)
+	if err != nil {
+		return err
+	}
+
+	var parsed pyprojectTOML
+	if err = toml.Unmarshal(content, &parsed); err != nil {
+		return err
+	}
+
+	pkgNameToGroups := buildDirectPkgs(parsed)
+
+	if len(pkgNameToGroups) == 0 {
+		return nil
+	}
+
+	rawLines := fileposition.BytesToLines(content)
+	lowerLines := make([]string, len(rawLines))
+	for i, line := range rawLines {
+		lowerLines[i] = strings.ToLower(line)
+	}
+
+	for key, pkg := range packages {
+		lowerName := strings.ToLower(pkg.Name)
+		groups, isDirect := pkgNameToGroups[lowerName]
+		if !isDirect {
+			continue
+		}
+
+		packages[key].IsDirect = true
+		packages[key].DepGroups = append(packages[key].DepGroups, groups...)
+
+		for index, lowerLine := range lowerLines {
+			if !isPoetryDepLine(lowerLine, lowerName) && !isPEP621DepLine(lowerLine, lowerName) {
+				continue
+			}
+
+			lineNumber := index + 1
+			startColumn := fileposition.GetFirstNonEmptyCharacterIndexInLine(lowerLine)
+			endColumn := fileposition.GetLastNonEmptyCharacterIndexInLine(lowerLine)
+
+			packages[key].BlockLocation = models.FilePosition{
+				Line:     models.Position{Start: lineNumber, End: lineNumber},
+				Column:   models.Position{Start: startColumn, End: endColumn},
+				Filename: sourceFile.Path(),
+			}
+
+			nameLocation := fileposition.ExtractStringPositionInBlock([]string{lowerLine}, lowerName, lineNumber)
+			if nameLocation != nil {
+				nameLocation.Filename = sourceFile.Path()
+				packages[key].NameLocation = nameLocation
+			}
+
+			versionLocation := extractVersionLocation(lowerLine, lineNumber, sourceFile.Path())
+			if versionLocation != nil {
+				packages[key].VersionLocation = versionLocation
+			}
+
+			break
+		}
+	}
+
+	return nil
+}
+
+// buildDirectPkgs returns a map of normalized package name → dep groups from all
+// supported pyproject.toml formats (Poetry and PEP 621).
+//
+// Poetry dependency specification: https://python-poetry.org/docs/dependency-specification/
+// Poetry dependency groups:        https://python-poetry.org/docs/managing-dependencies/
+// PEP 621 project metadata:        https://peps.python.org/pep-0621/
+func buildDirectPkgs(parsed pyprojectTOML) map[string][]string {
+	pkgNameToGroups := make(map[string][]string)
+
+	// Poetry: [tool.poetry.dependencies]
+	// https://python-poetry.org/docs/pyproject/#dependencies-and-dependency-groups
+	for pkgName := range parsed.Tool.Poetry.Dependencies {
+		pkgNameToGroups[strings.ToLower(pkgName)] = nil
+	}
+
+	// Poetry: [tool.poetry.dev-dependencies] (legacy format, superseded by groups)
+	// https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+	for pkgName := range parsed.Tool.Poetry.DevDependencies {
+		lowerPkgName := strings.ToLower(pkgName)
+		pkgNameToGroups[lowerPkgName] = appendGroup(pkgNameToGroups[lowerPkgName], "dev")
+	}
+
+	// Poetry: [tool.poetry.group.X.dependencies]
+	// https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+	for groupName, group := range parsed.Tool.Poetry.Groups {
+		for pkgName := range group.Dependencies {
+			lowerPkgName := strings.ToLower(pkgName)
+			pkgNameToGroups[lowerPkgName] = appendGroup(pkgNameToGroups[lowerPkgName], groupName)
+		}
+	}
+
+	// PEP 621: [project] dependencies = [...]
+	// https://peps.python.org/pep-0621/#dependencies-optional-dependencies
+	for _, spec := range parsed.Project.Dependencies {
+		pkgName := extractPEP508Name(spec)
+		if pkgName != "" {
+			pkgNameToGroups[pkgName] = nil
+		}
+	}
+
+	// PEP 621: [project.optional-dependencies]
+	// https://peps.python.org/pep-0621/#dependencies-optional-dependencies
+	for groupName, specs := range parsed.Project.OptionalDependencies {
+		for _, spec := range specs {
+			pkgName := extractPEP508Name(spec)
+			if pkgName != "" {
+				pkgNameToGroups[pkgName] = appendGroup(pkgNameToGroups[pkgName], groupName)
+			}
+		}
+	}
+
+	// Sort groups for deterministic output — Go map iteration order is random,
+	// so without sorting DepGroups can vary between runs producing unstable SBOMs.
+	for pkgName, groups := range pkgNameToGroups {
+		sort.Strings(groups)
+		pkgNameToGroups[pkgName] = groups
+	}
+
+	return pkgNameToGroups
+}
+
+// appendGroup appends groupName to groups, deduplicating.
+func appendGroup(groups []string, groupName string) []string {
+	if slices.Contains(groups, groupName) {
+		return groups
+	}
+
+	return append(groups, groupName)
+}
+
+// extractPEP508Name returns the normalized package name from a PEP 508 dependency
+// specifier string such as "numpy>=1.24", "requests[security]>=2.28", or "black".
+// Applies PEP 503 normalization so that "typing_extensions" and "typing-extensions"
+// resolve to the same key as the canonicalized lockfile name.
+// https://peps.python.org/pep-0508/
+// https://peps.python.org/pep-0503/#normalized-names
+func extractPEP508Name(spec string) string {
+	for i, c := range spec {
+		switch c {
+		case '[', '>', '<', '=', '!', '~', '@', ';', ' ', '\t':
+			return normalizedRequirementName(spec[:i])
+		}
+	}
+
+	return normalizedRequirementName(spec)
+}
+
+// extractVersionLocation tries to find the version value on the given line, trying
+// Poetry key=value format first, then PEP 621 array-entry format.
+// Environment markers (after `;`) are stripped before the PEP 621 search to avoid
+// false matches on marker comparators like `python_version < "3.10"`.
+func extractVersionLocation(line string, lineNumber int, filename string) *models.FilePosition {
+	// Poetry: name = "version"
+	loc := fileposition.ExtractDelimitedRegexpPositionInBlock([]string{line}, ".*", lineNumber, `=\s*"`, `"`)
+	if loc != nil {
+		loc.Filename = filename
+		return loc
+	}
+
+	// PEP 621: strip environment markers before matching version specifier
+	depPart, _, _ := strings.Cut(line, ";")
+
+	loc = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{depPart}, `[^",\s]+`, lineNumber, `[><=!~]{1,3}`, ``)
+	if loc != nil {
+		loc.Filename = filename
+		return loc
+	}
+
+	return nil
+}
+
+// isPoetryDepLine reports whether line is a Poetry TOML key=value dependency entry for pkgName.
+// Matches `pkgName =` or `pkgName=` at the start of the line (after whitespace),
+// preventing short names like "py" from matching "requires-python".
+func isPoetryDepLine(line, pkgName string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, pkgName) {
+		return false
+	}
+	rest := trimmed[len(pkgName):]
+
+	return strings.HasPrefix(rest, " ") || strings.HasPrefix(rest, "=") || strings.HasPrefix(rest, "\t")
+}
+
+// isPEP621DepLine reports whether line is a PEP 621 array dependency entry for pkgName.
+// Matches `"pkgName` — package name immediately following an opening quote.
+func isPEP621DepLine(line, pkgName string) bool {
+	return strings.Contains(line, `"`+pkgName)
 }
 
 var _ lockfile.Matcher = PyprojectTOMLMatcher{}

--- a/pkg/lockfile/python/match-pyproject-toml_test.go
+++ b/pkg/lockfile/python/match-pyproject-toml_test.go
@@ -212,3 +212,165 @@ func TestPyprojectTomlMatcher_Match_TransitiveDependencies(t *testing.T) {
 		},
 	})
 }
+
+func TestPyprojectTomlMatcher_Match_PEP621_OnePackage(t *testing.T) {
+	t.Parallel()
+
+	sourceFile, err := lockfile.OpenLocalDepFile("../fixtures/pyproject-toml/pep621-one-package/pyproject.toml")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packages := []lockfile.PackageDetails{
+		{
+			Name:           "numpy",
+			PackageManager: models.Uv,
+		},
+	}
+	err = pyprojectTOMLMatcher.Match(sourceFile, packages, testutil.GetTestContext())
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "numpy",
+			PackageManager: models.Uv,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 7, End: 7},
+				Column:   models.Position{Start: 3, End: 19},
+				Filename: sourceFile.Path(),
+			},
+			NameLocation: &models.FilePosition{
+				Line:     models.Position{Start: 7, End: 7},
+				Column:   models.Position{Start: 4, End: 9},
+				Filename: sourceFile.Path(),
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 7, End: 7},
+				Column:   models.Position{Start: 11, End: 17},
+				Filename: sourceFile.Path(),
+			},
+			IsDirect: true,
+		},
+	})
+}
+
+func TestPyprojectTomlMatcher_Match_PEP621_OnePackageDev(t *testing.T) {
+	t.Parallel()
+
+	sourceFile, err := lockfile.OpenLocalDepFile("../fixtures/pyproject-toml/pep621-one-package-dev/pyproject.toml")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packages := []lockfile.PackageDetails{
+		{
+			Name:           "numpy",
+			PackageManager: models.Uv,
+		},
+	}
+	err = pyprojectTOMLMatcher.Match(sourceFile, packages, testutil.GetTestContext())
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "numpy",
+			PackageManager: models.Uv,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 10, End: 10},
+				Column:   models.Position{Start: 3, End: 19},
+				Filename: sourceFile.Path(),
+			},
+			NameLocation: &models.FilePosition{
+				Line:     models.Position{Start: 10, End: 10},
+				Column:   models.Position{Start: 4, End: 9},
+				Filename: sourceFile.Path(),
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 10, End: 10},
+				Column:   models.Position{Start: 11, End: 17},
+				Filename: sourceFile.Path(),
+			},
+			IsDirect:  true,
+			DepGroups: []string{"dev"},
+		},
+	})
+}
+
+func TestPyprojectTomlMatcher_Match_PEP621_TransitiveDependencies(t *testing.T) {
+	t.Parallel()
+
+	sourceFile, err := lockfile.OpenLocalDepFile("../fixtures/pyproject-toml/pep621-transitive/pyproject.toml")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packages := []lockfile.PackageDetails{
+		{
+			Name:           "numpy",
+			PackageManager: models.Uv,
+		},
+		{
+			Name:           "proto-plus",
+			PackageManager: models.Uv,
+		},
+		{
+			Name:           "protobuf",
+			PackageManager: models.Uv,
+		},
+	}
+	err = pyprojectTOMLMatcher.Match(sourceFile, packages, testutil.GetTestContext())
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "numpy",
+			PackageManager: models.Uv,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 7, End: 7},
+				Column:   models.Position{Start: 3, End: 19},
+				Filename: sourceFile.Path(),
+			},
+			NameLocation: &models.FilePosition{
+				Line:     models.Position{Start: 7, End: 7},
+				Column:   models.Position{Start: 4, End: 9},
+				Filename: sourceFile.Path(),
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 7, End: 7},
+				Column:   models.Position{Start: 11, End: 17},
+				Filename: sourceFile.Path(),
+			},
+			IsDirect: true,
+		},
+		{
+			Name:           "proto-plus",
+			PackageManager: models.Uv,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 3, End: 18},
+				Filename: sourceFile.Path(),
+			},
+			NameLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 4, End: 14},
+				Filename: sourceFile.Path(),
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 15, End: 16},
+				Filename: sourceFile.Path(),
+			},
+			IsDirect: true,
+		},
+		{
+			Name:           "protobuf",
+			PackageManager: models.Uv,
+		},
+	})
+}

--- a/pkg/lockfile/python/normalize.go
+++ b/pkg/lockfile/python/normalize.go
@@ -1,0 +1,29 @@
+package python
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+)
+
+// normalizedRequirementName normalizes a Python package name per PEP 503.
+// PyPI treats [-_.] as equivalent separators and names are case-insensitive,
+// so "typing_extensions", "typing.extensions", and "typing-extensions" all
+// resolve to the same canonical name "typing-extensions".
+//
+// This is done to ensure we don't miss any advisories, as while the OSV
+// specification says that the normalized name should be used for advisories,
+// that's not the case currently in our databases, and Pip itself supports
+// non-normalized names in requirements files, so we need to normalize
+// on both sides to ensure we don't have false negatives.
+//
+// It's possible that this will cause some false positives, but that is better
+// than false negatives, and can be dealt with when/if it actually happens.
+// https://peps.python.org/pep-0503/#normalized-names
+func normalizedRequirementName(name string) string {
+	name = cachedregexp.MustCompile(`[-_.]+`).ReplaceAllString(name, "-")
+	name = strings.ToLower(name)
+	name, _, _ = strings.Cut(name, "[")
+
+	return name
+}

--- a/pkg/lockfile/python/parse-requirements-txt.go
+++ b/pkg/lockfile/python/parse-requirements-txt.go
@@ -187,25 +187,6 @@ func parseLine(path string, line string, lineNumber int, lineOffset int, columnS
 	}
 }
 
-// normalizedName ensures that the package name is normalized per PEP-0503
-// and then removing "added support" syntax if present.
-//
-// This is done to ensure we don't miss any advisories, as while the OSV
-// specification says that the normalized name should be used for advisories,
-// that's not the case currently in our databases, _and_ Pip itself supports
-// non-normalized names in the requirements.txt, so we need to normalize
-// on both sides to ensure we don't have false negatives.
-//
-// It's possible that this will cause some false positives, but that is better
-// than false negatives, and can be dealt with when/if it actually happens.
-func normalizedRequirementName(name string) string {
-	// per https://www.python.org/dev/peps/pep-0503/#normalized-names
-	name = cachedregexp.MustCompile(`[-_.]+`).ReplaceAllString(name, "-")
-	name = strings.ToLower(name)
-	name, _, _ = strings.Cut(name, "[")
-
-	return name
-}
 
 func removeComments(line string) string {
 	re := cachedregexp.MustCompile(`(\s*)#.*$`)

--- a/pkg/lockfile/python/parse-requirements-txt.go
+++ b/pkg/lockfile/python/parse-requirements-txt.go
@@ -187,7 +187,6 @@ func parseLine(path string, line string, lineNumber int, lineOffset int, columnS
 	}
 }
 
-
 func removeComments(line string) string {
 	re := cachedregexp.MustCompile(`(\s*)#.*$`)
 

--- a/pkg/lockfile/python/types.go
+++ b/pkg/lockfile/python/types.go
@@ -178,3 +178,31 @@ type PipfileMatcher struct{}
 type PyprojectTOMLMatcher struct{}
 
 type RequirementsInMatcher struct{}
+
+// ============================================================================
+// PyprojectTOML TOML Types
+// ============================================================================
+
+type pyprojectTOML struct {
+	Tool    pyprojectTool    `toml:"tool"`
+	Project pyprojectProject `toml:"project"`
+}
+
+type pyprojectProject struct {
+	Dependencies         []string            `toml:"dependencies"`
+	OptionalDependencies map[string][]string `toml:"optional-dependencies"`
+}
+
+type pyprojectTool struct {
+	Poetry pyprojectPoetry `toml:"poetry"`
+}
+
+type pyprojectPoetry struct {
+	Dependencies    map[string]any            `toml:"dependencies"`
+	DevDependencies map[string]any            `toml:"dev-dependencies"`
+	Groups          map[string]pyprojectGroup `toml:"group"`
+}
+
+type pyprojectGroup struct {
+	Dependencies map[string]any `toml:"dependencies"`
+}


### PR DESCRIPTION
## 🚀 Motivation
`PyprojectTOMLMatcher` previously delegated to `PipfileMatcher`, which only recognised Poetry's `[tool.poetry.dev-dependencies]` and `[tool.poetry.group.dev.dependencies]` sections via a dumb line scan. This meant any project using PEP 621 format (`[project.dependencies]`) got no direct/transitive classification or file-position enrichment, Poetry projects with non-`dev` named groups lost their group labels, and package names with `_` or `.` separators (e.g. `typing_extensions`) could fail to match their canonicalized lockfile entries.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [K9VULN-13516](https://datadoghq.atlassian.net/browse/K9VULN-13516)

## 📝 Summary
**Refactor:** Extracted `normalizedRequirementName` from `parse-requirements-txt.go` into a new `normalize.go` file so it can be shared across the Python package without either parser owning it.

**Rewrite of `PyprojectTOMLMatcher`:**
- TOML-decodes `pyproject.toml` (instead of a line scan) to build a precise map of which packages are direct dependencies and what groups they belong to
- Supports all Poetry formats: `[tool.poetry.dependencies]`, `[tool.poetry.dev-dependencies]` (legacy), and `[tool.poetry.group.X.dependencies]` for any named group, not just `dev`
- Supports PEP 621 format: `[project.dependencies]` and `[project.optional-dependencies]` — covering UV and other modern Python tools
- Applies PEP 503 normalization (`[-_.]+` → `-`) when indexing package names so that `typing_extensions` in `pyproject.toml` correctly matches `typing-extensions` from the lockfile
- Sets `IsDirect`, `DepGroups`, and source file positions (`BlockLocation`, `NameLocation`, `VersionLocation`) for matched packages

Both `PoetryExtractor` (`poetry.lock`) and `UvExtractor` (`uv.lock`) use this matcher.

## 🧪 Testing
- [x] New tests were added for new logic.
- [ ] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🚧 Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:

[K9VULN-13516]: https://datadoghq.atlassian.net/browse/K9VULN-13516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ