### PR TITLE
[K9VULN-13516] Add opt-in pyproject.toml extractor for lockfile-less Python projects

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -2286,6 +2286,112 @@ Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and fou
 [reachability] Reachability analysis is disabled
 ---
 
+[TestRun/Scan_pyproject.toml_without_lock_file - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:pypi/flask@2.3.2",
+      "type": "library",
+      "name": "flask",
+      "version": "2.3.2",
+      "purl": "pkg:pypi/flask@2.3.2",
+      "properties": [
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "uv"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":5,/"column_end/":20},/"name/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":6,/"column_end/":11},/"version/":{/"file_name/":/"pyproject.toml/",/"line_start/":7,/"line_end/":7,/"column_start/":13,/"column_end/":18}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/pytest@8.2.0",
+      "type": "library",
+      "name": "pytest",
+      "version": "8.2.0",
+      "purl": "pkg:pypi/pytest@8.2.0",
+      "properties": [
+        {
+          "name": "datadog:is-dev",
+          "value": "true"
+        },
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "uv"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pyproject.toml/",/"line_start/":13,/"line_end/":13,/"column_start/":5,/"column_end/":21},/"name/":{/"file_name/":/"pyproject.toml/",/"line_start/":13,/"line_end/":13,/"column_start/":6,/"column_end/":12},/"version/":{/"file_name/":/"pyproject.toml/",/"line_start/":13,/"line_end/":13,/"column_start/":14,/"column_end/":19}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/requests@2.28.0",
+      "type": "library",
+      "name": "requests",
+      "version": "2.28.0",
+      "purl": "pkg:pypi/requests@2.28.0",
+      "properties": [
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "uv"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pyproject.toml/",/"line_start/":6,/"line_end/":6,/"column_start/":5,/"column_end/":24},/"name/":{/"file_name/":/"pyproject.toml/",/"line_start/":6,/"line_end/":6,/"column_start/":6,/"column_end/":14},/"version/":{/"file_name/":/"pyproject.toml/",/"line_start/":6,/"line_end/":6,/"column_start/":16,/"column_end/":22}}"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+---
+
+[TestRun/Scan_pyproject.toml_without_lock_file - 2]
+Scanning directory './fixtures/integration-pyproject', resolved absolute path '<rootdir>/fixtures/integration-pyproject'
+Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3 packages
+[reachability] Reachability analysis is disabled
+---
+
 [TestRun/Scan_yarn_with_workspace_support - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",

--- a/cmd/datadog-sbom-generator/fixtures/integration-pyproject/pyproject.toml
+++ b/cmd/datadog-sbom-generator/fixtures/integration-pyproject/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "my-service"
+version = "1.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "requests==2.28.0",
+    "flask==2.3.2",
+    "numpy>=1.24",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest==8.2.0",
+]
+
+[tool.uv]

--- a/cmd/datadog-sbom-generator/main_test.go
+++ b/cmd/datadog-sbom-generator/main_test.go
@@ -300,6 +300,11 @@ func TestRun(t *testing.T) {
 			args: []string{"", "--pretty", "--verbosity", "verbose", "--enable-parsers=jar", "./fixtures/integration-jar"},
 			exit: 0,
 		},
+		{
+			name: "Scan pyproject.toml without lock file",
+			args: []string{"", "--pretty", "--verbosity", "verbose", "--no-lockfile-parsers", "./fixtures/integration-pyproject"},
+			exit: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/datadog-sbom-generator/scan/main.go
+++ b/cmd/datadog-sbom-generator/scan/main.go
@@ -76,6 +76,11 @@ Examples:
 				Name:  "enable-parsers",
 				Usage: "filter lockfiles to parse by lockfile, package manager or language. Use individual lockfile names (e.g., 'package-lock.json', 'pom.xml'), package manager names(e.g., 'gradle', 'poetry') or language names (e.g., 'javascript', 'java'). To list available parsers use the 'parsers list' command.",
 			},
+			&cli.BoolFlag{
+				Name:  "no-lockfile-parsers",
+				Usage: "also run parsers that extract packages from manifest files (e.g. pyproject.toml) when no lock file is present. Additive to the default parser set.",
+				Value: false,
+			},
 			&cli.StringSliceFlag{
 				Name:  "exclude",
 				Usage: "exclude paths from being scanned using a glob expression (relative to scanned directory)",
@@ -131,6 +136,7 @@ func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, 
 		DirectoryPaths:      context.Args().Slice(),
 		ExcludePaths:        context.StringSlice("exclude"),
 		EnableParsers:       context.StringSlice("enable-parsers"),
+		NoLockfileParsers:   context.Bool("no-lockfile-parsers"),
 		ExitOnConfigFailure: context.Bool("exit-on-config-failure"),
 	}, r)
 

--- a/pkg/lockfile/extract.go
+++ b/pkg/lockfile/extract.go
@@ -51,6 +51,21 @@ func ListSupportedExtractors() map[string]Extractor {
 	return supportedExtractors
 }
 
+func ListNoLockfileExtractorNames() []string {
+	var names []string
+	for name, extractor := range lockfileExtractors {
+		if e, ok := extractor.(NoLockfileExtractor); ok && e.IsNoLockfileParser() {
+			names = append(names, name)
+		}
+	}
+
+	sort.Slice(names, func(i, j int) bool {
+		return strings.ToLower(names[i]) < strings.ToLower(names[j])
+	})
+
+	return names
+}
+
 func ListExtractorNames() []string {
 	extractors := ListSupportedExtractors()
 	extractorNames := make([]string, 0, len(extractors))

--- a/pkg/lockfile/extract_test.go
+++ b/pkg/lockfile/extract_test.go
@@ -291,6 +291,7 @@ func filesToParsers() map[string]string {
 		"pom.xml":                          "pom.xml",
 		"pubspec.lock":                     "pubspec.lock",
 		"renv.lock":                        "renv.lock",
+		"pyproject.toml":                   "pyproject.toml",
 		"requirements-example.txt":         "requirements.txt",
 		"yarn.lock":                        "yarn.lock",
 		"uv.lock":                          "uv.lock",

--- a/pkg/lockfile/extractor.go
+++ b/pkg/lockfile/extractor.go
@@ -49,6 +49,14 @@ type ArtifactExtractor interface {
 	GetArtifact(f DepFile, context ScanContext) (*models.ScannedArtifact, error)
 }
 
+// NoLockfileExtractor is an optional interface for extractors that parse manifest
+// files directly (e.g. pyproject.toml) when no lock file is present.
+// These extractors are opt-in and not included in the default parser set.
+type NoLockfileExtractor interface {
+	Extractor
+	IsNoLockfileParser() bool
+}
+
 func (e WithMatcher) GetMatchers() []Matcher {
 	return e.Matchers
 }

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/duplicate-groups/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/duplicate-groups/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "my-app"
+version = "1.0.0"
+dependencies = [
+    "requests==2.28.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "requests==2.28.0",
+]

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/invalid/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/invalid/pyproject.toml
@@ -1,0 +1,1 @@
+this is not valid toml [[[

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/no-pinned/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/no-pinned/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "my-app"
+version = "1.0.0"
+dependencies = [
+    "requests>=2.28",
+    "flask~=2.3",
+    "numpy",
+]

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/pep621-optional/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/pep621-optional/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "my-lib"
+version = "1.0.0"
+dependencies = [
+    "requests==2.28.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest==7.4.0",
+    "mypy==1.5.0",
+]
+docs = [
+    "sphinx==7.1.0",
+]

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/pep621-parens/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/pep621-parens/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "my-app"
+version = "1.0.0"
+dependencies = [
+    "requests (==2.28.0)",
+]

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/pep621-pinned/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/pep621-pinned/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "my-app"
+version = "1.0.0"
+dependencies = [
+    "requests==2.28.0",
+    "flask==2.3.2",
+    "numpy>=1.24",
+    "scipy",
+    "boto3==1.26.0",
+]

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/poetry-groups/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/poetry-groups/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "my-app"
+version = "1.0.0"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+requests = "==2.28.0"
+
+[tool.poetry.dev-dependencies]
+black = "==23.1.0"
+
+[tool.poetry.group.test.dependencies]
+pytest = "==7.4.0"
+pytest-cov = {version = "==4.1.0"}

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/poetry-pinned/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/poetry-pinned/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "my-app"
+version = "1.0.0"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+requests = "==2.28.0"
+flask = "==2.3.2"
+boto3 = "1.26.0"
+numpy = "^1.24"

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/uv-dependency-groups/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/uv-dependency-groups/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "my-app"
+version = "1.0.0"
+dependencies = [
+    "requests==2.28.0",
+]
+
+[tool.uv]
+
+[dependency-groups]
+dev = [
+    "pytest==7.4.0",
+    "ruff==0.1.0",
+    {include-group = "test"},
+]
+test = [
+    "hypothesis==6.100.0",
+]

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/with-poetry-lock/poetry.lock
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/with-poetry-lock/poetry.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "requests"
+version = "2.28.0"

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/with-poetry-lock/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/with-poetry-lock/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "my-app"
+version = "1.0.0"
+
+[tool.poetry.dependencies]
+requests = "==2.28.0"

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/with-uv-lock/pyproject.toml
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/with-uv-lock/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "my-app"
+version = "1.0.0"
+dependencies = [
+    "requests==2.28.0",
+]

--- a/pkg/lockfile/fixtures/pyproject-toml-extractor/with-uv-lock/uv.lock
+++ b/pkg/lockfile/fixtures/pyproject-toml-extractor/with-uv-lock/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/pkg/lockfile/python/parse-pyproject-toml.go
+++ b/pkg/lockfile/python/parse-pyproject-toml.go
@@ -1,0 +1,343 @@
+package python
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+)
+
+var pyprojectSiblingLockfiles = []string{
+	models.PoetryFilePath.String(),
+	models.PdmFilePath.String(),
+	models.UvFilePath.String(),
+	models.PipfileFilePath.String(),
+}
+
+// hasSiblingLockfile returns true if any known Python lock file exists in the same directory as f.
+// The check is unconditional — regardless of which parsers are enabled — because a sibling lock
+// file always describes this project more accurately than a manifest-derived scan.
+// Ancestor directories are intentionally not checked: an ancestor lock file does not describe a nested project.
+func hasSiblingLockfile(f lockfile.DepFile) bool {
+	for _, name := range pyprojectSiblingLockfiles {
+		if sibling, err := f.Open(name); err == nil {
+			sibling.Close()
+			return true
+		}
+	}
+
+	return false
+}
+
+// detectPackageManager determines the package manager from the parsed pyproject.toml content.
+// Poetry is detected via [tool.poetry] or the poetry build backend.
+// PDM is detected via [tool.pdm].
+// uv is detected via [tool.uv].
+// Everything else is Unknown — [dependency-groups] alone is not sufficient since PEP 735 is tool-agnostic.
+func detectPackageManager(pyproject *PyProjectTOML) models.PackageManager {
+	if pyproject.Tool.Poetry != nil || strings.Contains(pyproject.BuildSystem.BuildBackend, "poetry") {
+		return models.Poetry
+	}
+
+	if pyproject.Tool.PDM != nil {
+		return models.Pdm
+	}
+
+	if pyproject.Tool.UV != nil {
+		return models.Uv
+	}
+
+	return models.Unknown
+}
+
+// extractPositions finds the line containing the given name in lines and returns
+// block, name, and version positions. For PEP 621 string deps the version appears
+// inline; for Poetry key=value deps the version is in a quoted value.
+func extractPositions(lines []string, filePath, name, version string, isPoetry bool) (models.FilePosition, *models.FilePosition, *models.FilePosition) {
+	lowerName := strings.ToLower(name)
+
+	for i, line := range lines {
+		if !strings.Contains(strings.ToLower(line), lowerName) {
+			continue
+		}
+
+		lineNumber := i + 1
+		startCol := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+		endCol := fileposition.GetLastNonEmptyCharacterIndexInLine(line)
+
+		block := models.FilePosition{
+			Line:     models.Position{Start: lineNumber, End: lineNumber},
+			Column:   models.Position{Start: startCol, End: endCol},
+			Filename: filePath,
+		}
+
+		nameLocation := fileposition.ExtractStringPositionInBlock([]string{line}, lowerName, lineNumber)
+		if nameLocation != nil {
+			nameLocation.Filename = filePath
+		}
+
+		var versionLocation *models.FilePosition
+		if version != "" {
+			if isPoetry {
+				versionLocation = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{line}, ".*", lineNumber, "=\\s*\"", "\"")
+			} else {
+				versionLocation = fileposition.ExtractStringPositionInBlock([]string{line}, version, lineNumber)
+			}
+			if versionLocation != nil {
+				versionLocation.Filename = filePath
+			}
+		}
+
+		return block, nameLocation, versionLocation
+	}
+
+	return models.FilePosition{Filename: filePath}, nil, nil
+}
+
+func (e PyProjectTOMLExtractor) ShouldExtract(path string) bool {
+	return filepath.Base(path) == models.PyProjectTomlFilePath.String()
+}
+
+func (e PyProjectTOMLExtractor) IsOfficiallySupported() bool {
+	return pyprojectOfficiallySupported
+}
+
+func (e PyProjectTOMLExtractor) IsNoLockfileParser() bool {
+	return true
+}
+
+func (e PyProjectTOMLExtractor) PackageManager() models.PackageManager {
+	return models.Uv
+}
+
+func (e PyProjectTOMLExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
+	if hasSiblingLockfile(f) {
+		return []lockfile.PackageDetails{}, nil
+	}
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read from %s: %w", f.Path(), err)
+	}
+
+	var pyproject PyProjectTOML
+	if err := toml.Unmarshal(content, &pyproject); err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	lines := fileposition.BytesToLines(content)
+	pm := detectPackageManager(&pyproject)
+	packages := map[string]lockfile.PackageDetails{}
+
+	for _, dep := range pyproject.Project.Dependencies {
+		if name, version, ok := parsePEP508Pin(dep); ok {
+			block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, false)
+			addOrMergeGroups(packages, name, version, []string{"prod"}, pm, block, nameLocation, versionLocation)
+		}
+	}
+
+	for group, deps := range pyproject.Project.OptionalDependencies {
+		for _, dep := range deps {
+			if name, version, ok := parsePEP508Pin(dep); ok {
+				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, false)
+				addOrMergeGroups(packages, name, version, []string{group}, pm, block, nameLocation, versionLocation)
+			}
+		}
+	}
+
+	for group, items := range pyproject.DependencyGroups {
+		for _, item := range items {
+			dep, ok := item.(string)
+			if !ok {
+				// skip {include-group = "..."} table entries
+				continue
+			}
+			if name, version, ok := parsePEP508Pin(dep); ok {
+				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, false)
+				addOrMergeGroups(packages, name, version, []string{group}, pm, block, nameLocation, versionLocation)
+			}
+		}
+	}
+
+	if pyproject.Tool.Poetry != nil {
+		for name, val := range pyproject.Tool.Poetry.Dependencies {
+			// Poetry uses the "python" key to constrain the interpreter version, not a package dependency
+			if name == "python" {
+				continue
+			}
+			if version, ok := parsePoetryPin(val); ok {
+				normalized := normalizedRequirementName(name)
+				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), normalized, version, true)
+				addOrMergeGroups(packages, normalized, version, []string{"prod"}, pm, block, nameLocation, versionLocation)
+			}
+		}
+		for name, val := range pyproject.Tool.Poetry.DevDependencies {
+			if version, ok := parsePoetryPin(val); ok {
+				normalized := normalizedRequirementName(name)
+				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), normalized, version, true)
+				addOrMergeGroups(packages, normalized, version, []string{"dev"}, pm, block, nameLocation, versionLocation)
+			}
+		}
+		for groupName, group := range pyproject.Tool.Poetry.Group {
+			for name, val := range group.Dependencies {
+				if version, ok := parsePoetryPin(val); ok {
+					normalized := normalizedRequirementName(name)
+					block, nameLocation, versionLocation := extractPositions(lines, f.Path(), normalized, version, true)
+					addOrMergeGroups(packages, normalized, version, []string{groupName}, pm, block, nameLocation, versionLocation)
+				}
+			}
+		}
+	}
+
+	return slices.Collect(maps.Values(packages)), nil
+}
+
+// addOrMergeGroups adds a package to the map, or if it already exists (same name+version),
+// merges the new dep groups into the existing entry rather than dropping the duplicate.
+func addOrMergeGroups(packages map[string]lockfile.PackageDetails, name, version string, groups []string, pm models.PackageManager, block models.FilePosition, nameLocation, versionLocation *models.FilePosition) {
+	key := name + "@" + version
+	if existing, exists := packages[key]; exists {
+		for _, g := range groups {
+			if !slices.Contains(existing.DepGroups, g) {
+				existing.DepGroups = append(existing.DepGroups, g)
+			}
+		}
+		packages[key] = existing
+
+		return
+	}
+	packages[key] = lockfile.PackageDetails{
+		Name:            name,
+		Version:         version,
+		PackageManager:  pm,
+		Ecosystem:       models.EcosystemPyPI,
+		IsDirect:        true,
+		DepGroups:       groups,
+		BlockLocation:   block,
+		NameLocation:    nameLocation,
+		VersionLocation: versionLocation,
+	}
+}
+
+// parsePEP508Pin parses a PEP 508 dependency string and returns the normalized name and version
+// only when the dependency is an exact pin (==). Returns ok=false for all other specifiers.
+func parsePEP508Pin(dep string) (name, version string, ok bool) {
+	// strip environment markers (PEP 508)
+	dep, _, _ = strings.Cut(dep, ";")
+	dep = strings.TrimSpace(dep)
+
+	// Find the == operator and ensure it is a standalone exact-pin, not part of
+	// !=, >=, <=, ~= (checked via the preceding character) or === (checked via the following character).
+	idx := strings.Index(dep, "==")
+	if idx < 0 {
+		return "", "", false
+	}
+	if idx > 0 {
+		if prev := dep[idx-1]; prev == '!' || prev == '>' || prev == '<' || prev == '~' {
+			return "", "", false
+		}
+	}
+	if idx+2 < len(dep) && dep[idx+2] == '=' {
+		return "", "", false
+	}
+	// reject multi-constraint specs where == appears after another constraint e.g. "requests~=2.28,==2.28.0"
+	if strings.Contains(dep[:idx], ",") {
+		return "", "", false
+	}
+
+	// strip optional parenthesis: "requests (" -> "requests"
+	rawName := strings.TrimRight(strings.TrimSpace(dep[:idx]), "( ")
+	rawVersion := strings.TrimSpace(dep[idx+2:])
+
+	// strip extras: requests[security] -> requests
+	rawName, _, _ = strings.Cut(rawName, "[")
+	rawName = strings.TrimSpace(rawName)
+
+	// reject multi-constraint specs like "==2.28.0,!=2.28.0" — not an exact pin
+	if strings.Contains(rawVersion, ",") {
+		return "", "", false
+	}
+	rawVersion = strings.TrimSpace(strings.TrimRight(rawVersion, ")"))
+
+	if rawName == "" || rawVersion == "" || !isConcreteVersion(rawVersion) {
+		return "", "", false
+	}
+
+	return normalizedRequirementName(rawName), rawVersion, true
+}
+
+// parsePoetryPin parses a Poetry dependency value (string or inline table) and returns
+// the version only when it is an exact pin (== prefix) with a concrete version.
+func parsePoetryPin(val any) (version string, ok bool) {
+	var versionStr string
+	switch v := val.(type) {
+	case string:
+		versionStr = v
+	case map[string]any:
+		versionStr, ok = v["version"].(string)
+		if !ok {
+			return "", false
+		}
+	default:
+		return "", false
+	}
+
+	versionStr = strings.TrimSpace(versionStr)
+
+	// Poetry bare version string "2.28.0" is an implicit exact pin
+	if len(versionStr) > 0 && !strings.ContainsAny(string(versionStr[0]), "=!<>~^*") {
+		if strings.Contains(versionStr, ",") {
+			return "", false
+		}
+		if isConcreteVersion(versionStr) {
+			return versionStr, true
+		}
+
+		return "", false
+	}
+
+	// reject === (arbitrary equality) and any non-== operator
+	if !strings.HasPrefix(versionStr, "==") || strings.HasPrefix(versionStr, "===") {
+		return "", false
+	}
+
+	after := strings.TrimSpace(versionStr[2:])
+
+	// reject multi-constraint: "==2.28.0,!=2.28.1" is not an exact pin
+	if strings.Contains(after, ",") {
+		return "", false
+	}
+
+	if isConcreteVersion(after) {
+		return after, true
+	}
+
+	return "", false
+}
+
+// isConcreteVersion returns true if version looks like a fully-specified version
+// (no wildcards, no spaces). This guards against patterns like "2.28.*" or "2.28 ".
+func isConcreteVersion(version string) bool {
+	return version != "" && !strings.Contains(version, "*") && !strings.ContainsAny(version, " \t")
+}
+
+var PyProjectExtractor = PyProjectTOMLExtractor{}
+
+func ParsePyProjectTOML(pathToLockfile string) ([]lockfile.PackageDetails, error) {
+	return lockfile.ExtractFromFile(pathToLockfile, PyProjectExtractor)
+}
+
+var _ lockfile.Extractor = PyProjectExtractor
+var _ lockfile.NoLockfileExtractor = PyProjectExtractor
+
+//nolint:gochecknoinits
+func init() {
+	lockfile.RegisterExtractor(models.PyProjectTomlFilePath, PyProjectExtractor)
+}

--- a/pkg/lockfile/python/parse-pyproject-toml.go
+++ b/pkg/lockfile/python/parse-pyproject-toml.go
@@ -67,6 +67,10 @@ func extractPositions(lines []string, filePath, rawName, version string, isPoetr
 
 	for i, line := range lines {
 		lowerLine := strings.ToLower(line)
+		// skip comment lines — a commented-out dependency must not be mistaken for an active one
+		if strings.HasPrefix(strings.TrimSpace(lowerLine), "#") {
+			continue
+		}
 		if !strings.Contains(lowerLine, lowerRawName) {
 			continue
 		}
@@ -94,7 +98,8 @@ func extractPositions(lines []string, filePath, rawName, version string, isPoetr
 		var versionLocation *models.FilePosition
 		if version != "" {
 			if isPoetry {
-				versionLocation = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{lowerLine}, ".*", lineNumber, "=\\s*\"", "\"")
+				// Match version in both single- and double-quoted TOML assignments: key = "..." or key = '...'
+				versionLocation = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{lowerLine}, ".*", lineNumber, "=\\s*[\"']", "[\"']")
 			} else {
 				versionLocation = fileposition.ExtractStringPositionInBlock([]string{lowerLine}, lowerVersion, lineNumber)
 			}

--- a/pkg/lockfile/python/parse-pyproject-toml.go
+++ b/pkg/lockfile/python/parse-pyproject-toml.go
@@ -57,14 +57,22 @@ func detectPackageManager(pyproject *PyProjectTOML) models.PackageManager {
 	return models.Unknown
 }
 
-// extractPositions finds the line containing the given name in lines and returns
-// block, name, and version positions. For PEP 621 string deps the version appears
-// inline; for Poetry key=value deps the version is in a quoted value.
-func extractPositions(lines []string, filePath, name, version string, isPoetry bool) (models.FilePosition, *models.FilePosition, *models.FilePosition) {
-	lowerName := strings.ToLower(name)
+// extractPositions finds the line containing the given rawName and version in lines and returns
+// block, name, and version positions. rawName is the pre-normalization name as it appears in the
+// file (e.g. "my_pkg"), which may differ from the normalized name used as the package key.
+// For PEP 621 string deps the version appears inline; for Poetry key=value deps it is quoted.
+func extractPositions(lines []string, filePath, rawName, version string, isPoetry bool) (models.FilePosition, *models.FilePosition, *models.FilePosition) {
+	lowerRawName := strings.ToLower(rawName)
+	lowerVersion := strings.ToLower(version)
 
 	for i, line := range lines {
-		if !strings.Contains(strings.ToLower(line), lowerName) {
+		lowerLine := strings.ToLower(line)
+		if !strings.Contains(lowerLine, lowerRawName) {
+			continue
+		}
+		// Verify the version also appears on this line to avoid matching the wrong occurrence
+		// when the same package name appears in multiple sections with different versions.
+		if version != "" && !strings.Contains(lowerLine, lowerVersion) {
 			continue
 		}
 
@@ -78,7 +86,7 @@ func extractPositions(lines []string, filePath, name, version string, isPoetry b
 			Filename: filePath,
 		}
 
-		nameLocation := fileposition.ExtractStringPositionInBlock([]string{line}, lowerName, lineNumber)
+		nameLocation := fileposition.ExtractStringPositionInBlock([]string{lowerLine}, lowerRawName, lineNumber)
 		if nameLocation != nil {
 			nameLocation.Filename = filePath
 		}
@@ -86,9 +94,9 @@ func extractPositions(lines []string, filePath, name, version string, isPoetry b
 		var versionLocation *models.FilePosition
 		if version != "" {
 			if isPoetry {
-				versionLocation = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{line}, ".*", lineNumber, "=\\s*\"", "\"")
+				versionLocation = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{lowerLine}, ".*", lineNumber, "=\\s*\"", "\"")
 			} else {
-				versionLocation = fileposition.ExtractStringPositionInBlock([]string{line}, version, lineNumber)
+				versionLocation = fileposition.ExtractStringPositionInBlock([]string{lowerLine}, lowerVersion, lineNumber)
 			}
 			if versionLocation != nil {
 				versionLocation.Filename = filePath
@@ -137,16 +145,16 @@ func (e PyProjectTOMLExtractor) Extract(f lockfile.DepFile, context lockfile.Sca
 	packages := map[string]lockfile.PackageDetails{}
 
 	for _, dep := range pyproject.Project.Dependencies {
-		if name, version, ok := parsePEP508Pin(dep); ok {
-			block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, false)
+		if name, rawName, version, ok := parsePEP508Pin(dep); ok {
+			block, nameLocation, versionLocation := extractPositions(lines, f.Path(), rawName, version, false)
 			addOrMergeGroups(packages, name, version, []string{"prod"}, pm, block, nameLocation, versionLocation)
 		}
 	}
 
 	for group, deps := range pyproject.Project.OptionalDependencies {
 		for _, dep := range deps {
-			if name, version, ok := parsePEP508Pin(dep); ok {
-				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, false)
+			if name, rawName, version, ok := parsePEP508Pin(dep); ok {
+				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), rawName, version, false)
 				addOrMergeGroups(packages, name, version, []string{group}, pm, block, nameLocation, versionLocation)
 			}
 		}
@@ -159,8 +167,8 @@ func (e PyProjectTOMLExtractor) Extract(f lockfile.DepFile, context lockfile.Sca
 				// skip {include-group = "..."} table entries
 				continue
 			}
-			if name, version, ok := parsePEP508Pin(dep); ok {
-				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, false)
+			if name, rawName, version, ok := parsePEP508Pin(dep); ok {
+				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), rawName, version, false)
 				addOrMergeGroups(packages, name, version, []string{group}, pm, block, nameLocation, versionLocation)
 			}
 		}
@@ -226,9 +234,10 @@ func addOrMergeGroups(packages map[string]lockfile.PackageDetails, name, version
 	}
 }
 
-// parsePEP508Pin parses a PEP 508 dependency string and returns the normalized name and version
-// only when the dependency is an exact pin (==). Returns ok=false for all other specifiers.
-func parsePEP508Pin(dep string) (name, version string, ok bool) {
+// parsePEP508Pin parses a PEP 508 dependency string and returns the normalized name, the raw
+// (pre-normalization) name as written in the file, and the version — only when the dependency
+// is an exact pin (==). Returns ok=false for all other specifiers.
+func parsePEP508Pin(dep string) (name, rawName, version string, ok bool) {
 	// strip environment markers (PEP 508)
 	dep, _, _ = strings.Cut(dep, ";")
 	dep = strings.TrimSpace(dep)
@@ -237,40 +246,40 @@ func parsePEP508Pin(dep string) (name, version string, ok bool) {
 	// !=, >=, <=, ~= (checked via the preceding character) or === (checked via the following character).
 	idx := strings.Index(dep, "==")
 	if idx < 0 {
-		return "", "", false
+		return "", "", "", false
 	}
 	if idx > 0 {
 		if prev := dep[idx-1]; prev == '!' || prev == '>' || prev == '<' || prev == '~' {
-			return "", "", false
+			return "", "", "", false
 		}
 	}
 	if idx+2 < len(dep) && dep[idx+2] == '=' {
-		return "", "", false
+		return "", "", "", false
 	}
 	// reject multi-constraint specs where == appears after another constraint e.g. "requests~=2.28,==2.28.0"
 	if strings.Contains(dep[:idx], ",") {
-		return "", "", false
+		return "", "", "", false
 	}
 
 	// strip optional parenthesis: "requests (" -> "requests"
-	rawName := strings.TrimRight(strings.TrimSpace(dep[:idx]), "( ")
+	fileRawName := strings.TrimRight(strings.TrimSpace(dep[:idx]), "( ")
 	rawVersion := strings.TrimSpace(dep[idx+2:])
 
 	// strip extras: requests[security] -> requests
-	rawName, _, _ = strings.Cut(rawName, "[")
-	rawName = strings.TrimSpace(rawName)
+	fileRawName, _, _ = strings.Cut(fileRawName, "[")
+	fileRawName = strings.TrimSpace(fileRawName)
 
 	// reject multi-constraint specs like "==2.28.0,!=2.28.0" — not an exact pin
 	if strings.Contains(rawVersion, ",") {
-		return "", "", false
+		return "", "", "", false
 	}
 	rawVersion = strings.TrimSpace(strings.TrimRight(rawVersion, ")"))
 
-	if rawName == "" || rawVersion == "" || !isConcreteVersion(rawVersion) {
-		return "", "", false
+	if fileRawName == "" || rawVersion == "" || !isConcreteVersion(rawVersion) {
+		return "", "", "", false
 	}
 
-	return normalizedRequirementName(rawName), rawVersion, true
+	return normalizedRequirementName(fileRawName), fileRawName, rawVersion, true
 }
 
 // parsePoetryPin parses a Poetry dependency value (string or inline table) and returns

--- a/pkg/lockfile/python/parse-pyproject-toml.go
+++ b/pkg/lockfile/python/parse-pyproject-toml.go
@@ -71,10 +71,17 @@ func extractPositions(lines []string, filePath, rawName, version string, isPoetr
 		if strings.HasPrefix(strings.TrimSpace(lowerLine), "#") {
 			continue
 		}
-		// Match the name as a full token — a name like "foo" must not match a line for "foo-bar"
+		// Match the name as a full token — neither a prefix ("foo" must not match "foo-bar")
+		// nor a suffix ("requests" must not match "myrequests").
 		nameIdx := strings.Index(lowerLine, lowerRawName)
 		if nameIdx < 0 {
 			continue
+		}
+		if nameIdx > 0 {
+			prev := lowerLine[nameIdx-1]
+			if prev != '"' && prev != '\'' && prev != ' ' && prev != '\t' {
+				continue
+			}
 		}
 		afterName := nameIdx + len(lowerRawName)
 		if afterName < len(lowerLine) {

--- a/pkg/lockfile/python/parse-pyproject-toml.go
+++ b/pkg/lockfile/python/parse-pyproject-toml.go
@@ -71,8 +71,17 @@ func extractPositions(lines []string, filePath, rawName, version string, isPoetr
 		if strings.HasPrefix(strings.TrimSpace(lowerLine), "#") {
 			continue
 		}
-		if !strings.Contains(lowerLine, lowerRawName) {
+		// Match the name as a full token — a name like "foo" must not match a line for "foo-bar"
+		nameIdx := strings.Index(lowerLine, lowerRawName)
+		if nameIdx < 0 {
 			continue
+		}
+		afterName := nameIdx + len(lowerRawName)
+		if afterName < len(lowerLine) {
+			next := lowerLine[afterName]
+			if next != '=' && next != '[' && next != '"' && next != '\'' && next != ' ' && next != '\t' && next != ',' && next != ')' {
+				continue
+			}
 		}
 		// Verify the version also appears on this line to avoid matching the wrong occurrence
 		// when the same package name appears in multiple sections with different versions.
@@ -98,8 +107,13 @@ func extractPositions(lines []string, filePath, rawName, version string, isPoetr
 		var versionLocation *models.FilePosition
 		if version != "" {
 			if isPoetry {
-				// Match version in both single- and double-quoted TOML assignments: key = "..." or key = '...'
-				versionLocation = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{lowerLine}, ".*", lineNumber, "=\\s*[\"']", "[\"']")
+				// For inline tables like {version = "==2.28.0", source = "..."}, anchor to the version key
+				// to avoid greedily matching other quoted fields.
+				// For simple assignments like requests = "==2.28.0", fall back to the first quoted value.
+				versionLocation = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{lowerLine}, "[^\"']+", lineNumber, "version\\s*=\\s*[\"']", "[\"']")
+				if versionLocation == nil {
+					versionLocation = fileposition.ExtractDelimitedRegexpPositionInBlock([]string{lowerLine}, "[^\"']+", lineNumber, "=\\s*[\"']", "[\"']")
+				}
 			} else {
 				versionLocation = fileposition.ExtractStringPositionInBlock([]string{lowerLine}, lowerVersion, lineNumber)
 			}

--- a/pkg/lockfile/python/parse-pyproject-toml.go
+++ b/pkg/lockfile/python/parse-pyproject-toml.go
@@ -182,14 +182,14 @@ func (e PyProjectTOMLExtractor) Extract(f lockfile.DepFile, context lockfile.Sca
 			}
 			if version, ok := parsePoetryPin(val); ok {
 				normalized := normalizedRequirementName(name)
-				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), normalized, version, true)
+				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, true)
 				addOrMergeGroups(packages, normalized, version, []string{"prod"}, pm, block, nameLocation, versionLocation)
 			}
 		}
 		for name, val := range pyproject.Tool.Poetry.DevDependencies {
 			if version, ok := parsePoetryPin(val); ok {
 				normalized := normalizedRequirementName(name)
-				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), normalized, version, true)
+				block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, true)
 				addOrMergeGroups(packages, normalized, version, []string{"dev"}, pm, block, nameLocation, versionLocation)
 			}
 		}
@@ -197,7 +197,7 @@ func (e PyProjectTOMLExtractor) Extract(f lockfile.DepFile, context lockfile.Sca
 			for name, val := range group.Dependencies {
 				if version, ok := parsePoetryPin(val); ok {
 					normalized := normalizedRequirementName(name)
-					block, nameLocation, versionLocation := extractPositions(lines, f.Path(), normalized, version, true)
+					block, nameLocation, versionLocation := extractPositions(lines, f.Path(), name, version, true)
 					addOrMergeGroups(packages, normalized, version, []string{groupName}, pm, block, nameLocation, versionLocation)
 				}
 			}
@@ -257,7 +257,13 @@ func parsePEP508Pin(dep string) (name, rawName, version string, ok bool) {
 		return "", "", "", false
 	}
 	// reject multi-constraint specs where == appears after another constraint e.g. "requests~=2.28,==2.28.0"
-	if strings.Contains(dep[:idx], ",") {
+	// Only check for commas outside of brackets to allow extras like "requests[socks,security]==2.28.0"
+	nameSegment := dep[:idx]
+	if bracketEnd := strings.Index(nameSegment, "]"); bracketEnd >= 0 {
+		if strings.Contains(nameSegment[bracketEnd:], ",") {
+			return "", "", "", false
+		}
+	} else if strings.Contains(nameSegment, ",") {
 		return "", "", "", false
 	}
 

--- a/pkg/lockfile/python/parse-pyproject-toml_test.go
+++ b/pkg/lockfile/python/parse-pyproject-toml_test.go
@@ -1,0 +1,292 @@
+package python_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/python"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+)
+
+func fixturePath(t *testing.T, rel string) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get working directory: %v", err)
+	}
+
+	return filepath.FromSlash(filepath.Join(dir, rel))
+}
+
+func pos(filename string, lineStart, lineEnd, colStart, colEnd int) models.FilePosition {
+	return models.FilePosition{
+		Line:     models.Position{Start: lineStart, End: lineEnd},
+		Column:   models.Position{Start: colStart, End: colEnd},
+		Filename: filename,
+	}
+}
+
+func posPtr(filename string, lineStart, lineEnd, colStart, colEnd int) *models.FilePosition {
+	p := pos(filename, lineStart, lineEnd, colStart, colEnd)
+	return &p
+}
+
+// ============================================================================
+// ShouldExtract
+// ============================================================================
+
+func TestPyProjectTOMLExtractor_ShouldExtract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "empty", path: "", want: false},
+		{name: "plain", path: "pyproject.toml", want: true},
+		{name: "absolute", path: "/path/to/pyproject.toml", want: true},
+		{name: "relative", path: "../../pyproject.toml", want: true},
+		{name: "in-path", path: "/path/with/pyproject.toml/in/middle", want: false},
+		{name: "invalid-suffix", path: "pyproject.toml.bak", want: false},
+		{name: "invalid-prefix", path: "old.pyproject.toml", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ext := python.PyProjectTOMLExtractor{}
+			if got := ext.ShouldExtract(tt.path); got != tt.want {
+				t.Errorf("ShouldExtract(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// PEP 621 [project] dependencies
+// ============================================================================
+
+func TestParsePyProjectTOML_PEP621_PinnedExtracted(t *testing.T) {
+	t.Parallel()
+
+	path := fixturePath(t, "../fixtures/pyproject-toml-extractor/pep621-pinned/pyproject.toml")
+	packages, err := python.ParsePyProjectTOML(path)
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name: "requests", Version: "2.28.0", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 5, 5, 5, 24), NameLocation: posPtr(path, 5, 5, 6, 14), VersionLocation: posPtr(path, 5, 5, 16, 22),
+		},
+		{
+			Name: "flask", Version: "2.3.2", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 6, 6, 5, 20), NameLocation: posPtr(path, 6, 6, 6, 11), VersionLocation: posPtr(path, 6, 6, 13, 18),
+		},
+		{
+			Name: "boto3", Version: "1.26.0", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 9, 9, 5, 21), NameLocation: posPtr(path, 9, 9, 6, 11), VersionLocation: posPtr(path, 9, 9, 13, 19),
+		},
+	})
+}
+
+func TestParsePyProjectTOML_PEP621_UnpinnedSkipped(t *testing.T) {
+	t.Parallel()
+
+	packages, err := python.ParsePyProjectTOML(fixturePath(t, "../fixtures/pyproject-toml-extractor/no-pinned/pyproject.toml"))
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+// ============================================================================
+// [project.optional-dependencies]
+// ============================================================================
+
+func TestParsePyProjectTOML_PEP621_OptionalDeps(t *testing.T) {
+	t.Parallel()
+
+	path := fixturePath(t, "../fixtures/pyproject-toml-extractor/pep621-optional/pyproject.toml")
+	packages, err := python.ParsePyProjectTOML(path)
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name: "requests", Version: "2.28.0", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 5, 5, 5, 24), NameLocation: posPtr(path, 5, 5, 6, 14), VersionLocation: posPtr(path, 5, 5, 16, 22),
+		},
+		{
+			Name: "pytest", Version: "7.4.0", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"dev"},
+			BlockLocation: pos(path, 10, 10, 5, 21), NameLocation: posPtr(path, 10, 10, 6, 12), VersionLocation: posPtr(path, 10, 10, 14, 19),
+		},
+		{
+			Name: "mypy", Version: "1.5.0", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"dev"},
+			BlockLocation: pos(path, 11, 11, 5, 19), NameLocation: posPtr(path, 11, 11, 6, 10), VersionLocation: posPtr(path, 11, 11, 12, 17),
+		},
+		{
+			Name: "sphinx", Version: "7.1.0", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"docs"},
+			BlockLocation: pos(path, 14, 14, 5, 21), NameLocation: posPtr(path, 14, 14, 6, 12), VersionLocation: posPtr(path, 14, 14, 14, 19),
+		},
+	})
+}
+
+// ============================================================================
+// [dependency-groups] (PEP 735 / uv)
+// ============================================================================
+
+func TestParsePyProjectTOML_DependencyGroups_PinnedExtracted(t *testing.T) {
+	t.Parallel()
+
+	path := fixturePath(t, "../fixtures/pyproject-toml-extractor/uv-dependency-groups/pyproject.toml")
+	packages, err := python.ParsePyProjectTOML(path)
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name: "requests", Version: "2.28.0", PackageManager: models.Uv, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 5, 5, 5, 24), NameLocation: posPtr(path, 5, 5, 6, 14), VersionLocation: posPtr(path, 5, 5, 16, 22),
+		},
+		{
+			Name: "pytest", Version: "7.4.0", PackageManager: models.Uv, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"dev"},
+			BlockLocation: pos(path, 12, 12, 5, 21), NameLocation: posPtr(path, 12, 12, 6, 12), VersionLocation: posPtr(path, 12, 12, 14, 19),
+		},
+		{
+			Name: "ruff", Version: "0.1.0", PackageManager: models.Uv, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"dev"},
+			BlockLocation: pos(path, 13, 13, 5, 19), NameLocation: posPtr(path, 13, 13, 6, 10), VersionLocation: posPtr(path, 13, 13, 12, 17),
+		},
+		{
+			Name: "hypothesis", Version: "6.100.0", PackageManager: models.Uv, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"test"},
+			BlockLocation: pos(path, 17, 17, 5, 27), NameLocation: posPtr(path, 17, 17, 6, 16), VersionLocation: posPtr(path, 17, 17, 18, 25),
+		},
+	})
+}
+
+// ============================================================================
+// [tool.poetry] detection
+// ============================================================================
+
+func TestParsePyProjectTOML_Poetry_PinnedExtracted(t *testing.T) {
+	t.Parallel()
+
+	path := fixturePath(t, "../fixtures/pyproject-toml-extractor/poetry-pinned/pyproject.toml")
+	packages, err := python.ParsePyProjectTOML(path)
+
+	expectNilErr(t, err)
+	// python version constraint must be skipped; unpinned numpy (^) must be skipped
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name: "requests", Version: "2.28.0", PackageManager: models.Poetry, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 11, 11, 1, 22), NameLocation: posPtr(path, 11, 11, 1, 9), VersionLocation: posPtr(path, 11, 11, 13, 21),
+		},
+		{
+			Name: "flask", Version: "2.3.2", PackageManager: models.Poetry, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 12, 12, 1, 18), NameLocation: posPtr(path, 12, 12, 1, 6), VersionLocation: posPtr(path, 12, 12, 10, 17),
+		},
+		{
+			Name: "boto3", Version: "1.26.0", PackageManager: models.Poetry, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 13, 13, 1, 17), NameLocation: posPtr(path, 13, 13, 1, 6), VersionLocation: posPtr(path, 13, 13, 10, 16),
+		},
+	})
+}
+
+func TestParsePyProjectTOML_Poetry_GroupDeps(t *testing.T) {
+	t.Parallel()
+
+	path := fixturePath(t, "../fixtures/pyproject-toml-extractor/poetry-groups/pyproject.toml")
+	packages, err := python.ParsePyProjectTOML(path)
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name: "requests", Version: "2.28.0", PackageManager: models.Poetry, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 11, 11, 1, 22), NameLocation: posPtr(path, 11, 11, 1, 9), VersionLocation: posPtr(path, 11, 11, 13, 21),
+		},
+		{
+			Name: "black", Version: "23.1.0", PackageManager: models.Poetry, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"dev"},
+			BlockLocation: pos(path, 14, 14, 1, 19), NameLocation: posPtr(path, 14, 14, 1, 6), VersionLocation: posPtr(path, 14, 14, 10, 18),
+		},
+		{
+			Name: "pytest", Version: "7.4.0", PackageManager: models.Poetry, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"test"},
+			BlockLocation: pos(path, 17, 17, 1, 19), NameLocation: posPtr(path, 17, 17, 1, 7), VersionLocation: posPtr(path, 17, 17, 11, 18),
+		},
+		{
+			Name: "pytest-cov", Version: "4.1.0", PackageManager: models.Poetry, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"test"},
+			BlockLocation: pos(path, 18, 18, 1, 35), NameLocation: posPtr(path, 18, 18, 1, 11), VersionLocation: posPtr(path, 18, 18, 26, 33),
+		},
+	})
+}
+
+// ============================================================================
+// Lock file guard
+// ============================================================================
+
+func TestParsePyProjectTOML_SupressedByUvLock(t *testing.T) {
+	t.Parallel()
+
+	packages, err := python.ParsePyProjectTOML(fixturePath(t, "../fixtures/pyproject-toml-extractor/with-uv-lock/pyproject.toml"))
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+func TestParsePyProjectTOML_SuppressedByPoetryLock(t *testing.T) {
+	t.Parallel()
+
+	packages, err := python.ParsePyProjectTOML(fixturePath(t, "../fixtures/pyproject-toml-extractor/with-poetry-lock/pyproject.toml"))
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+// ============================================================================
+// Parenthesized specifiers
+// ============================================================================
+
+func TestParsePyProjectTOML_PEP621_ParenthesizedPin(t *testing.T) {
+	t.Parallel()
+
+	path := fixturePath(t, "../fixtures/pyproject-toml-extractor/pep621-parens/pyproject.toml")
+	packages, err := python.ParsePyProjectTOML(path)
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name: "requests", Version: "2.28.0", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod"},
+			BlockLocation: pos(path, 5, 5, 5, 27), NameLocation: posPtr(path, 5, 5, 6, 14), VersionLocation: posPtr(path, 5, 5, 18, 24),
+		},
+	})
+}
+
+// ============================================================================
+// Group merging
+// ============================================================================
+
+func TestParsePyProjectTOML_MergesGroupsForDuplicatePackage(t *testing.T) {
+	t.Parallel()
+
+	path := fixturePath(t, "../fixtures/pyproject-toml-extractor/duplicate-groups/pyproject.toml")
+	packages, err := python.ParsePyProjectTOML(path)
+
+	expectNilErr(t, err)
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name: "requests", Version: "2.28.0", PackageManager: models.Unknown, Ecosystem: models.EcosystemPyPI, IsDirect: true, DepGroups: []string{"prod", "dev"},
+			BlockLocation: pos(path, 5, 5, 5, 24), NameLocation: posPtr(path, 5, 5, 6, 14), VersionLocation: posPtr(path, 5, 5, 16, 22),
+		},
+	})
+}
+
+// ============================================================================
+// Error cases
+// ============================================================================
+
+func TestParsePyProjectTOML_InvalidTOML(t *testing.T) {
+	t.Parallel()
+
+	_, err := python.ParsePyProjectTOML(fixturePath(t, "../fixtures/pyproject-toml-extractor/invalid/pyproject.toml"))
+
+	testutil.ExpectErrContaining(t, err, "could not extract from")
+}

--- a/pkg/lockfile/python/types.go
+++ b/pkg/lockfile/python/types.go
@@ -170,6 +170,46 @@ type RequirementsTxtExtractor struct {
 }
 
 // ============================================================================
+// PyProject Types
+// ============================================================================
+
+const pyprojectOfficiallySupported = false
+
+type PyProjectTOML struct {
+	BuildSystem      PyProjectBuildSystem  `toml:"build-system"`
+	Project          PyProjectProject      `toml:"project"`
+	DependencyGroups map[string][]any      `toml:"dependency-groups"`
+	Tool             PyProjectToolSections `toml:"tool"`
+}
+
+type PyProjectBuildSystem struct {
+	BuildBackend string `toml:"build-backend"`
+}
+
+type PyProjectProject struct {
+	Dependencies         []string            `toml:"dependencies"`
+	OptionalDependencies map[string][]string `toml:"optional-dependencies"`
+}
+
+type PyProjectToolSections struct {
+	Poetry *PyProjectPoetry `toml:"poetry"`
+	PDM    *map[string]any  `toml:"pdm"`
+	UV     *map[string]any  `toml:"uv"`
+}
+
+type PyProjectPoetry struct {
+	Dependencies    map[string]any                  `toml:"dependencies"`
+	DevDependencies map[string]any                  `toml:"dev-dependencies"`
+	Group           map[string]PyProjectPoetryGroup `toml:"group"`
+}
+
+type PyProjectPoetryGroup struct {
+	Dependencies map[string]any `toml:"dependencies"`
+}
+
+type PyProjectTOMLExtractor struct{}
+
+// ============================================================================
 // Matcher Types
 // ============================================================================
 

--- a/pkg/models/lockfile.go
+++ b/pkg/models/lockfile.go
@@ -32,6 +32,7 @@ const (
 	PipfileFilePath            ParsedFilePath = "Pipfile.lock"
 	PnpmFilePath               ParsedFilePath = "pnpm-lock.yaml"
 	PoetryFilePath             ParsedFilePath = "poetry.lock"
+	PyProjectTomlFilePath      ParsedFilePath = "pyproject.toml"
 	PubFilePath                ParsedFilePath = "pubspec.lock"
 	RenvFilePath               ParsedFilePath = "renv.lock"
 	RequirementsFilePath       ParsedFilePath = "requirements.txt"

--- a/pkg/scanner/datadog_sbom_generator.go
+++ b/pkg/scanner/datadog_sbom_generator.go
@@ -44,6 +44,7 @@ type ScannerActions struct {
 	Reachability        bool
 	Debug               bool
 	EnableParsers       []string
+	NoLockfileParsers   bool
 	DDEnvVars           DDEnvVars
 	ExitOnConfigFailure bool
 }
@@ -266,6 +267,11 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	}
 
 	enabledParsers := initializeEnabledParsers(actions.EnableParsers, r)
+	if actions.NoLockfileParsers {
+		for _, name := range lockfile.ListNoLockfileExtractorNames() {
+			enabledParsers[name] = true
+		}
+	}
 
 	if r == nil {
 		r = &reporter.VoidReporter{}


### PR DESCRIPTION
## 🚀 Motivation

Python projects using `uv` (and other PEP 621-compliant tools) that don't commit a lock file currently produce no SBOM output. This unblocks those customers by extracting packages directly from `pyproject.toml` when no lock file is present.

### Note
- We only support reporting pinned versions - supporting ranges will come with this [epic](https://datadoghq.atlassian.net/browse/K9VULN-13738)
- By default you must explicitly opt in to this feature with an argument - this behavior is new so its better to be scoped tighter at the start

## 📚 Documentation

**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | N/A

## 📝 Summary

New `PyProjectTOMLExtractor` that parses `pyproject.toml` directly when no lock file is present, enabled via a new `--no-lockfile-parsers` flag.

**New flag: `--no-lockfile-parsers`**
Additive boolean flag which is off by default. All default parsers still run, plus any registered no-lockfile parsers (currently `pyproject.toml`). Safe to enable per-customer in the CWP via a feature flag without affecting others.

**Extractor behaviour:**
- Only exact `==` pins are extracted — `===`, `>=`, `~=`, wildcards, multi-constraint specs, and unpinned deps are all rejected
- Package manager detected from file content:
     - `[tool.poetry]` or poetry build backend → `Poetry`
     - `[tool.pdm]` → `PDM`
     - `[tool.uv]` → `uv`
     - Unknown otherwise
- Three dependency formats: PEP 621 `[project]` + `[project.optional-dependencies]`, PEP 735 `[dependency-groups]` (uv), and `[tool.poetry.*]`
- Sibling lock file guard — suppressed when `poetry.lock`, `pdm.lock`, `uv.lock`, or `Pipfile.lock` exists in the same directory
- Packages declared in multiple sections get their groups merged rather than the second occurrence being silently dropped
- File positions (block, name, version) are populated for all extracted packages

**New interface: `NoLockfileExtractor`**
Optional marker interface alongside existing `ExtractorWithMatcher` and `ArtifactExtractor`. Future manifest-only parsers implement this to automatically participate in `--no-lockfile-parsers`.

## 🧪 Testing

- [x] New tests were added for new logic.
- [ ] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🚧 Staging validation

Tested against [rjcoulter22/sample-uv-service-v2](https://github.com/rjcoulter22/sample-uv-service-v2) — a sample uv project with pinned and unpinned deps and no lock file committed.

Commands run:
```bash
# Generate SBOM
datadog-sbom-generator scan --no-lockfile-parsers --output sbom.json /path/to/repo

# Upload to staging
dd-auth --domain dd.datad0g.com -- datadog-ci sbom upload --env staging sbom.json
```
- [Vulns page](https://dd.datad0g.com/security/code-security/sca?query=%40status%3Aopen%20%40git.repository_id%3Agithub.com%2Frjcoulter22%2Fsample-uv-service-v2&column=score&detection=runtime&group=library&order=desc)
- [Repository page](https://dd.datad0g.com/security/code-security/repositories/github.com%2Frjcoulter22%2Fsample-uv-service-v2/main/e8def7a27b91acb9e796c90840e968c5c069e016/library-vulnerabilities?query=%40git.repository.id%3Agithub.com%2Frjcoulter22%2Fsample-uv-service-v2%20%40git.branch%3Amain%20%40git.commit.sha%3Ae8def7a27b91acb9e796c90840e968c5c069e016%20%40dependency.ui_score%3A%3E0%20%40sent_by_vr%3Atrue&fromUser=false&index=cideps&softwareCompositionAnalysisId=AwAAAZ22prePlm7PAgAAABhBWjIycHJlUEFBQl9ILXpKT29IbUZ5YVgAAAAkZDE5ZGI2YTYtYjc4Zi00ODk2LTk5MWUtZGRmZDk3OThkYjNiAAAACQ&trace=AwAAAZ22prePlm7PAgAAABhBWjIycHJlUEFBQl9ILXpKT29IbUZ5YVgAAAAkZDE5ZGI2YTYtYjc4Zi00ODk2LTk5MWUtZGRmZDk3OThkYjNiAAAACQ&start=1776799465656&end=1776949410214&paused=false)

## 🆘 Recovery

Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:
