### PR TITLE
Add LocationRole=lockfile to all BlockLocation extractors

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -80,7 +80,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -93,7 +100,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -134,7 +148,17 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -151,7 +175,20 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"ignored/Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -172,7 +209,13 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"ignored/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":5,/"column_end/":31,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":24,/"column_end/":30,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -353,7 +396,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":30,/"line_end/":43,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/itoa@1.0.14",
@@ -366,7 +416,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":45,/"line_end/":49,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/memchr@2.7.4",
@@ -379,7 +436,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":171,/"line_end/":175,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/mockall@0.13.1",
@@ -420,7 +484,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":60,/"line_end/":64,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/pkg-config@0.3.31",
@@ -457,7 +528,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":72,/"line_end/":76,/"column_start/":1,/"column_end/":77,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/predicates@3.1.2",
@@ -470,7 +548,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":78,/"line_end/":82,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/proc-macro2@1.0.92",
@@ -483,7 +568,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":109,/"line_end/":116,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/quote@1.0.37",
@@ -496,7 +588,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":118,/"line_end/":125,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/regex-automata@0.4.9",
@@ -509,7 +608,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":94,/"line_end/":101,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/regex-syntax@0.8.5",
@@ -522,7 +628,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":103,/"line_end/":107,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/regex@1.11.1",
@@ -535,7 +648,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":84,/"line_end/":92,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/ryu@1.0.18",
@@ -548,7 +668,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":127,/"line_end/":131,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/serde@0.9.15",
@@ -613,7 +740,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":148,/"line_end/":157,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/serde_json@1.0.132",
@@ -650,7 +784,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":177,/"line_end/":181,/"column_start/":1,/"column_end/":78,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/syn@2.0.90",
@@ -663,7 +804,14 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
           "name": "datadog:package-manager",
           "value": "Crates"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Cargo.lock/",/"line_start/":183,/"line_end/":192,/"column_start/":1,/"column_end/":2,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:cargo/tokio@1.43.0",
@@ -1480,7 +1628,14 @@ Scanned <rootdir>/fixtures/integration-nuget/csproj-sample-app-manage-versions-c
           "name": "datadog:package-manager",
           "value": "NuGet"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":20,/"line_end/":24,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:nuget/Microsoft.NETFramework.ReferenceAssemblies@1.0.3",
@@ -1497,7 +1652,14 @@ Scanned <rootdir>/fixtures/integration-nuget/csproj-sample-app-manage-versions-c
           "name": "datadog:package-manager",
           "value": "NuGet"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":5,/"line_end/":13,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:nuget/Newtonsoft.Json@12.0.3",
@@ -1600,7 +1762,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -1617,7 +1786,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-html@0.0.1",
@@ -1630,7 +1806,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -1699,7 +1882,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -1794,7 +1984,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":37,/"line_end/":50,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":48,/"line_end/":50,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40babel%2Fhelper-validator-identifier@7.28.5",
@@ -1807,7 +2010,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":57,/"line_end/":65,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":52,/"line_end/":54,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fgen-mapping@0.3.13",
@@ -1820,7 +2036,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":75,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":56,/"line_end/":57,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fresolve-uri@3.1.2",
@@ -1833,7 +2062,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":76,/"line_end/":84,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":59,/"line_end/":61,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsource-map@0.3.11",
@@ -1846,7 +2088,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":85,/"line_end/":94,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":63,/"line_end/":64,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsourcemap-codec@1.5.5",
@@ -1859,7 +2114,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":95,/"line_end/":100,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":66,/"line_end/":67,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Ftrace-mapping@0.3.31",
@@ -1872,7 +2140,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":101,/"line_end/":110,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":69,/"line_end/":70,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":68,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fnode@24.10.1",
@@ -1885,7 +2166,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":111,/"line_end/":119,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":72,/"line_end/":73,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":70,/"line_end/":77,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.15.0",
@@ -1898,7 +2192,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":120,/"line_end/":131,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":75,/"line_end/":78,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":79,/"line_end/":86,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/buffer-from@1.1.2",
@@ -1911,7 +2218,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":132,/"line_end/":137,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":80,/"line_end/":81,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":88,/"line_end/":93,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/colors@1.4.0",
@@ -1928,7 +2248,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":138,/"line_end/":147,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":83,/"line_end/":85,/"column_start/":3,/"column_end/":32,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":95,/"line_end/":100,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/commander@2.20.3",
@@ -1941,7 +2274,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":148,/"line_end/":153,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":87,/"line_end/":88,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":102,/"line_end/":107,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fsevents@2.3.3",
@@ -1954,7 +2300,17 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":168,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":90,/"line_end/":93,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/group-dependencies@0.0.11",
@@ -1995,7 +2351,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":182,/"line_end/":190,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":99,/"line_end/":101,/"column_start/":3,/"column_end/":27,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":120,/"line_end/":125,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/jest-worker@26.6.2",
@@ -2008,7 +2377,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":191,/"line_end/":204,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":103,/"line_end/":105,/"column_start/":3,/"column_end/":34,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":136,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-tokens@4.0.0",
@@ -2021,7 +2403,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":205,/"line_end/":210,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":107,/"line_end/":108,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":138,/"line_end/":143,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge-stream@2.0.0",
@@ -2034,7 +2429,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":211,/"line_end/":216,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":110,/"line_end/":111,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":145,/"line_end/":150,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picocolors@0.2.1",
@@ -2079,6 +2487,12 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":51,/"line_end/":56,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":116,/"line_end/":117,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
           }
         ]
@@ -2095,7 +2509,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":231,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":119,/"line_end/":120,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":166,/"line_end/":173,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rollup-plugin-terser@7.0.2",
@@ -2132,7 +2559,17 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":232,/"line_end/":247,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":128,/"line_end/":131,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/safe-buffer@5.2.1",
@@ -2145,7 +2582,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":264,/"line_end/":283,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":133,/"line_end/":134,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@4.3.6",
@@ -2254,7 +2704,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":293,/"line_end/":301,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":153,/"line_end/":154,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map-support@0.5.21",
@@ -2267,7 +2730,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":311,/"line_end/":320,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":156,/"line_end/":157,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":249,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map@0.6.1",
@@ -2280,7 +2756,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":310,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":159,/"line_end/":161,/"column_start/":3,/"column_end/":32,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":251,/"line_end/":256,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -2293,7 +2782,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":321,/"line_end/":332,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":163,/"line_end/":165,/"column_start/":3,/"column_end/":27,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":258,/"line_end/":265,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/terser@5.44.1",
@@ -2306,7 +2808,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":333,/"line_end/":350,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":167,/"line_end/":170,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":279,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/undici-types@7.16.0",
@@ -2319,7 +2834,20 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":356,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":172,/"line_end/":173,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":281,/"line_end/":286,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -2470,7 +2998,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40babel%2Fhelper-validator-identifier@7.28.5",
@@ -2483,7 +3018,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fgen-mapping@0.3.13",
@@ -2496,7 +3038,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fresolve-uri@3.1.2",
@@ -2509,7 +3058,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsource-map@0.3.11",
@@ -2522,7 +3078,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsourcemap-codec@1.5.5",
@@ -2535,7 +3098,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Ftrace-mapping@0.3.31",
@@ -2548,7 +3118,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":68,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fnode@24.10.1",
@@ -2561,7 +3138,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":70,/"line_end/":77,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.15.0",
@@ -2574,7 +3158,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":79,/"line_end/":86,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/buffer-from@1.1.2",
@@ -2587,7 +3178,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":88,/"line_end/":93,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/colors@1.4.0",
@@ -2604,7 +3202,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":95,/"line_end/":100,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/commander@2.20.3",
@@ -2617,7 +3222,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":102,/"line_end/":107,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/group-dependencies@0.0.11",
@@ -2658,7 +3270,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":120,/"line_end/":125,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/jest-worker@26.6.2",
@@ -2671,7 +3290,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":136,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-tokens@4.0.0",
@@ -2684,7 +3310,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":138,/"line_end/":143,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge-stream@2.0.0",
@@ -2697,7 +3330,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":145,/"line_end/":150,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picocolors@0.2.1",
@@ -2758,7 +3398,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":166,/"line_end/":173,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rollup-plugin-terser@7.0.2",
@@ -2795,7 +3442,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@4.3.6",
@@ -2904,7 +3558,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map-support@0.5.21",
@@ -2917,7 +3578,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":249,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map@0.6.1",
@@ -2930,7 +3598,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":251,/"line_end/":256,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -2943,7 +3618,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":258,/"line_end/":265,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/terser@5.44.1",
@@ -2956,7 +3638,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":279,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/undici-types@7.16.0",
@@ -2969,7 +3658,14 @@ Scanned <rootdir>/fixtures/integration-pyproject/pyproject.toml file and found 3
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":281,/"line_end/":286,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3016,7 +3712,14 @@ Scanned <rootdir>/fixtures/integration-npm/with-workspace/yarn.lock file and fou
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -3075,6 +3778,18 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
             "ecosystem": "Packagist",
             "purl": "pkg:composer/sentry/sdk@2.0.4"
           },
+          "locations": [
+            {
+              "block": {
+                "file_name": "composer.lock",
+                "line_start": 9,
+                "line_end": 39,
+                "column_start": 5,
+                "column_end": 6,
+                "role": "lockfile"
+              }
+            }
+          ],
           "metadata": {
             "package-manager": "Composer"
           }
@@ -3120,7 +3835,14 @@ invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"nested/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -3537,7 +4259,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3578,7 +4307,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3671,7 +4407,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3712,7 +4455,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3813,7 +4563,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":7,/"line_end/":14,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -3826,7 +4583,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":15,/"line_end/":19,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -3839,7 +4603,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":20,/"line_end/":28,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -3852,7 +4623,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":29,/"line_end/":33,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -3865,7 +4643,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":34,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -3878,7 +4663,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":47,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -3891,7 +4683,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":48,/"line_end/":52,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -3904,7 +4703,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":53,/"line_end/":79,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -3917,7 +4723,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":80,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -3930,7 +4743,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":109,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -3943,7 +4763,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":110,/"line_end/":114,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -3956,7 +4783,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":115,/"line_end/":138,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -3969,7 +4803,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":139,/"line_end/":153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -3982,7 +4823,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -3995,7 +4843,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":163,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -4008,7 +4863,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -4025,7 +4887,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -4038,7 +4907,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":70,/"line_end/":77,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -4051,7 +4927,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -4064,7 +4947,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":201,/"line_end/":209,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -4077,7 +4967,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":210,/"line_end/":214,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -4090,7 +4987,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":215,/"line_end/":229,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -4103,7 +5007,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":230,/"line_end/":234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -4116,7 +5027,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":227,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -4129,7 +5047,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":235,/"line_end/":246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -4142,7 +5067,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":247,/"line_end/":254,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -4155,7 +5087,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":255,/"line_end/":262,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -4168,7 +5107,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":263,/"line_end/":270,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -4181,7 +5127,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":283,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -4194,7 +5147,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":284,/"line_end/":288,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -4207,7 +5167,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":289,/"line_end/":293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -4220,7 +5187,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":294,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -4233,7 +5207,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":299,/"line_end/":306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -4246,7 +5227,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":307,/"line_end/":311,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -4259,7 +5247,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":312,/"line_end/":316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -4272,7 +5267,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":317,/"line_end/":325,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -4289,7 +5291,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":185,/"line_end/":190,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -4302,7 +5311,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":326,/"line_end/":330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -4315,7 +5331,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":331,/"line_end/":335,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -4328,7 +5351,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":336,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -4341,7 +5371,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":345,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -4354,7 +5391,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":346,/"line_end/":350,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -4367,7 +5411,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":355,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -4380,7 +5431,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":356,/"line_end/":363,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -4393,7 +5451,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":364,/"line_end/":368,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -4406,7 +5471,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":369,/"line_end/":373,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -4419,7 +5491,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":374,/"line_end/":381,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -4432,7 +5511,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":382,/"line_end/":386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -4445,7 +5531,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":387,/"line_end/":394,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -4486,7 +5579,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -4499,7 +5599,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -4512,7 +5619,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -4525,7 +5639,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -4538,7 +5659,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -4551,7 +5679,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -4564,7 +5699,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -4577,7 +5719,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -4590,7 +5739,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -4603,7 +5759,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -4616,7 +5779,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -4629,7 +5799,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -4666,7 +5843,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -4679,7 +5863,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -4692,7 +5883,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -4705,7 +5903,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -4718,7 +5923,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -4731,7 +5943,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -4744,7 +5963,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -4757,7 +5983,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -4770,7 +6003,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -4783,7 +6023,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -4796,7 +6043,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -4809,7 +6063,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -4822,7 +6083,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -4835,7 +6103,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -4848,7 +6123,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -4861,7 +6143,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -4874,7 +6163,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -4887,7 +6183,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -4900,7 +6203,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -4913,7 +6223,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -4926,7 +6243,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -4939,7 +6263,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -4952,7 +6283,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -4965,7 +6303,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -5006,7 +6351,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -5019,7 +6371,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -5032,7 +6391,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -5045,7 +6411,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -5058,7 +6431,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -5071,7 +6451,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -5084,7 +6471,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -5097,7 +6491,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -5110,7 +6511,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -5123,7 +6531,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -5136,7 +6551,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -5149,7 +6571,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -5162,7 +6591,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -5175,7 +6611,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -5188,7 +6631,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -5201,7 +6651,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -5214,7 +6671,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -5227,7 +6691,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -5240,7 +6711,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -5253,7 +6731,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -5266,7 +6751,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -5279,7 +6771,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -5292,7 +6791,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -5305,7 +6811,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -5318,7 +6831,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -5331,7 +6851,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -5344,7 +6871,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -5357,7 +6891,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -5370,7 +6911,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -5383,7 +6931,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -5396,7 +6951,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -5409,7 +6971,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -5422,7 +6991,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -5435,7 +7011,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -5448,7 +7031,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -5461,7 +7051,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -5474,7 +7071,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -5487,7 +7091,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -5500,7 +7111,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -5513,7 +7131,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -5526,7 +7151,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -5539,7 +7171,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -5552,7 +7191,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -5565,7 +7211,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -5578,7 +7231,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -5591,7 +7251,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -5604,7 +7271,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -5617,7 +7291,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -5630,7 +7311,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -5643,7 +7331,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -5656,7 +7351,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -5669,7 +7371,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -5682,7 +7391,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -5695,7 +7411,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -5712,7 +7435,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -5725,7 +7455,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -5738,7 +7475,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -5751,7 +7495,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -5764,7 +7515,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -5777,7 +7535,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -5790,7 +7555,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -5803,7 +7575,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -5816,7 +7595,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -5829,7 +7615,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -5842,7 +7635,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -5855,7 +7655,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -5868,7 +7675,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -5881,7 +7695,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -5894,7 +7715,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -5907,7 +7735,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -5920,7 +7755,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -5933,7 +7775,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -5946,7 +7795,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -5959,7 +7815,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -5972,7 +7835,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -5985,7 +7855,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -5998,7 +7875,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -6011,7 +7895,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -6024,7 +7915,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -6037,7 +7935,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -6050,7 +7955,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -6063,7 +7975,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -6076,7 +7995,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -6089,7 +8015,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -6102,7 +8035,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -6115,7 +8055,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -6128,7 +8075,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -6141,7 +8095,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -6154,7 +8115,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -6167,7 +8135,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -6180,7 +8155,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -6193,7 +8175,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -6206,7 +8195,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -6219,7 +8215,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -6260,7 +8263,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -6273,7 +8283,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -6286,7 +8303,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -6299,7 +8323,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -6312,7 +8343,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -6325,7 +8363,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -6338,7 +8383,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -6351,7 +8403,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -6364,7 +8423,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -6377,7 +8443,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -6390,7 +8463,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -6403,7 +8483,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -6440,7 +8527,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -6453,7 +8547,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -6466,7 +8567,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -6479,7 +8587,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -6492,7 +8607,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -6505,7 +8627,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -6518,7 +8647,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -6531,7 +8667,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -6544,7 +8687,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -6557,7 +8707,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -6570,7 +8727,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -6583,7 +8747,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -6596,7 +8767,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -6609,7 +8787,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -6622,7 +8807,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -6635,7 +8827,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -6648,7 +8847,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -6661,7 +8867,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -6674,7 +8887,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -6687,7 +8907,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -6700,7 +8927,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -6713,7 +8947,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -6726,7 +8967,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -6739,7 +8987,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -6780,7 +9035,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -6793,7 +9055,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -6806,7 +9075,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -6819,7 +9095,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -6832,7 +9115,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -6845,7 +9135,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -6858,7 +9155,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -6871,7 +9175,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -6884,7 +9195,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -6897,7 +9215,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -6910,7 +9235,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -6923,7 +9255,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -6936,7 +9275,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -6949,7 +9295,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -6962,7 +9315,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -6975,7 +9335,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -6988,7 +9355,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -7001,7 +9375,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -7014,7 +9395,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -7027,7 +9415,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -7040,7 +9435,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -7053,7 +9455,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -7066,7 +9475,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -7079,7 +9495,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -7092,7 +9515,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -7105,7 +9535,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -7118,7 +9555,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -7131,7 +9575,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -7144,7 +9595,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -7157,7 +9615,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -7170,7 +9635,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -7183,7 +9655,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -7196,7 +9675,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -7209,7 +9695,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -7222,7 +9715,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -7235,7 +9735,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -7248,7 +9755,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -7261,7 +9775,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -7274,7 +9795,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -7287,7 +9815,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -7300,7 +9835,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -7313,7 +9855,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -7326,7 +9875,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -7339,7 +9895,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -7352,7 +9915,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -7365,7 +9935,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -7378,7 +9955,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -7391,7 +9975,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -7404,7 +9995,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -7417,7 +10015,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -7430,7 +10035,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -7443,7 +10055,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -7456,7 +10075,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -7469,7 +10095,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -7486,7 +10119,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -7499,7 +10139,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -7512,7 +10159,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -7525,7 +10179,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -7538,7 +10199,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -7551,7 +10219,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -7564,7 +10239,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -7577,7 +10259,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -7590,7 +10279,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -7603,7 +10299,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -7616,7 +10319,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -7629,7 +10339,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -7642,7 +10359,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -7655,7 +10379,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -7668,7 +10399,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -7681,7 +10419,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -7694,7 +10439,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -7707,7 +10459,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -7720,7 +10479,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -7733,7 +10499,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -7746,7 +10519,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -7759,7 +10539,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -7772,7 +10559,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -7785,7 +10579,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -7798,7 +10599,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -7811,7 +10619,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -7824,7 +10639,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -7837,7 +10659,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -7850,7 +10679,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -7863,7 +10699,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -7876,7 +10719,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -7889,7 +10739,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -7902,7 +10759,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -7915,7 +10779,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -7928,7 +10799,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -7941,7 +10819,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -7954,7 +10839,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -7967,7 +10859,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -7980,7 +10879,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -7993,7 +10899,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -8034,7 +10947,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -8047,7 +10967,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -8060,7 +10987,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -8073,7 +11007,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -8086,7 +11027,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -8099,7 +11047,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -8112,7 +11067,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -8125,7 +11087,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -8138,7 +11107,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -8151,7 +11127,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -8164,7 +11147,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -8177,7 +11167,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -8214,7 +11211,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -8227,7 +11231,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -8240,7 +11251,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -8253,7 +11271,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -8266,7 +11291,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -8279,7 +11311,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -8292,7 +11331,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -8305,7 +11351,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -8318,7 +11371,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -8331,7 +11391,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -8344,7 +11411,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -8357,7 +11431,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -8370,7 +11451,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -8383,7 +11471,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -8396,7 +11491,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -8409,7 +11511,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -8422,7 +11531,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -8435,7 +11551,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -8448,7 +11571,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -8461,7 +11591,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -8474,7 +11611,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -8487,7 +11631,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -8500,7 +11651,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -8513,7 +11671,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -8554,7 +11719,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -8567,7 +11739,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -8580,7 +11759,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -8593,7 +11779,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -8606,7 +11799,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -8619,7 +11819,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -8632,7 +11839,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -8645,7 +11859,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -8658,7 +11879,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -8671,7 +11899,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -8684,7 +11919,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -8697,7 +11939,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -8710,7 +11959,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -8723,7 +11979,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -8736,7 +11999,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -8749,7 +12019,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -8762,7 +12039,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -8775,7 +12059,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -8788,7 +12079,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -8801,7 +12099,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -8814,7 +12119,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -8827,7 +12139,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -8840,7 +12159,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -8853,7 +12179,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -8866,7 +12199,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -8879,7 +12219,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -8892,7 +12239,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -8905,7 +12259,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -8918,7 +12279,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -8931,7 +12299,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -8944,7 +12319,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -8957,7 +12339,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -8970,7 +12359,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -8983,7 +12379,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -8996,7 +12399,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -9009,7 +12419,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -9022,7 +12439,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -9035,7 +12459,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -9048,7 +12479,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -9061,7 +12499,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -9074,7 +12519,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -9087,7 +12539,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -9100,7 +12559,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -9113,7 +12579,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -9126,7 +12599,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -9139,7 +12619,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -9152,7 +12639,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -9165,7 +12659,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -9178,7 +12679,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -9191,7 +12699,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -9204,7 +12719,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -9217,7 +12739,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -9230,7 +12759,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -9243,7 +12779,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -9260,7 +12803,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -9273,7 +12823,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -9286,7 +12843,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -9299,7 +12863,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -9312,7 +12883,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -9325,7 +12903,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -9338,7 +12923,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -9351,7 +12943,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -9364,7 +12963,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -9377,7 +12983,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -9390,7 +13003,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -9403,7 +13023,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -9416,7 +13043,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -9429,7 +13063,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -9442,7 +13083,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -9455,7 +13103,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -9468,7 +13123,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -9481,7 +13143,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -9494,7 +13163,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -9507,7 +13183,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -9520,7 +13203,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -9533,7 +13223,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -9546,7 +13243,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -9559,7 +13263,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -9572,7 +13283,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -9585,7 +13303,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -9598,7 +13323,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -9611,7 +13343,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -9624,7 +13363,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -9637,7 +13383,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -9650,7 +13403,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -9663,7 +13423,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -9676,7 +13443,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -9689,7 +13463,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -9702,7 +13483,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -9715,7 +13503,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -9728,7 +13523,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -9741,7 +13543,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -9754,7 +13563,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -9767,7 +13583,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -9808,7 +13631,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":45,/"line_end/":68,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -9821,7 +13651,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":94,/"line_end/":103,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -9834,7 +13671,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":35,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -9847,7 +13691,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":36,/"line_end/":44,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -9860,7 +13711,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":104,/"line_end/":119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -9873,7 +13731,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":145,/"line_end/":158,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -9886,7 +13751,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":159,/"line_end/":166,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -9899,7 +13771,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":167,/"line_end/":179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -9912,7 +13791,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":180,/"line_end/":188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -9925,7 +13811,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":189,/"line_end/":201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -9938,7 +13831,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":202,/"line_end/":207,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -9951,7 +13851,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":208,/"line_end/":213,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -9988,7 +13895,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -10001,7 +13915,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":324,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -10014,7 +13935,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -10027,7 +13955,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":391,/"line_end/":403,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -10040,7 +13975,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":404,/"line_end/":430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -10053,7 +13995,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":454,/"line_end/":479,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -10066,7 +14015,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":480,/"line_end/":496,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -10079,7 +14035,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":497,/"line_end/":503,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -10092,7 +14055,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":526,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -10105,7 +14075,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":504,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -10118,7 +14095,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":527,/"line_end/":543,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -10131,7 +14115,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":544,/"line_end/":553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -10144,7 +14135,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":554,/"line_end/":569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -10157,7 +14155,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":570,/"line_end/":576,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -10170,7 +14175,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":577,/"line_end/":585,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -10183,7 +14195,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":586,/"line_end/":592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -10196,7 +14215,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":593,/"line_end/":603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -10209,7 +14235,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":604,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -10222,7 +14255,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":625,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -10235,7 +14275,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":626,/"line_end/":642,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -10248,7 +14295,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":643,/"line_end/":655,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -10261,7 +14315,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":656,/"line_end/":662,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -10274,7 +14335,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":663,/"line_end/":669,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -10287,7 +14355,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":670,/"line_end/":684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -10328,7 +14403,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":69,/"line_end/":86,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -10341,7 +14423,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":695,/"line_end/":701,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -10354,7 +14443,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":702,/"line_end/":713,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -10367,7 +14463,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":714,/"line_end/":726,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -10380,7 +14483,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":727,/"line_end/":739,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -10393,7 +14503,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":797,/"line_end/":809,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -10406,7 +14523,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":840,/"line_end/":856,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -10419,7 +14543,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":810,/"line_end/":821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -10432,7 +14563,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":740,/"line_end/":796,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -10445,7 +14583,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":874,/"line_end/":891,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -10458,7 +14603,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":892,/"line_end/":904,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -10471,7 +14623,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":915,/"line_end/":926,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -10484,7 +14643,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":936,/"line_end/":944,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -10497,7 +14663,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":857,/"line_end/":866,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -10510,7 +14683,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":945,/"line_end/":954,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -10523,7 +14703,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":955,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -10536,7 +14723,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -10549,7 +14743,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":990,/"line_end/":996,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -10562,7 +14763,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":997,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -10575,7 +14783,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1012,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -10588,7 +14803,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1013,/"line_end/":1025,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -10601,7 +14823,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1026,/"line_end/":1037,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -10614,7 +14843,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1038,/"line_end/":1054,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -10627,7 +14863,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1055,/"line_end/":1069,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -10640,7 +14883,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1070,/"line_end/":1076,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -10653,7 +14903,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1077,/"line_end/":1083,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -10666,7 +14923,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":989,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -10679,7 +14943,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1106,/"line_end/":1118,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -10692,7 +14963,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1084,/"line_end/":1105,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -10705,7 +14983,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1119,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -10718,7 +15003,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1154,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -10731,7 +15023,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1155,/"line_end/":1160,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -10744,7 +15043,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1161,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -10757,7 +15063,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -10770,7 +15083,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1180,/"line_end/":1196,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -10783,7 +15103,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1197,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -10796,7 +15123,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1218,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -10809,7 +15143,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1219,/"line_end/":1225,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -10822,7 +15163,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1226,/"line_end/":1234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -10835,7 +15183,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1235,/"line_end/":1246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -10848,7 +15203,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1247,/"line_end/":1255,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -10861,7 +15223,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1256,/"line_end/":1265,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -10874,7 +15243,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1266,/"line_end/":1272,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -10887,7 +15263,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1273,/"line_end/":1285,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -10900,7 +15283,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1286,/"line_end/":1292,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -10913,7 +15303,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1293,/"line_end/":1299,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -10926,7 +15323,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1300,/"line_end/":1306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -10939,7 +15343,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1307,/"line_end/":1316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -10952,7 +15363,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1317,/"line_end/":1330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -10965,7 +15383,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1331,/"line_end/":1346,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -10978,7 +15403,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1347,/"line_end/":1353,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -10991,7 +15423,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1354,/"line_end/":1362,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -11004,7 +15443,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1363,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -11017,7 +15463,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1388,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -11034,7 +15487,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1389,/"line_end/":1395,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -11047,7 +15507,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":87,/"line_end/":93,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -11060,7 +15527,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1403,/"line_end/":1408,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -11073,7 +15547,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1396,/"line_end/":1402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -11086,7 +15567,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1409,/"line_end/":1418,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -11099,7 +15587,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1419,/"line_end/":1436,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -11112,7 +15607,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1437,/"line_end/":1452,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -11125,7 +15627,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1453,/"line_end/":1468,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -11138,7 +15647,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1469,/"line_end/":1481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -11151,7 +15667,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1482,/"line_end/":1491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -11164,7 +15687,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1492,/"line_end/":1501,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -11177,7 +15707,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1502,/"line_end/":1511,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -11190,7 +15727,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1512,/"line_end/":1520,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -11203,7 +15747,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1521,/"line_end/":1532,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -11216,7 +15767,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1533,/"line_end/":1542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -11229,7 +15787,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1543,/"line_end/":1552,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -11242,7 +15807,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1553,/"line_end/":1572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -11255,7 +15827,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1573,/"line_end/":1582,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -11268,7 +15847,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1583,/"line_end/":1592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -11281,7 +15867,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1593,/"line_end/":1609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -11294,7 +15887,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1610,/"line_end/":1632,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -11307,7 +15907,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1633,/"line_end/":1644,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -11320,7 +15927,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1645,/"line_end/":1657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -11333,7 +15947,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1658,/"line_end/":1667,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -11346,7 +15967,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1668,/"line_end/":1676,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -11359,7 +15987,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1677,/"line_end/":1689,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -11372,7 +16007,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1690,/"line_end/":1702,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -11385,7 +16027,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1703,/"line_end/":1715,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -11398,7 +16047,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1716,/"line_end/":1722,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -11411,7 +16067,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1723,/"line_end/":1734,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -11424,7 +16087,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1735,/"line_end/":1740,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -11437,7 +16107,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1741,/"line_end/":1755,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -11450,7 +16127,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1756,/"line_end/":1768,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -11463,7 +16147,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1769,/"line_end/":1781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -11476,7 +16167,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1782,/"line_end/":1795,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -11489,7 +16187,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1796,/"line_end/":1805,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -11502,7 +16207,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1806,/"line_end/":1821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -11515,7 +16227,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1822,/"line_end/":1831,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -11528,7 +16247,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1832,/"line_end/":1838,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -11541,7 +16267,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1839,/"line_end/":1851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -11616,7 +16349,14 @@ Warning: `parsers` exists as both a subcommand of datadog-sbom-generator and as 
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"nested/composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -11682,7 +16422,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -11723,7 +16470,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -11839,7 +16593,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NuGet"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"packages.lock.json/",/"line_start/":5,/"line_end/":10,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pom.xml",
@@ -11983,7 +16744,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/aws/aws-sdk-php@3.317.2",
@@ -12048,7 +16816,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dflydev/dot-access-data@v3.0.3",
@@ -12061,7 +16836,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/doctrine/inflector@2.0.10",
@@ -12098,7 +16880,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
@@ -12211,7 +17000,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/guzzle@7.9.2",
@@ -12248,7 +17044,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/psr7@2.7.0",
@@ -12261,7 +17064,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
@@ -12302,7 +17112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/collections@v11.19.0",
@@ -12315,7 +17132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/conditionable@v11.19.0",
@@ -12328,7 +17152,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/contracts@v11.19.0",
@@ -12341,7 +17172,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/macroable@v11.19.0",
@@ -12354,7 +17192,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/laravel/prompts@v0.1.24",
@@ -12439,7 +17284,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
@@ -12484,7 +17336,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
@@ -12557,7 +17416,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/mime-type-detection@1.15.0",
@@ -12574,7 +17440,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/mockery/mockery@1.6.12",
@@ -12643,7 +17516,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/myclabs/deep-copy@1.12.0",
@@ -12660,7 +17540,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nesbot/carbon@3.7.0",
@@ -12697,7 +17584,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nette/utils@v4.0.4",
@@ -12710,7 +17604,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nikic/php-parser@v5.1.0",
@@ -12727,7 +17628,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nunomaduro/termwind@v2.0.1",
@@ -12824,7 +17732,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phar-io/version@3.2.1",
@@ -12841,7 +17756,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpoption/phpoption@1.9.3",
@@ -12854,7 +17776,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpstan/phpstan@1.11.9",
@@ -12899,7 +17828,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-file-iterator@5.0.1",
@@ -12916,7 +17852,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-invoker@5.0.1",
@@ -12933,7 +17876,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-text-template@4.0.1",
@@ -12950,7 +17900,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-timer@7.0.1",
@@ -12967,7 +17924,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/phpunit@11.3.0",
@@ -13040,7 +18004,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/clock@1.0.0",
@@ -13053,7 +18024,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/container@2.0.2",
@@ -13090,7 +18068,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-client@1.0.3",
@@ -13103,7 +18088,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-factory@1.1.0",
@@ -13116,7 +18108,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-message@2.0",
@@ -13129,7 +18128,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/log@3.0.0",
@@ -13190,7 +18196,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/collection@2.0.0",
@@ -13203,7 +18216,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/uuid@4.7.6",
@@ -13272,7 +18292,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/cli-parser@3.0.2",
@@ -13289,7 +18316,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
@@ -13306,7 +18340,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit@3.0.1",
@@ -13323,7 +18364,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/comparator@6.0.1",
@@ -13340,7 +18388,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/complexity@4.0.1",
@@ -13357,7 +18412,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/diff@6.0.2",
@@ -13374,7 +18436,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/environment@7.2.0",
@@ -13391,7 +18460,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/exporter@6.1.3",
@@ -13408,7 +18484,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/global-state@7.0.2",
@@ -13425,7 +18508,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/lines-of-code@3.0.1",
@@ -13442,7 +18532,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-enumerator@6.0.1",
@@ -13459,7 +18556,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-reflector@4.0.1",
@@ -13476,7 +18580,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/recursion-context@6.0.2",
@@ -13493,7 +18604,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/type@5.0.1",
@@ -13510,7 +18628,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/version@5.0.1",
@@ -13527,7 +18652,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache-contracts@v3.5.0",
@@ -13544,7 +18676,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache@v7.1.3",
@@ -13585,7 +18724,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/console@v7.1.3",
@@ -13622,7 +18768,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
@@ -13635,7 +18788,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/error-handler@v7.1.3",
@@ -13672,7 +18832,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/event-dispatcher@v7.1.1",
@@ -13685,7 +18852,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/finder@v7.1.3",
@@ -13726,7 +18900,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/http-client@v7.1.3",
@@ -13863,7 +19044,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
@@ -13876,7 +19064,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
@@ -13889,7 +19084,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
@@ -13902,7 +19104,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
@@ -13915,7 +19124,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php72@v1.30.0",
@@ -13928,7 +19144,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php80@v1.30.0",
@@ -13941,7 +19164,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php83@v1.30.0",
@@ -13978,7 +19208,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/process@v7.1.3",
@@ -14067,7 +19304,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/string@v7.1.3",
@@ -14080,7 +19324,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation-contracts@v3.5.0",
@@ -14093,7 +19344,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation@v7.1.3",
@@ -14106,7 +19364,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/uid@v7.1.1",
@@ -14171,7 +19436,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/theseer/tokenizer@1.2.3",
@@ -14188,7 +19460,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
@@ -14273,7 +19552,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:conan/zlib@1.2.11",
@@ -14286,7 +19572,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Conan"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"conan.lock/",/"line_start/":13,/"line_end/":19,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/RedCloth@4.2.9",
@@ -14323,7 +19616,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailbox@7.1.2",
@@ -14336,7 +19636,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailer@7.1.2",
@@ -14349,7 +19656,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionpack@7.1.2",
@@ -14362,7 +19676,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actiontext@7.1.2",
@@ -14375,7 +19696,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionview@7.1.2",
@@ -14388,7 +19716,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activejob@7.1.2",
@@ -14401,7 +19736,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activemodel@7.1.2",
@@ -14414,7 +19756,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activerecord@7.1.2",
@@ -14427,7 +19776,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activestorage@7.1.2",
@@ -14440,7 +19796,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activesupport@7.1.2",
@@ -14453,7 +19816,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/addressable@2.8.7",
@@ -14466,7 +19836,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/base64@0.2.0",
@@ -14479,7 +19856,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/bigdecimal@3.1.8",
@@ -14492,7 +19876,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/builder@3.3.0",
@@ -14505,7 +19896,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/capybara@3.39.2",
@@ -14518,7 +19916,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/childprocess@5.0.0",
@@ -14531,7 +19936,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/chronic@0.10.2",
@@ -14592,7 +20004,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/connection_pool@2.4.1",
@@ -14605,7 +20024,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/crass@1.0.6",
@@ -14618,7 +20044,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-ci-environment@10.0.1",
@@ -14631,7 +20064,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-core@13.0.3",
@@ -14644,7 +20084,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
@@ -14657,7 +20104,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-gherkin@27.0.0",
@@ -14670,7 +20124,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-html-formatter@21.4.1",
@@ -14683,7 +20144,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-messages@22.0.0",
@@ -14696,7 +20164,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-rails@1.4.0",
@@ -14737,7 +20212,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-websteps@0.10.0",
@@ -14778,7 +20260,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-active_record@2.2.0",
@@ -14791,7 +20280,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-core@2.0.1",
@@ -14804,7 +20300,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner@2.0.2",
@@ -14845,7 +20348,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/diff-lcs@1.5.1",
@@ -14858,7 +20368,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/drb@2.2.1",
@@ -14871,7 +20388,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/erubi@1.13.0",
@@ -14884,7 +20408,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/factory_girl@4.9.0",
@@ -14925,7 +20456,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/globalid@1.2.1",
@@ -14938,7 +20476,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/i18n@1.14.5",
@@ -14951,7 +20496,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/io-console@0.7.2",
@@ -14964,7 +20516,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/irb@1.14.0",
@@ -14977,7 +20536,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/jquery-rails@4.6.0",
@@ -15014,7 +20580,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/loofah@2.22.0",
@@ -15027,7 +20600,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mail@2.8.1",
@@ -15040,7 +20620,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/marcel@1.0.4",
@@ -15053,7 +20640,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/matrix@0.4.2",
@@ -15066,7 +20660,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_mime@1.1.5",
@@ -15079,7 +20680,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_portile2@2.8.7",
@@ -15092,7 +20700,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/minitest@5.24.1",
@@ -15105,7 +20720,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/multi_test@1.1.0",
@@ -15118,7 +20740,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mutex_m@0.2.0",
@@ -15131,7 +20760,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-imap@0.4.14",
@@ -15144,7 +20780,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-pop@0.1.2",
@@ -15157,7 +20800,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-protocol@0.2.2",
@@ -15170,7 +20820,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-smtp@0.5.0",
@@ -15183,7 +20840,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nio4r@2.7.3",
@@ -15196,7 +20860,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nokogiri@1.15.6",
@@ -15209,7 +20880,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/psych@5.1.2",
@@ -15222,7 +20900,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/public_suffix@5.1.1",
@@ -15235,7 +20920,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/racc@1.8.1",
@@ -15248,7 +20940,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-openid@1.4.2",
@@ -15285,7 +20984,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-test@2.1.0",
@@ -15298,7 +21004,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack@3.1.7",
@@ -15311,7 +21024,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rackup@2.1.0",
@@ -15324,7 +21044,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-dom-testing@2.2.0",
@@ -15337,7 +21064,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-html-sanitizer@1.6.0",
@@ -15350,7 +21084,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails@7.1.2",
@@ -15387,7 +21128,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rake@13.2.1",
@@ -15400,7 +21148,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rdoc@6.7.0",
@@ -15413,7 +21168,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/regexp_parser@2.9.2",
@@ -15426,7 +21188,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/reline@0.5.9",
@@ -15439,7 +21208,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-activemodel-mocks@1.2.0",
@@ -15508,7 +21284,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-expectations@3.13.1",
@@ -15521,7 +21304,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-mocks@3.13.1",
@@ -15534,7 +21324,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-support@3.13.1",
@@ -15547,7 +21344,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec@3.13.0",
@@ -15636,7 +21440,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/sys-uname@1.3.0",
@@ -15649,7 +21460,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/thor@1.3.1",
@@ -15662,7 +21480,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/timeout@0.4.1",
@@ -15675,7 +21500,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/tzinfo@2.0.6",
@@ -15688,7 +21520,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/webrick@1.8.1",
@@ -15701,7 +21540,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-driver@0.7.6",
@@ -15714,7 +21560,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-extensions@0.1.5",
@@ -15727,7 +21580,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/will_paginate@3.0.12",
@@ -15764,7 +21624,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/zeitwerk@2.6.17",
@@ -15777,7 +21644,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
@@ -15885,7 +21759,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Hex"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"mix.lock/",/"line_start/":2,/"line_end/":2,/"column_start/":1,/"column_end/":421,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
@@ -15986,7 +21867,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
@@ -16003,7 +21891,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
@@ -16170,7 +22065,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm/pnpm-lock.yaml/",/"line_start/":21,/"line_end/":25,/"column_start/":3,/"column_end/":14}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.6.9",
@@ -16219,7 +22121,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash@4.17.20",
@@ -16236,7 +22145,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.0.0",
@@ -16253,7 +22169,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.2",
@@ -16270,7 +22193,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -16475,7 +22405,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pub"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pubspec.lock/",/"line_start/":4,/"line_end/":10,/"column_start/":3,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:pypi/beautifulsoup4@4.9.3",
@@ -16875,7 +22812,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/aws/aws-sdk-php@3.317.2",
@@ -16940,7 +22884,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dflydev/dot-access-data@v3.0.3",
@@ -16953,7 +22904,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/doctrine/inflector@2.0.10",
@@ -16990,7 +22948,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
@@ -17103,7 +23068,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/guzzle@7.9.2",
@@ -17140,7 +23112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/psr7@2.7.0",
@@ -17153,7 +23132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
@@ -17194,7 +23180,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/collections@v11.19.0",
@@ -17207,7 +23200,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/conditionable@v11.19.0",
@@ -17220,7 +23220,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/contracts@v11.19.0",
@@ -17233,7 +23240,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/macroable@v11.19.0",
@@ -17246,7 +23260,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/laravel/prompts@v0.1.24",
@@ -17331,7 +23352,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
@@ -17376,7 +23404,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
@@ -17449,7 +23484,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/mime-type-detection@1.15.0",
@@ -17466,7 +23508,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/mockery/mockery@1.6.12",
@@ -17535,7 +23584,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/myclabs/deep-copy@1.12.0",
@@ -17552,7 +23608,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nesbot/carbon@3.7.0",
@@ -17589,7 +23652,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nette/utils@v4.0.4",
@@ -17602,7 +23672,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nikic/php-parser@v5.1.0",
@@ -17619,7 +23696,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nunomaduro/termwind@v2.0.1",
@@ -17716,7 +23800,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phar-io/version@3.2.1",
@@ -17733,7 +23824,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpoption/phpoption@1.9.3",
@@ -17746,7 +23844,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpstan/phpstan@1.11.9",
@@ -17791,7 +23896,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-file-iterator@5.0.1",
@@ -17808,7 +23920,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-invoker@5.0.1",
@@ -17825,7 +23944,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-text-template@4.0.1",
@@ -17842,7 +23968,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-timer@7.0.1",
@@ -17859,7 +23992,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/phpunit@11.3.0",
@@ -17932,7 +24072,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/clock@1.0.0",
@@ -17945,7 +24092,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/container@2.0.2",
@@ -17982,7 +24136,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-client@1.0.3",
@@ -17995,7 +24156,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-factory@1.1.0",
@@ -18008,7 +24176,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-message@2.0",
@@ -18021,7 +24196,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/log@3.0.0",
@@ -18082,7 +24264,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/collection@2.0.0",
@@ -18095,7 +24284,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/uuid@4.7.6",
@@ -18164,7 +24360,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/cli-parser@3.0.2",
@@ -18181,7 +24384,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
@@ -18198,7 +24408,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit@3.0.1",
@@ -18215,7 +24432,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/comparator@6.0.1",
@@ -18232,7 +24456,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/complexity@4.0.1",
@@ -18249,7 +24480,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/diff@6.0.2",
@@ -18266,7 +24504,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/environment@7.2.0",
@@ -18283,7 +24528,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/exporter@6.1.3",
@@ -18300,7 +24552,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/global-state@7.0.2",
@@ -18317,7 +24576,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/lines-of-code@3.0.1",
@@ -18334,7 +24600,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-enumerator@6.0.1",
@@ -18351,7 +24624,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-reflector@4.0.1",
@@ -18368,7 +24648,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/recursion-context@6.0.2",
@@ -18385,7 +24672,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/type@5.0.1",
@@ -18402,7 +24696,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/version@5.0.1",
@@ -18419,7 +24720,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache-contracts@v3.5.0",
@@ -18436,7 +24744,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache@v7.1.3",
@@ -18477,7 +24792,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/console@v7.1.3",
@@ -18514,7 +24836,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
@@ -18527,7 +24856,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/error-handler@v7.1.3",
@@ -18564,7 +24900,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/event-dispatcher@v7.1.1",
@@ -18577,7 +24920,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/finder@v7.1.3",
@@ -18618,7 +24968,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/http-client@v7.1.3",
@@ -18755,7 +25112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
@@ -18768,7 +25132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
@@ -18781,7 +25152,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
@@ -18794,7 +25172,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
@@ -18807,7 +25192,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php72@v1.30.0",
@@ -18820,7 +25212,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php80@v1.30.0",
@@ -18833,7 +25232,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php83@v1.30.0",
@@ -18870,7 +25276,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/process@v7.1.3",
@@ -18959,7 +25372,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/string@v7.1.3",
@@ -18972,7 +25392,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation-contracts@v3.5.0",
@@ -18985,7 +25412,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation@v7.1.3",
@@ -18998,7 +25432,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/uid@v7.1.1",
@@ -19063,7 +25504,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/theseer/tokenizer@1.2.3",
@@ -19080,7 +25528,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
@@ -19165,7 +25620,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:conan/zlib@1.2.11",
@@ -19178,7 +25640,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Conan"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"conan.lock/",/"line_start/":13,/"line_end/":19,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/RedCloth@4.2.9",
@@ -19215,7 +25684,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailbox@7.1.2",
@@ -19228,7 +25704,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailer@7.1.2",
@@ -19241,7 +25724,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionpack@7.1.2",
@@ -19254,7 +25744,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actiontext@7.1.2",
@@ -19267,7 +25764,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionview@7.1.2",
@@ -19280,7 +25784,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activejob@7.1.2",
@@ -19293,7 +25804,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activemodel@7.1.2",
@@ -19306,7 +25824,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activerecord@7.1.2",
@@ -19319,7 +25844,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activestorage@7.1.2",
@@ -19332,7 +25864,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activesupport@7.1.2",
@@ -19345,7 +25884,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/addressable@2.8.7",
@@ -19358,7 +25904,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/base64@0.2.0",
@@ -19371,7 +25924,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/bigdecimal@3.1.8",
@@ -19384,7 +25944,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/builder@3.3.0",
@@ -19397,7 +25964,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/capybara@3.39.2",
@@ -19410,7 +25984,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/childprocess@5.0.0",
@@ -19423,7 +26004,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/chronic@0.10.2",
@@ -19484,7 +26072,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/connection_pool@2.4.1",
@@ -19497,7 +26092,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/crass@1.0.6",
@@ -19510,7 +26112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-ci-environment@10.0.1",
@@ -19523,7 +26132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-core@13.0.3",
@@ -19536,7 +26152,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
@@ -19549,7 +26172,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-gherkin@27.0.0",
@@ -19562,7 +26192,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-html-formatter@21.4.1",
@@ -19575,7 +26212,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-messages@22.0.0",
@@ -19588,7 +26232,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-rails@1.4.0",
@@ -19629,7 +26280,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-websteps@0.10.0",
@@ -19670,7 +26328,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-active_record@2.2.0",
@@ -19683,7 +26348,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-core@2.0.1",
@@ -19696,7 +26368,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner@2.0.2",
@@ -19737,7 +26416,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/diff-lcs@1.5.1",
@@ -19750,7 +26436,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/drb@2.2.1",
@@ -19763,7 +26456,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/erubi@1.13.0",
@@ -19776,7 +26476,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/factory_girl@4.9.0",
@@ -19817,7 +26524,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/globalid@1.2.1",
@@ -19830,7 +26544,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/i18n@1.14.5",
@@ -19843,7 +26564,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/io-console@0.7.2",
@@ -19856,7 +26584,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/irb@1.14.0",
@@ -19869,7 +26604,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/jquery-rails@4.6.0",
@@ -19906,7 +26648,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/loofah@2.22.0",
@@ -19919,7 +26668,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mail@2.8.1",
@@ -19932,7 +26688,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/marcel@1.0.4",
@@ -19945,7 +26708,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/matrix@0.4.2",
@@ -19958,7 +26728,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_mime@1.1.5",
@@ -19971,7 +26748,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_portile2@2.8.7",
@@ -19984,7 +26768,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/minitest@5.24.1",
@@ -19997,7 +26788,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/multi_test@1.1.0",
@@ -20010,7 +26808,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mutex_m@0.2.0",
@@ -20023,7 +26828,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-imap@0.4.14",
@@ -20036,7 +26848,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-pop@0.1.2",
@@ -20049,7 +26868,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-protocol@0.2.2",
@@ -20062,7 +26888,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-smtp@0.5.0",
@@ -20075,7 +26908,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nio4r@2.7.3",
@@ -20088,7 +26928,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nokogiri@1.15.6",
@@ -20101,7 +26948,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/psych@5.1.2",
@@ -20114,7 +26968,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/public_suffix@5.1.1",
@@ -20127,7 +26988,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/racc@1.8.1",
@@ -20140,7 +27008,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-openid@1.4.2",
@@ -20177,7 +27052,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-test@2.1.0",
@@ -20190,7 +27072,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack@3.1.7",
@@ -20203,7 +27092,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rackup@2.1.0",
@@ -20216,7 +27112,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-dom-testing@2.2.0",
@@ -20229,7 +27132,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-html-sanitizer@1.6.0",
@@ -20242,7 +27152,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails@7.1.2",
@@ -20279,7 +27196,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rake@13.2.1",
@@ -20292,7 +27216,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rdoc@6.7.0",
@@ -20305,7 +27236,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/regexp_parser@2.9.2",
@@ -20318,7 +27256,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/reline@0.5.9",
@@ -20331,7 +27276,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-activemodel-mocks@1.2.0",
@@ -20400,7 +27352,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-expectations@3.13.1",
@@ -20413,7 +27372,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-mocks@3.13.1",
@@ -20426,7 +27392,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-support@3.13.1",
@@ -20439,7 +27412,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec@3.13.0",
@@ -20528,7 +27508,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/sys-uname@1.3.0",
@@ -20541,7 +27528,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/thor@1.3.1",
@@ -20554,7 +27548,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/timeout@0.4.1",
@@ -20567,7 +27568,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/tzinfo@2.0.6",
@@ -20580,7 +27588,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/webrick@1.8.1",
@@ -20593,7 +27608,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-driver@0.7.6",
@@ -20606,7 +27628,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-extensions@0.1.5",
@@ -20619,7 +27648,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/will_paginate@3.0.12",
@@ -20656,7 +27692,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/zeitwerk@2.6.17",
@@ -20669,7 +27712,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
@@ -20730,7 +27780,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Hex"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"mix.lock/",/"line_start/":2,/"line_end/":2,/"column_start/":1,/"column_end/":421,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
@@ -20831,7 +27888,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
@@ -20848,7 +27912,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
@@ -21043,7 +28114,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash@4.17.20",
@@ -21060,7 +28138,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.0.0",
@@ -21077,7 +28162,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.2",
@@ -21094,7 +28186,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -21299,7 +28398,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pub"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pubspec.lock/",/"line_start/":4,/"line_end/":10,/"column_start/":3,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:pypi/beautifulsoup4@4.9.3",
@@ -21699,7 +28805,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5333,/"line_end/":5386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/aws/aws-sdk-php@3.317.2",
@@ -21764,7 +28877,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":69,/"line_end/":137,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dflydev/dot-access-data@v3.0.3",
@@ -21777,7 +28897,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":138,/"line_end/":212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/doctrine/inflector@2.0.10",
@@ -21814,7 +28941,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":304,/"line_end/":380,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/dragonmantank/cron-expression@v3.3.3",
@@ -21927,7 +29061,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":580,/"line_end/":641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/guzzle@7.9.2",
@@ -21964,7 +29105,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":768,/"line_end/":850,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/psr7@2.7.0",
@@ -21977,7 +29125,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":851,/"line_end/":966,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/guzzlehttp/uri-template@v1.0.3",
@@ -22018,7 +29173,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5545,/"line_end/":5595,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/collections@v11.19.0",
@@ -22031,7 +29193,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1053,/"line_end/":1107,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/conditionable@v11.19.0",
@@ -22044,7 +29213,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1108,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/contracts@v11.19.0",
@@ -22057,7 +29233,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1154,/"line_end/":1201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/illuminate/macroable@v11.19.0",
@@ -22070,7 +29253,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1202,/"line_end/":1247,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/laravel/prompts@v0.1.24",
@@ -22155,7 +29345,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1472,/"line_end/":1553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-aws-s3-v3@3.28.0",
@@ -22200,7 +29397,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5734,/"line_end/":5782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/flysystem-path-prefixing@3.28.0",
@@ -22273,7 +29477,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5596,/"line_end/":5678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/league/mime-type-detection@1.15.0",
@@ -22290,7 +29501,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5876,/"line_end/":5931,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/mockery/mockery@1.6.12",
@@ -22359,7 +29577,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6015,/"line_end/":6080,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/myclabs/deep-copy@1.12.0",
@@ -22376,7 +29601,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6081,/"line_end/":6140,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nesbot/carbon@3.7.0",
@@ -22413,7 +29645,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1761,/"line_end/":1822,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nette/utils@v4.0.4",
@@ -22426,7 +29665,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1823,/"line_end/":1908,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nikic/php-parser@v5.1.0",
@@ -22443,7 +29689,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6141,/"line_end/":6198,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/nunomaduro/termwind@v2.0.1",
@@ -22540,7 +29793,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6343,/"line_end/":6409,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phar-io/version@3.2.1",
@@ -22557,7 +29817,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6410,/"line_end/":6460,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpoption/phpoption@1.9.3",
@@ -22570,7 +29837,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":1997,/"line_end/":2071,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpstan/phpstan@1.11.9",
@@ -22615,7 +29889,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6519,/"line_end/":6596,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-file-iterator@5.0.1",
@@ -22632,7 +29913,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6597,/"line_end/":6657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-invoker@5.0.1",
@@ -22649,7 +29937,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6658,/"line_end/":6721,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-text-template@4.0.1",
@@ -22666,7 +29961,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6722,/"line_end/":6781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/php-timer@7.0.1",
@@ -22683,7 +29985,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6782,/"line_end/":6841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/phpunit/phpunit@11.3.0",
@@ -22756,7 +30065,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7003,/"line_end/":7051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/clock@1.0.0",
@@ -22769,7 +30085,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2072,/"line_end/":2119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/container@2.0.2",
@@ -22806,7 +30129,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2173,/"line_end/":2222,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-client@1.0.3",
@@ -22819,7 +30149,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2223,/"line_end/":2274,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-factory@1.1.0",
@@ -22832,7 +30169,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2275,/"line_end/":2329,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/http-message@2.0",
@@ -22845,7 +30189,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2330,/"line_end/":2382,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/psr/log@3.0.0",
@@ -22906,7 +30257,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2484,/"line_end/":2527,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/collection@2.0.0",
@@ -22919,7 +30277,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2528,/"line_end/":2616,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/ramsey/uuid@4.7.6",
@@ -22988,7 +30353,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7109,/"line_end/":7170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/cli-parser@3.0.2",
@@ -23005,7 +30377,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7171,/"line_end/":7227,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit-reverse-lookup@4.0.1",
@@ -23022,7 +30401,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7285,/"line_end/":7340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/code-unit@3.0.1",
@@ -23039,7 +30425,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7228,/"line_end/":7284,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/comparator@6.0.1",
@@ -23056,7 +30449,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7341,/"line_end/":7417,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/complexity@4.0.1",
@@ -23073,7 +30473,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7418,/"line_end/":7475,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/diff@6.0.2",
@@ -23090,7 +30497,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7476,/"line_end/":7542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/environment@7.2.0",
@@ -23107,7 +30521,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7543,/"line_end/":7606,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/exporter@6.1.3",
@@ -23124,7 +30545,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7607,/"line_end/":7684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/global-state@7.0.2",
@@ -23141,7 +30569,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7685,/"line_end/":7746,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/lines-of-code@3.0.1",
@@ -23158,7 +30593,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7747,/"line_end/":7804,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-enumerator@6.0.1",
@@ -23175,7 +30617,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7805,/"line_end/":7862,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/object-reflector@4.0.1",
@@ -23192,7 +30641,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7863,/"line_end/":7918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/recursion-context@6.0.2",
@@ -23209,7 +30665,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7919,/"line_end/":7982,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/type@5.0.1",
@@ -23226,7 +30689,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7983,/"line_end/":8039,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/sebastian/version@5.0.1",
@@ -23243,7 +30713,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8040,/"line_end/":8093,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache-contracts@v3.5.0",
@@ -23260,7 +30737,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8191,/"line_end/":8266,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/cache@v7.1.3",
@@ -23301,7 +30785,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2709,/"line_end/":2782,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/console@v7.1.3",
@@ -23338,7 +30829,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2876,/"line_end/":2940,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/deprecation-contracts@v3.5.0",
@@ -23351,7 +30849,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":2941,/"line_end/":3007,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/error-handler@v7.1.3",
@@ -23388,7 +30893,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3163,/"line_end/":3238,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/event-dispatcher@v7.1.1",
@@ -23401,7 +30913,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3083,/"line_end/":3162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/finder@v7.1.3",
@@ -23442,7 +30961,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8361,/"line_end/":8438,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/http-client@v7.1.3",
@@ -23579,7 +31105,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3658,/"line_end/":3736,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-grapheme@v1.30.0",
@@ -23592,7 +31125,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3737,/"line_end/":3814,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-idn@v1.30.0",
@@ -23605,7 +31145,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3815,/"line_end/":3898,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-intl-normalizer@v1.30.0",
@@ -23618,7 +31165,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3899,/"line_end/":3979,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-mbstring@v1.30.0",
@@ -23631,7 +31185,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":3980,/"line_end/":4059,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php72@v1.30.0",
@@ -23644,7 +31205,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4060,/"line_end/":4132,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php80@v1.30.0",
@@ -23657,7 +31225,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4133,/"line_end/":4212,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/polyfill-php83@v1.30.0",
@@ -23694,7 +31269,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4289,/"line_end/":4367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/process@v7.1.3",
@@ -23783,7 +31365,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4510,/"line_end/":4592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/string@v7.1.3",
@@ -23796,7 +31385,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4593,/"line_end/":4679,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation-contracts@v3.5.0",
@@ -23809,7 +31405,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4774,/"line_end/":4851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/translation@v7.1.3",
@@ -23822,7 +31425,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":4680,/"line_end/":4773,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/symfony/uid@v7.1.1",
@@ -23887,7 +31497,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8522,/"line_end/":8597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/theseer/tokenizer@1.2.3",
@@ -23904,7 +31521,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8598,/"line_end/":8647,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:composer/tijsverkoyen/css-to-inline-styles@v2.2.7",
@@ -23989,7 +31613,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5220,/"line_end/":5277,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:conan/zlib@1.2.11",
@@ -24002,7 +31633,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Conan"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"conan.lock/",/"line_start/":13,/"line_end/":19,/"column_start/":7,/"column_end/":8,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/RedCloth@4.2.9",
@@ -24039,7 +31677,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":6,/"line_end/":6,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailbox@7.1.2",
@@ -24052,7 +31697,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":12,/"line_end/":12,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionmailer@7.1.2",
@@ -24065,7 +31717,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":22,/"line_end/":22,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionpack@7.1.2",
@@ -24078,7 +31737,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":32,/"line_end/":32,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actiontext@7.1.2",
@@ -24091,7 +31757,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":42,/"line_end/":42,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/actionview@7.1.2",
@@ -24104,7 +31777,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":49,/"line_end/":49,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activejob@7.1.2",
@@ -24117,7 +31797,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":55,/"line_end/":55,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activemodel@7.1.2",
@@ -24130,7 +31817,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":58,/"line_end/":58,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activerecord@7.1.2",
@@ -24143,7 +31837,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":60,/"line_end/":60,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activestorage@7.1.2",
@@ -24156,7 +31857,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":64,/"line_end/":64,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/activesupport@7.1.2",
@@ -24169,7 +31877,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":70,/"line_end/":70,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/addressable@2.8.7",
@@ -24182,7 +31897,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":107,/"line_end/":107,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/base64@0.2.0",
@@ -24195,7 +31917,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":109,/"line_end/":109,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/bigdecimal@3.1.8",
@@ -24208,7 +31937,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":110,/"line_end/":110,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/builder@3.3.0",
@@ -24221,7 +31957,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":111,/"line_end/":111,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/capybara@3.39.2",
@@ -24234,7 +31977,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":112,/"line_end/":112,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/childprocess@5.0.0",
@@ -24247,7 +31997,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":121,/"line_end/":121,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/chronic@0.10.2",
@@ -24308,7 +32065,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":124,/"line_end/":124,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/connection_pool@2.4.1",
@@ -24321,7 +32085,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":125,/"line_end/":125,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/crass@1.0.6",
@@ -24334,7 +32105,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":126,/"line_end/":126,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-ci-environment@10.0.1",
@@ -24347,7 +32125,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":139,/"line_end/":139,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-core@13.0.3",
@@ -24360,7 +32145,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":140,/"line_end/":140,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-cucumber-expressions@17.1.0",
@@ -24373,7 +32165,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":144,/"line_end/":144,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-gherkin@27.0.0",
@@ -24386,7 +32185,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":146,/"line_end/":146,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-html-formatter@21.4.1",
@@ -24399,7 +32205,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":148,/"line_end/":148,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-messages@22.0.0",
@@ -24412,7 +32225,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":150,/"line_end/":150,/"column_start/":1,/"column_end/":31,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-rails@1.4.0",
@@ -24453,7 +32273,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":156,/"line_end/":156,/"column_start/":1,/"column_end/":37,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/cucumber-websteps@0.10.0",
@@ -24494,7 +32321,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":127,/"line_end/":127,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-active_record@2.2.0",
@@ -24507,7 +32341,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":163,/"line_end/":163,/"column_start/":1,/"column_end/":43,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner-core@2.0.1",
@@ -24520,7 +32361,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":166,/"line_end/":166,/"column_start/":1,/"column_end/":34,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/database_cleaner@2.0.2",
@@ -24561,7 +32409,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":167,/"line_end/":167,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/diff-lcs@1.5.1",
@@ -24574,7 +32429,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":168,/"line_end/":168,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/drb@2.2.1",
@@ -24587,7 +32449,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":169,/"line_end/":169,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/erubi@1.13.0",
@@ -24600,7 +32469,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":170,/"line_end/":170,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/factory_girl@4.9.0",
@@ -24641,7 +32517,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":173,/"line_end/":173,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/globalid@1.2.1",
@@ -24654,7 +32537,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":174,/"line_end/":174,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/i18n@1.14.5",
@@ -24667,7 +32557,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":176,/"line_end/":176,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/io-console@0.7.2",
@@ -24680,7 +32577,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":178,/"line_end/":178,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/irb@1.14.0",
@@ -24693,7 +32597,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":179,/"line_end/":179,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/jquery-rails@4.6.0",
@@ -24730,7 +32641,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":186,/"line_end/":186,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/loofah@2.22.0",
@@ -24743,7 +32661,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":189,/"line_end/":189,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mail@2.8.1",
@@ -24756,7 +32681,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":192,/"line_end/":192,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/marcel@1.0.4",
@@ -24769,7 +32701,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":197,/"line_end/":197,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/matrix@0.4.2",
@@ -24782,7 +32721,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":198,/"line_end/":198,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_mime@1.1.5",
@@ -24795,7 +32741,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":199,/"line_end/":199,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mini_portile2@2.8.7",
@@ -24808,7 +32761,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":200,/"line_end/":200,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/minitest@5.24.1",
@@ -24821,7 +32781,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":201,/"line_end/":201,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/multi_test@1.1.0",
@@ -24834,7 +32801,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":202,/"line_end/":202,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/mutex_m@0.2.0",
@@ -24847,7 +32821,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":203,/"line_end/":203,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-imap@0.4.14",
@@ -24860,7 +32841,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":204,/"line_end/":204,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-pop@0.1.2",
@@ -24873,7 +32861,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":207,/"line_end/":207,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-protocol@0.2.2",
@@ -24886,7 +32881,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":209,/"line_end/":209,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/net-smtp@0.5.0",
@@ -24899,7 +32901,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":211,/"line_end/":211,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nio4r@2.7.3",
@@ -24912,7 +32921,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":213,/"line_end/":213,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/nokogiri@1.15.6",
@@ -24925,7 +32941,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":214,/"line_end/":214,/"column_start/":1,/"column_end/":35,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/psych@5.1.2",
@@ -24938,7 +32961,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":216,/"line_end/":216,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/public_suffix@5.1.1",
@@ -24951,7 +32981,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":218,/"line_end/":218,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/racc@1.8.1",
@@ -24964,7 +33001,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":219,/"line_end/":219,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-openid@1.4.2",
@@ -25001,7 +33045,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":224,/"line_end/":224,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack-test@2.1.0",
@@ -25014,7 +33065,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":226,/"line_end/":226,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rack@3.1.7",
@@ -25027,7 +33085,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":220,/"line_end/":220,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rackup@2.1.0",
@@ -25040,7 +33105,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":228,/"line_end/":228,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-dom-testing@2.2.0",
@@ -25053,7 +33125,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":231,/"line_end/":231,/"column_start/":1,/"column_end/":30,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails-html-sanitizer@1.6.0",
@@ -25066,7 +33145,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":235,/"line_end/":235,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rails@7.1.2",
@@ -25103,7 +33189,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":94,/"line_end/":94,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rake@13.2.1",
@@ -25116,7 +33209,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":238,/"line_end/":238,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rdoc@6.7.0",
@@ -25129,7 +33229,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":239,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/regexp_parser@2.9.2",
@@ -25142,7 +33249,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":241,/"line_end/":241,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/reline@0.5.9",
@@ -25155,7 +33269,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":242,/"line_end/":242,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-activemodel-mocks@1.2.0",
@@ -25224,7 +33345,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":254,/"line_end/":254,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-expectations@3.13.1",
@@ -25237,7 +33365,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":256,/"line_end/":256,/"column_start/":1,/"column_end/":32,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-mocks@3.13.1",
@@ -25250,7 +33385,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":259,/"line_end/":259,/"column_start/":1,/"column_end/":25,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec-support@3.13.1",
@@ -25263,7 +33405,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":262,/"line_end/":262,/"column_start/":1,/"column_end/":27,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/rspec@3.13.0",
@@ -25352,7 +33501,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":266,/"line_end/":266,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/sys-uname@1.3.0",
@@ -25365,7 +33521,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":267,/"line_end/":267,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/thor@1.3.1",
@@ -25378,7 +33541,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":269,/"line_end/":269,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/timeout@0.4.1",
@@ -25391,7 +33561,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":270,/"line_end/":270,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/tzinfo@2.0.6",
@@ -25404,7 +33581,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":271,/"line_end/":271,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/webrick@1.8.1",
@@ -25417,7 +33601,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":273,/"line_end/":273,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-driver@0.7.6",
@@ -25430,7 +33621,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":274,/"line_end/":274,/"column_start/":1,/"column_end/":29,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/websocket-extensions@0.1.5",
@@ -25443,7 +33641,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":276,/"line_end/":276,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/will_paginate@3.0.12",
@@ -25480,7 +33685,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":278,/"line_end/":278,/"column_start/":1,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/zeitwerk@2.6.17",
@@ -25493,7 +33705,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":280,/"line_end/":280,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:golang/github.com/BurntSushi/toml@1.0.0",
@@ -25554,7 +33773,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Hex"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"mix.lock/",/"line_start/":2,/"line_end/":2,/"column_start/":1,/"column_end/":421,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
@@ -25655,7 +33881,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-groovy/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
@@ -25672,7 +33905,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Gradle"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"gradle-kotlin/gradle.lockfile/",/"line_start/":5,/"line_end/":5,/"column_start/":1,/"column_end/":73,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test",
@@ -25867,7 +34107,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":35,/"line_end/":42,/"column_start/":3,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash@4.17.20",
@@ -25884,7 +34131,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":44,/"line_end/":45,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.0.0",
@@ -25901,7 +34155,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":47,/"line_end/":48,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.2",
@@ -25918,7 +34179,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pnpm"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pnpm-9/pnpm-lock.yaml/",/"line_start/":50,/"line_end/":51,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -26123,7 +34391,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Pub"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"pubspec.lock/",/"line_start/":4,/"line_end/":10,/"column_start/":3,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:pypi/beautifulsoup4@4.9.3",
@@ -26585,7 +34860,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Composer"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"composer.lock/",/"line_start/":9,/"line_end/":39,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:gem/ast@2.4.2",
@@ -26602,7 +34884,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Bundler"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"Gemfile.lock/",/"line_start/":4,/"line_end/":4,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -26643,7 +34932,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":5,/"line_end/":10,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -26656,7 +34952,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":12,/"line_end/":15,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -26669,7 +34972,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":17,/"line_end/":23,/"column_start/":1,/"column_end/":26,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -26682,7 +34992,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":25,/"line_end/":28,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -26695,7 +35012,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":30,/"line_end/":36,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -26708,7 +35032,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":38,/"line_end/":41,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -26721,7 +35052,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":46,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -26758,7 +35096,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":64,/"line_end/":70,/"column_start/":1,/"column_end/":47,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -26771,7 +35116,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":72,/"line_end/":80,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -26784,7 +35136,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":82,/"line_end/":85,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -26797,7 +35156,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":87,/"line_end/":98,/"column_start/":1,/"column_end/":22,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -26810,7 +35176,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":100,/"line_end/":112,/"column_start/":1,/"column_end/":20,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -26823,7 +35196,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":114,/"line_end/":120,/"column_start/":1,/"column_end/":33,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -26836,7 +35216,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":122,/"line_end/":125,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -26849,7 +35236,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":127,/"line_end/":132,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -26871,6 +35265,9 @@ No package sources found. Use the 'parsers list' command to view supported lockf
         "occurrences": [
           {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":134,/"line_end/":139,/"column_start/":1,/"column_end/":16,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -26886,7 +35283,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":141,/"line_end/":146,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -26899,7 +35303,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":148,/"line_end/":154,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -26912,7 +35323,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":156,/"line_end/":159,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -26925,7 +35343,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":166,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -26938,7 +35363,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":168,/"line_end/":171,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -26951,7 +35383,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":173,/"line_end/":176,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.2",
@@ -26964,7 +35403,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":187,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -26977,7 +35423,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":189,/"line_end/":194,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -26990,7 +35443,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":196,/"line_end/":201,/"column_start/":1,/"column_end/":28,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -27003,7 +35463,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":203,/"line_end/":208,/"column_start/":1,/"column_end/":21,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -27016,7 +35483,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":210,/"line_end/":220,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -27029,7 +35503,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":222,/"line_end/":225,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -27042,7 +35523,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":227,/"line_end/":230,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -27055,7 +35543,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":232,/"line_end/":235,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -27068,7 +35563,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":237,/"line_end/":242,/"column_start/":1,/"column_end/":24,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -27081,7 +35583,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":244,/"line_end/":247,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -27094,7 +35603,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":249,/"line_end/":252,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -27107,7 +35623,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":254,/"line_end/":260,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -27120,7 +35643,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":262,/"line_end/":265,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -27133,7 +35663,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":267,/"line_end/":270,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -27146,7 +35683,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":272,/"line_end/":275,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -27159,7 +35703,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":277,/"line_end/":280,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -27172,7 +35723,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":282,/"line_end/":285,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -27185,7 +35743,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":287,/"line_end/":290,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -27198,7 +35763,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":292,/"line_end/":297,/"column_start/":1,/"column_end/":29,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -27211,7 +35783,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":299,/"line_end/":302,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -27224,7 +35803,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":304,/"line_end/":307,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -27237,7 +35823,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":23,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -27250,7 +35843,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":319,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -27263,7 +35863,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":321,/"line_end/":326,/"column_start/":1,/"column_end/":19,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -27304,7 +35911,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -27317,7 +35931,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -27330,7 +35951,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -27343,7 +35971,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -27356,7 +35991,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -27369,7 +36011,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -27382,7 +36031,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":65,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -27419,7 +36075,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":91,/"line_end/":99,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -27432,7 +36095,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":101,/"line_end/":116,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -27445,7 +36115,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":118,/"line_end/":123,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -27458,7 +36135,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":125,/"line_end/":141,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -27471,7 +36155,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":143,/"line_end/":159,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -27484,7 +36175,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":169,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -27497,7 +36195,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":171,/"line_end/":176,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -27510,7 +36215,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":185,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -27532,6 +36244,9 @@ No package sources found. Use the 'parsers list' command to view supported lockf
         "occurrences": [
           {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":187,/"line_end/":197,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -27547,7 +36262,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":199,/"line_end/":206,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -27560,7 +36282,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":208,/"line_end/":216,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -27573,7 +36302,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":218,/"line_end/":223,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -27586,7 +36322,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":225,/"line_end/":232,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -27599,7 +36342,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":234,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -27612,7 +36362,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":246,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.2",
@@ -27625,7 +36382,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":248,/"line_end/":259,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -27638,7 +36402,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":261,/"line_end/":268,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -27651,7 +36422,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":270,/"line_end/":277,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -27664,7 +36442,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":279,/"line_end/":286,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -27677,7 +36462,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":288,/"line_end/":300,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -27690,7 +36482,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":302,/"line_end/":307,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -27703,7 +36502,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -27716,7 +36522,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":321,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -27729,7 +36542,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":323,/"line_end/":330,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -27742,7 +36562,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":332,/"line_end/":337,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -27755,7 +36582,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":339,/"line_end/":344,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -27768,7 +36602,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":346,/"line_end/":354,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -27781,7 +36622,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":356,/"line_end/":361,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -27794,7 +36642,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":363,/"line_end/":368,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -27807,7 +36662,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":370,/"line_end/":375,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -27820,7 +36682,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":377,/"line_end/":382,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -27833,7 +36702,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":384,/"line_end/":389,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -27846,7 +36722,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":391,/"line_end/":396,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -27859,7 +36742,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":398,/"line_end/":405,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -27872,7 +36762,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":407,/"line_end/":414,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -27885,7 +36782,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":416,/"line_end/":421,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -27898,7 +36802,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":432,/"line_end/":439,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -27911,7 +36822,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":441,/"line_end/":446,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -27924,7 +36842,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":448,/"line_end/":457,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -27965,7 +36890,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":8,/"line_end/":17,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -27978,7 +36910,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":19,/"line_end/":24,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -27991,7 +36930,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":26,/"line_end/":34,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -28004,7 +36950,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":36,/"line_end/":41,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -28017,7 +36970,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":43,/"line_end/":51,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -28030,7 +36990,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":53,/"line_end/":58,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -28043,7 +37010,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":60,/"line_end/":65,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -28080,7 +37054,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":91,/"line_end/":99,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -28093,7 +37074,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":101,/"line_end/":116,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -28106,7 +37094,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":118,/"line_end/":123,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -28119,7 +37114,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":125,/"line_end/":141,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -28132,7 +37134,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":143,/"line_end/":159,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -28145,7 +37154,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":161,/"line_end/":169,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -28158,7 +37174,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":171,/"line_end/":176,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -28171,7 +37194,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":178,/"line_end/":185,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -28193,6 +37223,9 @@ No package sources found. Use the 'parsers list' command to view supported lockf
         "occurrences": [
           {
             "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":9,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":10,/"column_end/":15,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":11,/"line_end/":11,/"column_start/":19,/"column_end/":24,/"role/":/"manifest/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":187,/"line_end/":197,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -28208,7 +37241,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":199,/"line_end/":206,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -28221,7 +37261,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":208,/"line_end/":216,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -28234,7 +37281,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":218,/"line_end/":223,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -28247,7 +37301,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":225,/"line_end/":232,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -28260,7 +37321,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":234,/"line_end/":239,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -28273,7 +37341,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":241,/"line_end/":246,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.2",
@@ -28286,7 +37361,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":248,/"line_end/":259,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -28299,7 +37381,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":261,/"line_end/":268,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -28312,7 +37401,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":270,/"line_end/":277,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -28325,7 +37421,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":279,/"line_end/":286,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -28338,7 +37441,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":288,/"line_end/":300,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -28351,7 +37461,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":302,/"line_end/":307,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -28364,7 +37481,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":309,/"line_end/":314,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -28377,7 +37501,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":316,/"line_end/":321,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -28390,7 +37521,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":323,/"line_end/":330,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -28403,7 +37541,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":332,/"line_end/":337,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -28416,7 +37561,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":339,/"line_end/":344,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -28429,7 +37581,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":346,/"line_end/":354,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -28442,7 +37601,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":356,/"line_end/":361,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -28455,7 +37621,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":363,/"line_end/":368,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -28468,7 +37641,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":370,/"line_end/":375,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -28481,7 +37661,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":377,/"line_end/":382,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -28494,7 +37681,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":384,/"line_end/":389,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -28507,7 +37701,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":391,/"line_end/":396,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -28520,7 +37721,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":398,/"line_end/":405,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -28533,7 +37741,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":407,/"line_end/":414,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -28546,7 +37761,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":416,/"line_end/":421,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -28559,7 +37781,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":432,/"line_end/":439,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -28572,7 +37801,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":441,/"line_end/":446,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -28585,7 +37821,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "Yarn"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"yarn.lock/",/"line_start/":448,/"line_end/":457,/"column_start/":1,/"column_end/":17,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -100,6 +100,9 @@ func addLocations(component *cyclonedx.Component, details models.PackageVulns) {
 		seenLocations[jsonLocation] = struct{}{}
 	}
 	if len(occurrences) > 0 {
+		slices.SortFunc(occurrences, func(a, b cyclonedx.EvidenceOccurrence) int {
+			return strings.Compare(a.Location, b.Location)
+		})
 		component.Evidence = &cyclonedx.Evidence{Occurrences: &occurrences}
 	}
 }

--- a/pkg/lockfile/cpp/parse-conan-lock-v1-revisions_test.go
+++ b/pkg/lockfile/cpp/parse-conan-lock-v1-revisions_test.go
@@ -2,7 +2,10 @@ package cpp_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/cpp"
@@ -49,7 +52,7 @@ func TestParseConanLock_v1_revisions_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -68,7 +71,7 @@ func TestParseConanLock_v1_revisions_NoName(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -87,7 +90,7 @@ func TestParseConanLock_v1_revisions_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -112,7 +115,7 @@ func TestParseConanLock_v1_revisions_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.13",
@@ -155,7 +158,7 @@ func TestParseConanLock_v1_revisions_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ninja",
 			Version:        "1.11.1",
@@ -163,4 +166,40 @@ func TestParseConanLock_v1_revisions_OnePackageDev(t *testing.T) {
 			Ecosystem:      models.EcosystemConanCenter,
 		},
 	})
+}
+
+func TestParseConanLock_v1_revisions_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := cpp.ParseConanLock("../fixtures/conan/two-packages.v1.revisions.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/conan/two-packages.v1.revisions.json")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// Node "1": zlib, lines 14-20, column 7-8
+	zlibPkg := packagesByName["zlib"]
+	assert.Equal(t, absoluteLockfilePath, zlibPkg.BlockLocation.Filename)
+	assert.Equal(t, 14, zlibPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 20, zlibPkg.BlockLocation.Line.End)
+	assert.Equal(t, 7, zlibPkg.BlockLocation.Column.Start)
+	assert.Equal(t, 8, zlibPkg.BlockLocation.Column.End)
+
+	// Node "2": bzip2, lines 21-27, column 7-8
+	bzip2Pkg := packagesByName["bzip2"]
+	assert.Equal(t, absoluteLockfilePath, bzip2Pkg.BlockLocation.Filename)
+	assert.Equal(t, 21, bzip2Pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 27, bzip2Pkg.BlockLocation.Line.End)
+	assert.Equal(t, 7, bzip2Pkg.BlockLocation.Column.Start)
+	assert.Equal(t, 8, bzip2Pkg.BlockLocation.Column.End)
 }

--- a/pkg/lockfile/cpp/parse-conan-lock-v1_test.go
+++ b/pkg/lockfile/cpp/parse-conan-lock-v1_test.go
@@ -2,7 +2,10 @@ package cpp_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/cpp"
@@ -49,7 +52,7 @@ func TestParseConanLock_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -68,7 +71,7 @@ func TestParseConanLock_v1_NoName(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -87,7 +90,7 @@ func TestParseConanLock_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -112,7 +115,7 @@ func TestParseConanLock_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.13",
@@ -155,7 +158,7 @@ func TestParseConanLock_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ninja",
 			Version:        "1.11.1",
@@ -174,7 +177,7 @@ func TestParseConanLock_v1_OldFormat00(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -193,7 +196,7 @@ func TestParseConanLock_v1_OldFormat01(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -212,7 +215,7 @@ func TestParseConanLock_v1_OldFormat02(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -231,7 +234,7 @@ func TestParseConanLock_v1_OldFormat03(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -239,4 +242,40 @@ func TestParseConanLock_v1_OldFormat03(t *testing.T) {
 			Ecosystem:      models.EcosystemConanCenter,
 		},
 	})
+}
+
+func TestParseConanLock_v1_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := cpp.ParseConanLock("../fixtures/conan/two-packages.v1.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/conan/two-packages.v1.json")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// Node "1": zlib, lines 14-20, column 7-8
+	zlibPkg := packagesByName["zlib"]
+	assert.Equal(t, absoluteLockfilePath, zlibPkg.BlockLocation.Filename)
+	assert.Equal(t, 14, zlibPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 20, zlibPkg.BlockLocation.Line.End)
+	assert.Equal(t, 7, zlibPkg.BlockLocation.Column.Start)
+	assert.Equal(t, 8, zlibPkg.BlockLocation.Column.End)
+
+	// Node "2": bzip2, lines 21-27, column 7-8
+	bzip2Pkg := packagesByName["bzip2"]
+	assert.Equal(t, absoluteLockfilePath, bzip2Pkg.BlockLocation.Filename)
+	assert.Equal(t, 21, bzip2Pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 27, bzip2Pkg.BlockLocation.Line.End)
+	assert.Equal(t, 7, bzip2Pkg.BlockLocation.Column.Start)
+	assert.Equal(t, 8, bzip2Pkg.BlockLocation.Column.End)
 }

--- a/pkg/lockfile/cpp/parse-conan-lock-v2_test.go
+++ b/pkg/lockfile/cpp/parse-conan-lock-v2_test.go
@@ -2,7 +2,10 @@ package cpp_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/cpp"
@@ -49,7 +52,7 @@ func TestParseConanLock_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -69,7 +72,7 @@ func TestParseConanLock_v2_NoName(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -89,7 +92,7 @@ func TestParseConanLock_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.11",
@@ -116,7 +119,7 @@ func TestParseConanLock_v2_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "zlib",
 			Version:        "1.2.13",
@@ -164,7 +167,7 @@ func TestParseConanLock_v2_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ninja",
 			Version:        "1.11.1",
@@ -173,4 +176,36 @@ func TestParseConanLock_v2_OnePackageDev(t *testing.T) {
 			DepGroups:      []string{"build-requires"},
 		},
 	})
+}
+
+func TestParseConanLock_v2_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := cpp.ParseConanLock("../fixtures/conan/two-packages.v2.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/conan/two-packages.v2.json")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// zlib on line 4: "zlib/1.2.11#ffa77daf83a57094149707928bdce823%1667396813.184"
+	zlibPkg := packagesByName["zlib"]
+	assert.Equal(t, absoluteLockfilePath, zlibPkg.BlockLocation.Filename)
+	assert.Equal(t, 4, zlibPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 4, zlibPkg.BlockLocation.Line.End)
+
+	// bzip2 on line 5: "bzip2/1.0.8#464be69744fa6d48ed01928cfe470008%1666580345.213"
+	bzip2Pkg := packagesByName["bzip2"]
+	assert.Equal(t, absoluteLockfilePath, bzip2Pkg.BlockLocation.Filename)
+	assert.Equal(t, 5, bzip2Pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 5, bzip2Pkg.BlockLocation.Line.End)
 }

--- a/pkg/lockfile/cpp/parse-conan-lock.go
+++ b/pkg/lockfile/cpp/parse-conan-lock.go
@@ -1,11 +1,14 @@
 package cpp
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -103,11 +106,11 @@ func parseConanRenference(ref string) ConanReference {
 	return reference
 }
 
-func parseConanV1Lock(sourceFile ConanLockFile) []lockfile.PackageDetails {
+func parseConanV1Lock(sourceFile ConanLockFile, positions map[string]*models.FilePosition, filePath string) []lockfile.PackageDetails {
 	var reference ConanReference
 	packages := make([]lockfile.PackageDetails, 0, len(sourceFile.GraphLock.Nodes))
 
-	for _, node := range sourceFile.GraphLock.Nodes {
+	for nodeID, node := range sourceFile.GraphLock.Nodes {
 		if node.Path != "" {
 			// a local "conanfile.txt", skip
 			continue
@@ -126,18 +129,28 @@ func parseConanV1Lock(sourceFile ConanLockFile) []lockfile.PackageDetails {
 		if reference.Name == "" {
 			continue
 		}
-		packages = append(packages, lockfile.PackageDetails{
+
+		pkg := lockfile.PackageDetails{
 			Name:           reference.Name,
 			Version:        reference.Version,
 			PackageManager: conanPackageManager,
 			Ecosystem:      models.EcosystemConanCenter,
-		})
+			LocationRole:   models.LocationRoleLockfile,
+		}
+
+		if pos, ok := positions[nodeID]; ok {
+			blockLocation := *pos
+			blockLocation.Filename = filePath
+			pkg.BlockLocation = blockLocation
+		}
+
+		packages = append(packages, pkg)
 	}
 
 	return packages
 }
 
-func parseConanRequires(packages *[]lockfile.PackageDetails, requires []string, group string) {
+func parseConanRequires(packages *[]lockfile.PackageDetails, requires []string, group string, lines []string, filePath string) {
 	for _, ref := range requires {
 		reference := parseConanRenference(ref)
 		// skip entries with no name, they are most likely consumer's conanfiles
@@ -146,36 +159,53 @@ func parseConanRequires(packages *[]lockfile.PackageDetails, requires []string, 
 			continue
 		}
 
-		*packages = append(*packages, lockfile.PackageDetails{
+		pkg := lockfile.PackageDetails{
 			Name:           reference.Name,
 			Version:        reference.Version,
 			PackageManager: conanPackageManager,
 			Ecosystem:      models.EcosystemConanCenter,
 			DepGroups:      []string{group},
-		})
+			LocationRole:   models.LocationRoleLockfile,
+		}
+
+		// Find the line containing this exact reference string
+		pos := fileposition.ExtractDelimitedStringPositionInBlock(lines, ref, 1, "\"", "\"")
+		if pos != nil {
+			pos.Filename = filePath
+			pkg.BlockLocation = *pos
+		}
+
+		*packages = append(*packages, pkg)
 	}
 }
 
-func parseConanV2Lock(sourceFile ConanLockFile) []lockfile.PackageDetails {
+func parseConanV2Lock(sourceFile ConanLockFile, lines []string, filePath string) []lockfile.PackageDetails {
 	packages := make(
 		[]lockfile.PackageDetails,
 		0,
 		uint64(len(sourceFile.Requires))+uint64(len(sourceFile.BuildRequires))+uint64(len(sourceFile.PythonRequires)),
 	)
 
-	parseConanRequires(&packages, sourceFile.Requires, "requires")
-	parseConanRequires(&packages, sourceFile.BuildRequires, "build-requires")
-	parseConanRequires(&packages, sourceFile.PythonRequires, "python-requires")
+	parseConanRequires(&packages, sourceFile.Requires, "requires", lines, filePath)
+	parseConanRequires(&packages, sourceFile.BuildRequires, "build-requires", lines, filePath)
+	parseConanRequires(&packages, sourceFile.PythonRequires, "python-requires", lines, filePath)
 
 	return packages
 }
 
-func parseConanLock(lockfile ConanLockFile) []lockfile.PackageDetails {
+func parseConanLock(lockfile ConanLockFile, lines []string, filePath string) []lockfile.PackageDetails {
 	if lockfile.GraphLock.Nodes != nil {
-		return parseConanV1Lock(lockfile)
+		positions := make(map[string]*models.FilePosition, len(lockfile.GraphLock.Nodes))
+		for nodeID := range lockfile.GraphLock.Nodes {
+			positions[nodeID] = &models.FilePosition{}
+		}
+
+		fileposition.InJSON("nodes", positions, lines, 0)
+
+		return parseConanV1Lock(lockfile, positions, filePath)
 	}
 
-	return parseConanV2Lock(lockfile)
+	return parseConanV2Lock(lockfile, lines, filePath)
 }
 
 type ConanLockExtractor struct{}
@@ -195,12 +225,19 @@ func (e ConanLockExtractor) PackageManager() models.PackageManager {
 func (e ConanLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *ConanLockFile
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
-	return parseConanLock(*parsedLockfile), nil
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	return parseConanLock(*parsedLockfile, lines, f.Path()), nil
 }
 
 var _ lockfile.Extractor = ConanLockExtractor{}

--- a/pkg/lockfile/dart/parse-pubspec-lock.go
+++ b/pkg/lockfile/dart/parse-pubspec-lock.go
@@ -1,12 +1,14 @@
 package dart
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -86,10 +88,108 @@ func (e PubspecLockExtractor) PackageManager() models.PackageManager {
 	return pubsecPackageManager
 }
 
+// extractPubspecPackagePositions scans YAML lines for package entries under "packages:".
+// Package names appear at 2-space indent (e.g. "  shelf:"), and their blocks extend
+// until the next entry at the same or lesser indent level.
+func extractPubspecPackagePositions(lines []string) map[string]models.FilePosition {
+	positions := make(map[string]models.FilePosition)
+
+	inPackages := false
+	var currentName string
+	var startLine int
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		// Detect the "packages:" top-level key
+		if strings.TrimSpace(line) == "packages:" {
+			inPackages = true
+
+			continue
+		}
+
+		if !inPackages {
+			continue
+		}
+
+		// Check if we've left the packages section (non-indented, non-empty line)
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// A line with no leading spaces means we've exited the packages block
+		if len(line) > 0 && line[0] != ' ' {
+			// Close current package if any
+			if currentName != "" {
+				pos := positions[currentName]
+				pos.Line.End = i // previous line (1-indexed)
+				pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[i-1])
+				positions[currentName] = pos
+				currentName = ""
+			}
+
+			inPackages = false
+
+			continue
+		}
+
+		// 2-space indent: package name (e.g. "  shelf:")
+		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' && strings.HasSuffix(trimmed, ":") {
+			// Close previous package
+			if currentName != "" {
+				pos := positions[currentName]
+				pos.Line.End = i // previous line (1-indexed)
+				pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[i-1])
+				positions[currentName] = pos
+			}
+
+			pkgName := strings.TrimSuffix(trimmed, ":")
+			currentName = pkgName
+			startLine = lineNum
+
+			colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+
+			positions[currentName] = models.FilePosition{
+				Line:   models.Position{Start: startLine, End: 0}, // End will be set when block closes
+				Column: models.Position{Start: colStart, End: 0},
+			}
+
+			continue
+		}
+	}
+
+	// Close last package if file ended within packages section
+	if currentName != "" {
+		pos := positions[currentName]
+		lastIdx := len(lines) - 1
+		// Find last non-empty line
+		for lastIdx >= 0 && strings.TrimSpace(lines[lastIdx]) == "" {
+			lastIdx--
+		}
+
+		if lastIdx >= 0 {
+			pos.Line.End = lastIdx + 1
+			pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastIdx])
+		} else {
+			pos.Line.End = pos.Line.Start
+		}
+
+		positions[currentName] = pos
+	}
+
+	return positions
+}
+
 func (e PubspecLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PubspecLockfile
 
-	err := yaml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = yaml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil && !errors.Is(err, io.EOF) {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -97,6 +197,9 @@ func (e PubspecLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanC
 	if parsedLockfile == nil {
 		return []lockfile.PackageDetails{}, nil
 	}
+
+	lines := fileposition.BytesToLines(content)
+	positions := extractPubspecPackagePositions(lines)
 
 	packages := make([]lockfile.PackageDetails, 0, len(parsedLockfile.Packages))
 
@@ -107,6 +210,7 @@ func (e PubspecLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanC
 			Commit:         pkg.Description.Ref,
 			PackageManager: pubsecPackageManager,
 			Ecosystem:      models.EcosystemPub,
+			LocationRole:   models.LocationRoleLockfile,
 		}
 		for _, str := range strings.Split(pkg.Dependency, " ") {
 			if str == "dev" {
@@ -114,6 +218,12 @@ func (e PubspecLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanC
 				break
 			}
 		}
+
+		if pos, ok := positions[name]; ok {
+			pos.Filename = f.Path()
+			pkgDetails.BlockLocation = pos
+		}
+
 		packages = append(packages, pkgDetails)
 	}
 

--- a/pkg/lockfile/dart/parse-pubspec-lock_test.go
+++ b/pkg/lockfile/dart/parse-pubspec-lock_test.go
@@ -2,7 +2,10 @@ package dart_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/dart"
@@ -112,7 +115,7 @@ func TestParsePubspecLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "back_button_interceptor",
 			Version:        "6.0.1",
@@ -131,7 +134,7 @@ func TestParsePubspecLock_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "build_runner",
 			Version:        "2.2.1",
@@ -151,7 +154,7 @@ func TestParsePubspecLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "shelf",
 			Version:        "1.3.2",
@@ -176,7 +179,7 @@ func TestParsePubspecLock_MixedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "back_button_interceptor",
 			Version:        "6.0.1",
@@ -214,7 +217,7 @@ func TestParsePubspecLock_PackageWithGitSource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "flutter_rust_bridge",
 			Version:        "1.32.0",
@@ -262,7 +265,7 @@ func TestParsePubspecLock_PackageWithSdkSource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "flutter_web_plugins",
 			Version:        "0.0.0",
@@ -282,7 +285,7 @@ func TestParsePubspecLock_PackageWithPathSource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "maa_core",
 			Version:        "0.0.1",
@@ -291,4 +294,36 @@ func TestParsePubspecLock_PackageWithPathSource(t *testing.T) {
 			Commit:         "",
 		},
 	})
+}
+
+func TestParsePubspecLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := dart.ParsePubspecLock("../fixtures/pub/two-packages.lock")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/pub/two-packages.lock")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// shelf: lines 4-10
+	shelfPkg := packagesByName["shelf"]
+	assert.Equal(t, absoluteLockfilePath, shelfPkg.BlockLocation.Filename)
+	assert.Equal(t, 4, shelfPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 10, shelfPkg.BlockLocation.Line.End)
+
+	// shelf_web_socket: lines 11-17
+	swsPkg := packagesByName["shelf_web_socket"]
+	assert.Equal(t, absoluteLockfilePath, swsPkg.BlockLocation.Filename)
+	assert.Equal(t, 11, swsPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 17, swsPkg.BlockLocation.Line.End)
 }

--- a/pkg/lockfile/dotnet/parse-nuget-lock-v1_test.go
+++ b/pkg/lockfile/dotnet/parse-nuget-lock-v1_test.go
@@ -390,6 +390,7 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 				Column:   models.Position{Start: 7, End: 8},
 				Filename: absoluteLockfilePath,
 			},
+			LocationRole: models.LocationRoleLockfile,
 		},
 		{
 			Name:             "Newtonsoft.Json",
@@ -427,6 +428,7 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 				Column:   models.Position{Start: 7, End: 8},
 				Filename: absoluteLockfilePath,
 			},
+			LocationRole: models.LocationRoleLockfile,
 		},
 	})
 }

--- a/pkg/lockfile/dotnet/parse-nuget-lock-v1_test.go
+++ b/pkg/lockfile/dotnet/parse-nuget-lock-v1_test.go
@@ -55,7 +55,7 @@ func TestParseNuGetLock_v1_OneFramework_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -74,7 +74,7 @@ func TestParseNuGetLock_v1_OneFramework_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -92,6 +92,36 @@ func TestParseNuGetLock_v1_OneFramework_TwoPackages(t *testing.T) {
 	})
 }
 
+func TestParseNuGetLock_v1_OneFramework_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := dotnet.ParseNuGetLock("../fixtures/nuget/one-framework-two-packages/packages.lock.json")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	// Test.Core block: lines 5-10 within "net6.0" framework
+	testCore := packagesByName["Test.Core"]
+	assert.Equal(t, 5, testCore.BlockLocation.Line.Start)
+	assert.Equal(t, 10, testCore.BlockLocation.Line.End)
+	assert.Equal(t, 7, testCore.BlockLocation.Column.Start)
+	assert.Equal(t, 8, testCore.BlockLocation.Column.End)
+	assert.Contains(t, testCore.BlockLocation.Filename, "one-framework-two-packages")
+
+	// Test.System block: lines 11-19 within "net6.0" framework
+	testSystem := packagesByName["Test.System"]
+	assert.Equal(t, 11, testSystem.BlockLocation.Line.Start)
+	assert.Equal(t, 19, testSystem.BlockLocation.Line.End)
+	assert.Equal(t, 7, testSystem.BlockLocation.Column.Start)
+	assert.Equal(t, 8, testSystem.BlockLocation.Column.End)
+	assert.Contains(t, testSystem.BlockLocation.Filename, "one-framework-two-packages")
+}
+
 func TestParseNuGetLock_v1_TwoFrameworks_MixedPackages(t *testing.T) {
 	t.Parallel()
 
@@ -100,7 +130,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_MixedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -133,7 +163,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_DifferentPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -159,7 +189,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_DuplicatePackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -202,7 +232,7 @@ func TestParseNuGetLock_v1_OneFramework_OnePackage_MatchedFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "Test.Core",
 			Version:        "6.0.5",
@@ -318,6 +348,11 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/nuget/multiple-versions-with-lockfile/packages.lock.json")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
 	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:             "Newtonsoft.Json",
@@ -350,7 +385,11 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      models.EcosystemNuGet,
 			IsDirect:       true,
-			BlockLocation:  models.FilePosition{},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 5, End: 13},
+				Column:   models.Position{Start: 7, End: 8},
+				Filename: absoluteLockfilePath,
+			},
 		},
 		{
 			Name:             "Newtonsoft.Json",
@@ -383,7 +422,11 @@ func TestMultipleVersionsNonDeterministicOrder(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      models.EcosystemNuGet,
 			IsDirect:       false,
-			BlockLocation:  models.FilePosition{},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 20, End: 24},
+				Column:   models.Position{Start: 7, End: 8},
+				Filename: absoluteLockfilePath,
+			},
 		},
 	})
 }

--- a/pkg/lockfile/dotnet/parse-nuget-lock.go
+++ b/pkg/lockfile/dotnet/parse-nuget-lock.go
@@ -1,45 +1,75 @@
 package dotnet
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"maps"
 )
 
-func parseNuGetLockDependencies(dependencies map[string]NuGetLockPackage) map[string]lockfile.PackageDetails {
+func parseNuGetLockDependencies(
+	dependencies map[string]NuGetLockPackage,
+	positions map[string]*models.FilePosition,
+	filePath string,
+) map[string]lockfile.PackageDetails {
 	details := map[string]lockfile.PackageDetails{}
 
 	for name, dependency := range dependencies {
 		if strings.EqualFold(dependency.Type, projectDependencyType) {
 			continue
 		}
-		details[name+"@"+dependency.Resolved] = lockfile.PackageDetails{
+		pkgDetails := lockfile.PackageDetails{
 			Name:           name,
 			Version:        dependency.Resolved,
 			PackageManager: nugetPackageManager,
 			Ecosystem:      models.EcosystemNuGet,
 			IsDirect:       dependency.Type == "Direct",
+			LocationRole:   models.LocationRoleLockfile,
 		}
+		if pos, ok := positions[name]; ok {
+			blockLocation := *pos
+			blockLocation.Filename = filePath
+			pkgDetails.BlockLocation = blockLocation
+		}
+		details[name+"@"+dependency.Resolved] = pkgDetails
 	}
 
 	return details
 }
 
-func parseNuGetLock(file NuGetLockfile) ([]lockfile.PackageDetails, error) {
+func parseNuGetLock(
+	file NuGetLockfile,
+	lines []string,
+	filePath string,
+) ([]lockfile.PackageDetails, error) {
 	details := map[string]lockfile.PackageDetails{}
 
 	// go through the dependencies for each framework, e.g. `net6.0` and parse
 	// its dependencies, there might be different or duplicate dependencies
-	// between frameworks
-	for _, dependencies := range file.Dependencies {
-		maps.Copy(details, parseNuGetLockDependencies(dependencies))
+	// between frameworks.
+	// Sort framework names so that when the same package appears in multiple
+	// frameworks, the first framework alphabetically wins (deterministic output).
+	frameworkNames := slices.Sorted(maps.Keys(file.Dependencies))
+	for _, frameworkName := range frameworkNames {
+		dependencies := file.Dependencies[frameworkName]
+		// Build position map for this framework's packages
+		positions := make(map[string]*models.FilePosition, len(dependencies))
+		for name := range dependencies {
+			positions[name] = &models.FilePosition{}
+		}
+
+		fileposition.InJSON(frameworkName, positions, lines, 0)
+
+		maps.Copy(details, parseNuGetLockDependencies(dependencies, positions, filePath))
 	}
 
 	return slices.Collect(maps.Values(details)), nil
@@ -60,7 +90,12 @@ func (e NuGetLockExtractor) PackageManager() models.PackageManager {
 func (e NuGetLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *NuGetLockfile
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
@@ -69,7 +104,9 @@ func (e NuGetLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCon
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract: unsupported lock file version %d", parsedLockfile.Version)
 	}
 
-	return parseNuGetLock(*parsedLockfile)
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	return parseNuGetLock(*parsedLockfile, lines, f.Path())
 }
 
 var NuGetExtractor = NuGetLockExtractor{

--- a/pkg/lockfile/elixir/parse-mix-lock.go
+++ b/pkg/lockfile/elixir/parse-mix-lock.go
@@ -34,10 +34,12 @@ func (e MixLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 	re := cachedregexp.MustCompile(`^ +"(\w+)": \{.+,$`)
 
 	scanner := bufio.NewScanner(f)
+	lineNumber := 0
 
 	var packages []lockfile.PackageDetails
 
 	for scanner.Scan() {
+		lineNumber++
 		line := scanner.Text()
 
 		match := re.FindStringSubmatch(line)
@@ -79,6 +81,12 @@ func (e MixLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 			PackageManager: mixPackageManager,
 			Ecosystem:      models.EcosystemHex,
 			Commit:         commit,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: lineNumber, End: lineNumber},
+				Column:   models.Position{Start: 1, End: len(line) + 1},
+				Filename: f.Path(),
+			},
+			LocationRole: models.LocationRoleLockfile,
 		})
 	}
 

--- a/pkg/lockfile/elixir/parse-mix-lock_test.go
+++ b/pkg/lockfile/elixir/parse-mix-lock_test.go
@@ -122,13 +122,13 @@ func TestParseMixLock_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
 			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.End,
 			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
 			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.End,
 			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
 		assert.NotEmpty(t, pkg.BlockLocation.Filename,
 			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)

--- a/pkg/lockfile/elixir/parse-mix-lock_test.go
+++ b/pkg/lockfile/elixir/parse-mix-lock_test.go
@@ -2,6 +2,8 @@ package elixir_test
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/elixir"
@@ -10,6 +12,8 @@ import (
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMixLockExtractor_ShouldExtract(t *testing.T) {
@@ -93,7 +97,7 @@ func TestParseMixLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "plug",
 			Version:        "1.11.1",
@@ -102,6 +106,33 @@ func TestParseMixLock_OnePackage(t *testing.T) {
 			Commit:         "f2992bac66fdae679453c9e86134a4201f6f43a687d8ff1cd1b2862d53c80259",
 		},
 	})
+}
+
+func TestParseMixLock_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/mix/one-package.lock"))
+	packages, err := elixir.ParseMixLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
 }
 
 func TestParseMixLock_TwoPackages(t *testing.T) {
@@ -113,7 +144,7 @@ func TestParseMixLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "plug",
 			Version:        "1.11.1",
@@ -140,7 +171,7 @@ func TestParseMixLock_Many(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "backoff",
 			Version:        "1.1.6",
@@ -300,7 +331,7 @@ func TestParseMixLock_GitPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "foe",
 			Version:        "",

--- a/pkg/lockfile/internal/testutil/helpers.go
+++ b/pkg/lockfile/internal/testutil/helpers.go
@@ -82,7 +82,7 @@ func HasPackage(t *testing.T, expectedPkgs []lockfile.PackageDetails, currentPkg
 	for _, expectedPkg := range expectedPkgs {
 		var ignore []string
 		if ignoreLocations {
-			ignore = []string{"BlockLocation", "NameLocation", "VersionLocation"}
+			ignore = []string{"BlockLocation", "NameLocation", "VersionLocation", "LocationRole"}
 		}
 
 		if cmp.Equal(expectedPkg, currentPkg, cmpopts.IgnoreFields(lockfile.PackageDetails{}, ignore...)) {

--- a/pkg/lockfile/java/parse-gradle-lock.go
+++ b/pkg/lockfile/java/parse-gradle-lock.go
@@ -63,8 +63,10 @@ func (e GradleLockExtractor) PackageManager() models.PackageManager {
 func (e GradleLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	pkgs := make([]lockfile.PackageDetails, 0)
 	scanner := bufio.NewScanner(f)
+	lineNumber := 0
 
 	for scanner.Scan() {
+		lineNumber++
 		lockLine := strings.TrimSpace(scanner.Text())
 		if !isGradleLockFileDepLine(lockLine) {
 			continue
@@ -74,6 +76,13 @@ func (e GradleLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCo
 		if err != nil {
 			continue
 		}
+
+		pkg.BlockLocation = models.FilePosition{
+			Line:     models.Position{Start: lineNumber, End: lineNumber},
+			Column:   models.Position{Start: 1, End: len(scanner.Text()) + 1},
+			Filename: f.Path(),
+		}
+		pkg.LocationRole = models.LocationRoleLockfile
 
 		pkgs = append(pkgs, pkg)
 	}

--- a/pkg/lockfile/java/parse-gradle-lock_test.go
+++ b/pkg/lockfile/java/parse-gradle-lock_test.go
@@ -152,6 +152,34 @@ func TestParseGradleLock_OnePackage(t *testing.T) {
 }
 
 //nolint:paralleltest
+func TestParseGradleLock_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/gradle-lockfile/one-pkg"))
+	packages, err := java.ParseGradleLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
+}
+
+//nolint:paralleltest
 func TestParseGradleLock_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/pkg/lockfile/java/parse-gradle-lock_test.go
+++ b/pkg/lockfile/java/parse-gradle-lock_test.go
@@ -151,7 +151,6 @@ func TestParseGradleLock_OnePackage(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest
 func TestParseGradleLock_OnePackage_BlockLocation(t *testing.T) {
 	t.Parallel()
 	dir, err := os.Getwd()
@@ -166,13 +165,13 @@ func TestParseGradleLock_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
 			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.End,
 			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
 			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.End,
 			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
 		assert.NotEmpty(t, pkg.BlockLocation.Filename,
 			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)

--- a/pkg/lockfile/java/parse-gradle-verification-metadata.go
+++ b/pkg/lockfile/java/parse-gradle-verification-metadata.go
@@ -1,10 +1,15 @@
 package java
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -21,24 +26,97 @@ func (e GradleVerificationMetadataExtractor) PackageManager() models.PackageMana
 	return gradleVerificationPackageManager
 }
 
+// componentKey builds a unique key from a component's attributes for position lookup.
+func componentKey(group, name, version string) string {
+	return group + ":" + name + ":" + version
+}
+
+var componentStartRe = cachedregexp.MustCompile(`<component\s+group="([^"]+)"\s+name="([^"]+)"\s+version="([^"]+)"`)
+
+// extractComponentPositions scans lines for <component> blocks and returns positions keyed by group:name:version.
+// When the same group:name:version appears multiple times (multiple versions scenario),
+// we store positions in order and consume them sequentially.
+func extractComponentPositions(lines []string) map[string][]models.FilePosition {
+	positions := make(map[string][]models.FilePosition)
+
+	for i, line := range lines {
+		matches := componentStartRe.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		group, name, version := matches[1], matches[2], matches[3]
+		key := componentKey(group, name, version)
+		lineNum := i + 1 // 1-indexed
+
+		colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+		colEnd := fileposition.GetLastNonEmptyCharacterIndexInLine(line)
+
+		// Find the end of this component block (</component> or self-closing />)
+		endLine := lineNum
+		if !strings.Contains(line, "/>") {
+			for j := i + 1; j < len(lines); j++ {
+				if strings.Contains(lines[j], "</component>") {
+					endLine = j + 1
+					colEnd = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[j])
+
+					break
+				}
+			}
+		}
+
+		positions[key] = append(positions[key], models.FilePosition{
+			Line:   models.Position{Start: lineNum, End: endLine},
+			Column: models.Position{Start: colStart, End: colEnd},
+		})
+	}
+
+	return positions
+}
+
 func (e GradleVerificationMetadataExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *GradleVerificationMetadataFile
 
-	err := xml.NewDecoder(f).Decode(&parsedLockfile)
-
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
+	err = xml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	lines := fileposition.BytesToLines(content)
+	positions := extractComponentPositions(lines)
+
+	// Track consumption index per key for duplicate group:name:version entries
+	consumed := make(map[string]int)
+
 	pkgs := make([]lockfile.PackageDetails, 0, len(parsedLockfile.Components))
 
 	for _, component := range parsedLockfile.Components {
-		pkgs = append(pkgs, lockfile.PackageDetails{
+		key := componentKey(component.Group, component.Name, component.Version)
+
+		pkg := lockfile.PackageDetails{
 			Name:           component.Group + ":" + component.Name,
 			Version:        component.Version,
 			PackageManager: gradleVerificationPackageManager,
 			Ecosystem:      models.EcosystemMaven,
-		})
+			LocationRole:   models.LocationRoleLockfile,
+		}
+
+		if posList, ok := positions[key]; ok {
+			idx := consumed[key]
+			if idx < len(posList) {
+				pos := posList[idx]
+				pos.Filename = f.Path()
+				pkg.BlockLocation = pos
+				consumed[key] = idx + 1
+			}
+		}
+
+		pkgs = append(pkgs, pkg)
 	}
 
 	return pkgs, nil

--- a/pkg/lockfile/java/parse-gradle-verification-metadata_test.go
+++ b/pkg/lockfile/java/parse-gradle-verification-metadata_test.go
@@ -133,7 +133,7 @@ func TestParseGradleVerificationMetadata_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "org.apache.pdfbox:pdfbox",
 			Version:        "2.0.17",
@@ -200,7 +200,7 @@ func TestParseGradleVerificationMetadata_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "org.apache.pdfbox:pdfbox",
 			Version:        "2.0.17",
@@ -225,7 +225,7 @@ func TestParseGradleVerificationMetadata_MultipleVersions(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "androidx.activity:activity",
 			Version:        "1.2.1",
@@ -346,7 +346,7 @@ func TestParseGradleVerificationMetadata_Complex(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "com.google:google",
 			Version:        "1",
@@ -744,4 +744,36 @@ func TestParseGradleVerificationMetadata_Complex(t *testing.T) {
 			Ecosystem:      models.EcosystemMaven,
 		},
 	})
+}
+
+func TestParseGradleVerificationMetadata_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := java.ParseGradleVerificationMetadata("../fixtures/gradle-verification-metadata/two-packages.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	absoluteLockfilePath, err := filepath.Abs("../fixtures/gradle-verification-metadata/two-packages.xml")
+	if err != nil {
+		t.Fatalf("Could not get absolute path: %v", err)
+	}
+
+	// pdfbox: <component> on line 10, </component> on line 17
+	pdfboxPkg := packagesByName["org.apache.pdfbox:pdfbox"]
+	assert.Equal(t, absoluteLockfilePath, pdfboxPkg.BlockLocation.Filename)
+	assert.Equal(t, 10, pdfboxPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 17, pdfboxPkg.BlockLocation.Line.End)
+
+	// javaparser-core: <component> on line 18, </component> on line 22
+	javaparserPkg := packagesByName["com.github.javaparser:javaparser-core"]
+	assert.Equal(t, absoluteLockfilePath, javaparserPkg.BlockLocation.Filename)
+	assert.Equal(t, 18, javaparserPkg.BlockLocation.Line.Start)
+	assert.Equal(t, 22, javaparserPkg.BlockLocation.Line.End)
 }

--- a/pkg/lockfile/java/parse-maven-install.go
+++ b/pkg/lockfile/java/parse-maven-install.go
@@ -65,7 +65,7 @@ func extractMavenInstallArtifacts(installFile mavenInstallLockfile, contentBytes
 		return []lockfile.PackageDetails{}, err
 	}
 
-	lines := strings.Split(string(contentBytes), "\n")
+	lines := strings.Split(strings.ReplaceAll(string(contentBytes), "\r\n", "\n"), "\n")
 	fileposition.InJSON("artifacts", installFile.Artifacts, lines, 0)
 
 	artifactNames := make([]string, 0, len(installFile.Artifacts))

--- a/pkg/lockfile/javascript/match-package-json.go
+++ b/pkg/lockfile/javascript/match-package-json.go
@@ -63,9 +63,12 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 			depGroup = "optional"
 		}
 
-		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.BlockLocation.Line.Start != 0 {
-			// If it is a dev or optional dependency definition and we already found a package location,
-			// we skip it to prioritize non-dev dependencies
+		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.BlockLocation.Filename == depMap.FilePath {
+			// If it is a dev or optional dependency definition and this package's BlockLocation
+			// already points to the current source file (meaning a prior matcher section like
+			// "dependencies" already set it), skip the location overwrite to prioritize the
+			// non-dev location. We compare Filename rather than checking Line.Start != 0
+			// because extractors may now set BlockLocation from the lockfile for all packages.
 			pkgIndexes = []int{}
 		}
 		depMap.UpdatePackageDetails(pkg, packageJSONContent, pkgIndexes, depGroup)

--- a/pkg/lockfile/javascript/node-modules-npm-v1_test.go
+++ b/pkg/lockfile/javascript/node-modules-npm-v1_test.go
@@ -36,7 +36,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -55,7 +55,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -74,7 +74,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -100,7 +100,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -126,7 +126,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -178,29 +178,29 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 		t.Errorf("Expected to get 39 packages, but got %d", len(packages))
 	}
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "6.1.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "5.5.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "2.0.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 }
 
 func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
@@ -211,7 +211,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "",

--- a/pkg/lockfile/javascript/node-modules-npm-v2_test.go
+++ b/pkg/lockfile/javascript/node-modules-npm-v2_test.go
@@ -14,7 +14,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_InvalidJson(t *testing.T) {
 	packages, err := testParsingNodeModules(t, "../fixtures/npm/not-json.txt")
 
 	testutil.ExpectErrContaining(t, err, "could not extract from")
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestNodeModulesExtractor_Extract_npm_v2_NoPackages(t *testing.T) {
@@ -25,7 +25,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
@@ -36,7 +36,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -56,7 +56,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -76,7 +76,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -104,7 +104,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -130,7 +130,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -177,7 +177,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "supports-color",
 			Version:        "6.1.0",
@@ -203,7 +203,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "2.4.1",
@@ -339,7 +339,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "etag",
 			Version:        "1.8.0",
@@ -376,7 +376,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.0.0",
@@ -412,7 +412,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",

--- a/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/javascript"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseNpmLock_v1_FileDoesNotExist(t *testing.T) {
@@ -63,6 +65,34 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 			DepGroups:      []string{"prod"},
 		},
 	})
+}
+
+func TestParseNpmLock_v1_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/npm/one-package.v1.json"))
+	packages, err := javascript.ParseNpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// Every package must have a valid BlockLocation from the lockfile
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
 }
 
 func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {

--- a/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
@@ -56,7 +56,7 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -108,7 +108,7 @@ func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -132,7 +132,7 @@ func TestParseNpmLock_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -163,7 +163,7 @@ func TestParseNpmLock_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -194,7 +194,7 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -251,29 +251,29 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		t.Errorf("Expected to get 39 packages, but got %d", len(packages))
 	}
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "6.1.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "5.5.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "2.0.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 }
 
 func TestParseNpmLock_v1_Commits(t *testing.T) {
@@ -289,7 +289,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "",
@@ -426,7 +426,7 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "lodash",
 			Version:        "1.3.1",
@@ -459,7 +459,7 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.0.0",
@@ -497,7 +497,7 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",

--- a/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
@@ -82,13 +82,13 @@ func TestParseNpmLock_v1_OnePackage_BlockLocation(t *testing.T) {
 
 	// Every package must have a valid BlockLocation from the lockfile
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
 			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.End,
 			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
 			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.End,
 			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
 		assert.NotEmpty(t, pkg.BlockLocation.Filename,
 			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)

--- a/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
@@ -86,6 +86,34 @@ func TestParseNpmLock_v2_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseNpmLock_v2_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/npm/one-package.v2.json"))
+	packages, err := javascript.ParseNpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// Every package must have a valid BlockLocation from the lockfile
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
+}
+
 //nolint:paralleltest
 func TestParseNpmLock_v2_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()

--- a/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
@@ -987,9 +987,13 @@ func TestParseNpmLock_v2_WorkspacesComplex(t *testing.T) {
 			Version:        "1.4.0",
 			PackageManager: models.NPM,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 37, End: 46},
+				Column:   models.Position{Start: 5, End: 6},
+				Filename: path,
+			},
+			IsDirect:  false, // is a dependency of group-dependencies@0.0.11
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
@@ -101,13 +101,13 @@ func TestParseNpmLock_v2_OnePackage_BlockLocation(t *testing.T) {
 
 	// Every package must have a valid BlockLocation from the lockfile
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
 			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.End,
 			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
 			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.End,
 			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
 		assert.NotEmpty(t, pkg.BlockLocation.Filename,
 			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
@@ -992,8 +992,9 @@ func TestParseNpmLock_v2_WorkspacesComplex(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: path,
 			},
-			IsDirect:  false, // is a dependency of group-dependencies@0.0.11
-			DepGroups: []string{"dev"},
+			LocationRole: models.LocationRoleLockfile,
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-npm-lock.go
+++ b/pkg/lockfile/javascript/parse-npm-lock.go
@@ -73,7 +73,7 @@ func (dep *NpmLockDependency) depGroups() []string {
 	return groups
 }
 
-func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[string]lockfile.PackageDetails {
+func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency, sourceFile string) map[string]lockfile.PackageDetails {
 	details := npmPackageDetailsMap{}
 
 	keys := reflect.ValueOf(dependencies).MapKeys()
@@ -84,7 +84,7 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 		name := key.Interface().(string)
 		detail := dependencies[name]
 		if detail.Dependencies != nil {
-			nestedDeps := parseNpmLockDependencies(detail.Dependencies)
+			nestedDeps := parseNpmLockDependencies(detail.Dependencies, sourceFile)
 			for k, v := range nestedDeps {
 				details.add(k, v)
 			}
@@ -118,6 +118,9 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 			}
 		}
 
+		blockLocation := detail.FilePosition
+		blockLocation.Filename = sourceFile
+
 		details.add(name+"@"+version, lockfile.PackageDetails{
 			Name:           name,
 			Version:        finalVersion,
@@ -125,6 +128,8 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 			Ecosystem:      models.EcosystemNPM,
 			Commit:         commit,
 			DepGroups:      detail.depGroups(),
+			BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 		})
 	}
 
@@ -244,6 +249,7 @@ func processWorkspacePackages(
 	declaredWorkspacePackages map[string]*NpmLockPackage,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for workspacePath, workspacePkg := range declaredWorkspacePackages {
 		allDeps := make(map[string]string)
@@ -266,6 +272,7 @@ func processWorkspacePackages(
 				TargetVersion:     targetVersion,
 				DeclarationPath:   workspacePath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			}
 
 			if resolvedPkg, exists := resolvedPackages[workspaceNodeModulesPath]; exists {
@@ -295,6 +302,7 @@ func processRootPackages(
 	declaredRootPackages map[string]string,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for depName, targetVersion := range declaredRootPackages {
 		rootNodeModulesPath := getRootResolvedPath(depName)
@@ -307,6 +315,7 @@ func processRootPackages(
 				DeclarationPath:   "",
 				PhysicalPath:      rootNodeModulesPath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			})
 		}
 	}
@@ -317,6 +326,7 @@ func processLocalPackages(
 	localPackages map[string]*NpmLockPackage,
 	declaredRootPackages map[string]string,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for localPath, localPkg := range localPackages {
 		depName := path.Base(localPath)
@@ -335,6 +345,7 @@ func processLocalPackages(
 			DeclarationPath:   "",
 			PhysicalPath:      localPath,
 			ProcessedPackages: processedPackages,
+			SourceFile:        sourceFile,
 		})
 	}
 }
@@ -343,6 +354,7 @@ func processRemainingPackages(
 	details npmPackageDetailsMap,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for physicalPath, pkg := range resolvedPackages {
 		if !(*processedPackages)[physicalPath] {
@@ -355,6 +367,7 @@ func processRemainingPackages(
 				DeclarationPath:   "",
 				PhysicalPath:      physicalPath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			})
 		}
 	}
@@ -368,6 +381,7 @@ type packageProcessingParams struct {
 	DeclarationPath   string
 	PhysicalPath      string
 	ProcessedPackages *map[string]bool
+	SourceFile        string
 }
 
 func processPackage(params packageProcessingParams) {
@@ -413,6 +427,9 @@ func processPackage(params packageProcessingParams) {
 		location = &models.FilePosition{Filename: params.DeclarationPath}
 	}
 
+	blockLocation := params.Pkg.FilePosition
+	blockLocation.Filename = params.SourceFile
+
 	packageUniqKey := getWorkspaceDependencyKey(finalName, finalVersion, params.DeclarationPath)
 	params.Details.add(packageUniqKey, lockfile.PackageDetails{
 		Name:           finalName,
@@ -422,6 +439,8 @@ func processPackage(params packageProcessingParams) {
 		Ecosystem:      models.EcosystemNPM,
 		Commit:         commit,
 		DepGroups:      params.Pkg.depGroups(),
+		BlockLocation:  blockLocation,
+		LocationRole:   models.LocationRoleLockfile,
 		NameLocation:   location,
 	})
 
@@ -429,7 +448,7 @@ func processPackage(params packageProcessingParams) {
 	(*params.ProcessedPackages)[params.PhysicalPath] = true
 }
 
-func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]lockfile.PackageDetails {
+func parseNpmLockPackages(packages map[string]*NpmLockPackage, sourceFile string) map[string]lockfile.PackageDetails {
 	details := npmPackageDetailsMap{}
 
 	workspacePatterns := extractWorkspacePatterns(packages)
@@ -437,10 +456,10 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]lockfi
 
 	processedPackages := make(map[string]bool) // makes sure we do not process the same package twice (meaningful with the support of workspaces)
 
-	processRootPackages(details, categorized.DeclaredRoot, categorized.Resolved, &processedPackages)
-	processWorkspacePackages(details, categorized.DeclaredWorkspace, categorized.Resolved, &processedPackages)
-	processLocalPackages(details, categorized.Local, categorized.DeclaredRoot, &processedPackages)
-	processRemainingPackages(details, categorized.Resolved, &processedPackages)
+	processRootPackages(details, categorized.DeclaredRoot, categorized.Resolved, &processedPackages, sourceFile)
+	processWorkspacePackages(details, categorized.DeclaredWorkspace, categorized.Resolved, &processedPackages, sourceFile)
+	processLocalPackages(details, categorized.Local, categorized.DeclaredRoot, &processedPackages, sourceFile)
+	processRemainingPackages(details, categorized.Resolved, &processedPackages, sourceFile)
 
 	return details
 }
@@ -449,12 +468,12 @@ func parseNpmLock(lockfile NpmLockfile, lines []string) map[string]lockfile.Pack
 	if lockfile.Packages != nil {
 		fileposition.InJSON("packages", lockfile.Packages, lines, 0)
 
-		return parseNpmLockPackages(lockfile.Packages)
+		return parseNpmLockPackages(lockfile.Packages, lockfile.SourceFile)
 	}
 
 	fileposition.InJSON("dependencies", lockfile.Dependencies, lines, 0)
 
-	return parseNpmLockDependencies(lockfile.Dependencies)
+	return parseNpmLockDependencies(lockfile.Dependencies, lockfile.SourceFile)
 }
 
 func getWorkspaceDependencyKey(pkgName string, pkgVersion string, workspace string) string {
@@ -488,7 +507,7 @@ func (e NpmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not read from %s: %w", f.Path(), err)
 	}
 	contentString := string(contentBytes)
-	lines := strings.Split(contentString, "\n")
+	lines := strings.Split(strings.ReplaceAll(contentString, "\r\n", "\n"), "\n")
 	decoder := json.NewDecoder(strings.NewReader(contentString))
 
 	if err := decoder.Decode(&parsedLockfile); err != nil {

--- a/pkg/lockfile/javascript/parse-npm-lock.go
+++ b/pkg/lockfile/javascript/parse-npm-lock.go
@@ -54,6 +54,12 @@ func (pdm npmPackageDetailsMap) add(key string, details lockfile.PackageDetails)
 
 	if ok {
 		details.DepGroups = mergeNpmDepsGroups(existing, details)
+		// Keep the earlier lockfile location to ensure deterministic output
+		// (multiple node_modules paths may resolve to the same package key)
+		if existing.BlockLocation.Line.Start > 0 &&
+			(details.BlockLocation.Line.Start == 0 || existing.BlockLocation.Line.Start < details.BlockLocation.Line.Start) {
+			details.BlockLocation = existing.BlockLocation
+		}
 	}
 
 	pdm[key] = details

--- a/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
+++ b/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/javascript"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParsePnpmLock_v9_NoPackages(t *testing.T) {
@@ -41,6 +43,46 @@ func TestParsePnpmLock_v9_OnePackage(t *testing.T) {
 			DepGroups:      []string{"prod"},
 		},
 	})
+}
+
+func TestParsePnpmLock_v9_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/one-package.v9.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	if pkg.BlockLocation.Line.Start == 0 {
+		t.Errorf("Expected BlockLocation.Line.Start > 0 for %s, got 0", pkg.Name)
+	}
+	if pkg.BlockLocation.Line.End == 0 {
+		t.Errorf("Expected BlockLocation.Line.End > 0 for %s, got 0", pkg.Name)
+	}
+	if pkg.BlockLocation.Column.Start == 0 {
+		t.Errorf("Expected BlockLocation.Column.Start > 0 for %s, got 0", pkg.Name)
+	}
+	if pkg.BlockLocation.Column.End == 0 {
+		t.Errorf("Expected BlockLocation.Column.End > 0 for %s, got 0", pkg.Name)
+	}
+	if pkg.BlockLocation.Filename != path {
+		t.Errorf("Expected BlockLocation.Filename = %s, got %s", path, pkg.BlockLocation.Filename)
+	}
+
+	// acorn@8.11.3 is at lines 17-20 in one-package.v9.yaml (last non-empty line before "snapshots:")
+	assert.Equal(t, 17, pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 20, pkg.BlockLocation.Line.End)
 }
 
 func TestParsePnpmLock_v9_OnePackageDev(t *testing.T) {
@@ -313,6 +355,90 @@ func TestParsePnpmLock_v9_Commits(t *testing.T) {
 	})
 }
 
+// TestParsePnpmLock_v9_Commits_BlockLocation verifies that git/tarball dependencies
+// (whose packages: key uses a full URL like "ansi-regex@https://codeload.github.com/...")
+// correctly resolve their BlockLocation even though lookupPnpmPosition receives a cleaned
+// semver version, not the raw URL.
+func TestParsePnpmLock_v9_Commits_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/commits.v9.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
+func TestParsePnpmLock_v9_MixedGroups_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/mixed-groups.v9.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// All packages should have BlockLocation set
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
+// TestParsePnpmLock_v9_PeerDependenciesAdvanced_BlockLocation verifies that scoped packages
+// (whose YAML keys are surrounded by single quotes, e.g. '@scope/pkg@1.0.0':) get their
+// BlockLocation correctly populated. This is a regression test for the bug where the single
+// quotes were stored as part of the position map key, causing lookups to miss.
+func TestParsePnpmLock_v9_PeerDependenciesAdvanced_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/peer-dependencies-advanced.v9.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// Packages that appear in the packages: section should all have BlockLocation set.
+	// chalk@4.1.2 only appears in snapshots: (not packages:) so it is the only exception.
+	packagesWithoutPosition := map[string]bool{
+		"chalk@4.1.2": true,
+	}
+
+	for _, pkg := range packages {
+		key := pkg.Name + "@" + pkg.Version
+		if packagesWithoutPosition[key] {
+			continue
+		}
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
 func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 	t.Parallel()
 
@@ -573,6 +699,7 @@ func TestParsePnpmLock_v9_WorkspacesComplex(t *testing.T) {
 	}
 
 	rootPath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/package.json"))
+	lockfilePath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/pnpm-lock.yaml"))
 	workspace1Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/workspace-1/package.json"))
 	workspace2Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/nested/workspace-2/package.json"))
 	workspace3Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/workspace-3/package.json"))
@@ -608,9 +735,13 @@ func TestParsePnpmLock_v9_WorkspacesComplex(t *testing.T) {
 			Version:        "1.4.0",
 			PackageManager: models.Pnpm,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 45, End: 47},
+				Column:   models.Position{Start: 3, End: 32},
+				Filename: lockfilePath,
+			},
+			IsDirect:  false, // is a dependency of group-dependencies@0.0.11
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:           "semver",
@@ -763,4 +894,58 @@ func TestParsePnpmLock_v9_WorkspacesComplex(t *testing.T) {
 			DepGroups: []string{"prod", "prod"},
 		},
 	})
+}
+
+func TestParsePnpmLock_Legacy_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/one-package.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Equal(t, path, pkg.BlockLocation.Filename)
+
+	// /acorn/8.7.0 is at lines 11-15 in one-package.yaml
+	assert.Equal(t, 11, pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 15, pkg.BlockLocation.Line.End)
+}
+
+func TestParsePnpmLock_Legacy_MultiplePackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pnpm/multiple-packages.yaml"))
+	packages, err := javascript.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// All packages should have BlockLocation set
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
 }

--- a/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
+++ b/pkg/lockfile/javascript/parse-pnpm-lock-v9_test.go
@@ -396,10 +396,10 @@ func TestParsePnpmLock_v9_MixedGroups_BlockLocation(t *testing.T) {
 
 	// All packages should have BlockLocation set
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
 		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
 	}
 }
@@ -740,8 +740,9 @@ func TestParsePnpmLock_v9_WorkspacesComplex(t *testing.T) {
 				Column:   models.Position{Start: 3, End: 32},
 				Filename: lockfilePath,
 			},
-			IsDirect:  false, // is a dependency of group-dependencies@0.0.11
-			DepGroups: []string{"dev"},
+			LocationRole: models.LocationRoleLockfile,
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
 		},
 		{
 			Name:           "semver",
@@ -915,10 +916,10 @@ func TestParsePnpmLock_Legacy_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	pkg := packages[0]
-	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0")
 	assert.Equal(t, path, pkg.BlockLocation.Filename)
 
 	// /acorn/8.7.0 is at lines 11-15 in one-package.yaml
@@ -942,10 +943,10 @@ func TestParsePnpmLock_Legacy_MultiplePackages_BlockLocation(t *testing.T) {
 
 	// All packages should have BlockLocation set
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
 		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
 	}
 }

--- a/pkg/lockfile/javascript/parse-pnpm-v9-lock.go
+++ b/pkg/lockfile/javascript/parse-pnpm-v9-lock.go
@@ -1,6 +1,7 @@
 package javascript
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"maps"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -74,7 +76,7 @@ func addDependencyToPackageDetails(dependency lockfile.PackageDetails, packageId
 	return deps
 }
 
-func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, targetedKey string, deps map[string]lockfile.PackageDetails) map[string]lockfile.PackageDetails {
+func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, targetedKey string, deps map[string]lockfile.PackageDetails, positions map[string]models.FilePosition, filePath string) map[string]lockfile.PackageDetails {
 	// Need to look at dependencies
 	visitedSnapshots := make(map[string]bool)
 	snapshotQueue := make([]string, 0)
@@ -96,14 +98,17 @@ func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, t
 		}
 
 		for depName, depVersion := range snapshot.Dependencies {
+			version := getCleanedVersion(sourceFile, depName, depVersion)
 			transitiveDep := lockfile.PackageDetails{
 				Name:           depName,
-				Version:        getCleanedVersion(sourceFile, depName, depVersion),
+				Version:        version,
 				Commit:         getCommitFromVersion(depVersion),
 				Ecosystem:      models.EcosystemNPM,
 				DepGroups:      root.Pkg.DepGroups,
 				PackageManager: models.Pnpm,
 				IsDirect:       false,
+				BlockLocation:  lookupPnpmPosition(depName, version, depVersion, filePath, positions),
+				LocationRole:   models.LocationRoleLockfile,
 			}
 			addDependencyToPackageDetails(transitiveDep, getPnpmDependencyKey(transitiveDep), deps)
 			childKey := depName + "@" + depVersion
@@ -111,14 +116,17 @@ func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, t
 		}
 
 		for depName, depVersion := range snapshot.OptionalDependencies {
+			version := getCleanedVersion(sourceFile, depName, depVersion)
 			transitiveDep := lockfile.PackageDetails{
 				Name:           depName,
-				Version:        getCleanedVersion(sourceFile, depName, depVersion),
+				Version:        version,
 				Commit:         getCommitFromVersion(depVersion),
 				Ecosystem:      models.EcosystemNPM,
 				DepGroups:      root.Pkg.DepGroups,
 				PackageManager: models.Pnpm,
 				IsDirect:       false,
+				BlockLocation:  lookupPnpmPosition(depName, version, depVersion, filePath, positions),
+				LocationRole:   models.LocationRoleLockfile,
 			}
 			addDependencyToPackageDetails(transitiveDep, getPnpmDependencyKey(transitiveDep), deps)
 			childKey := depName + "@" + depVersion
@@ -129,17 +137,19 @@ func extractTransitiveDeps(sourceFile PnpmLockfile, root PnpmDirectDependency, t
 	return deps
 }
 
-func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDependency, dependencies PnpmDependencies, depGroup string, workspacePath string) []PnpmDirectDependency {
+func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDependency, dependencies PnpmDependencies, depGroup string, workspacePath string, positions map[string]models.FilePosition, filePath string) []PnpmDirectDependency {
 	for dependencyName, dependency := range dependencies {
 		var nameLocation *models.FilePosition
 		if workspacePath != "" && workspacePath != "." {
 			nameLocation = &models.FilePosition{Filename: workspacePath}
 		}
 
+		version := getCleanedVersion(sourceFile, dependencyName, dependency.Version)
+
 		roots = append(roots, PnpmDirectDependency{
 			Pkg: lockfile.PackageDetails{
 				Name:           dependencyName,
-				Version:        getCleanedVersion(sourceFile, dependencyName, dependency.Version),
+				Version:        version,
 				Commit:         getCommitFromVersion(dependency.Version),
 				TargetVersions: []string{dependency.Specifier},
 				Ecosystem:      models.EcosystemNPM,
@@ -147,6 +157,8 @@ func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDepend
 				PackageManager: models.Pnpm,
 				IsDirect:       true,
 				NameLocation:   nameLocation,
+				BlockLocation:  lookupPnpmPosition(dependencyName, version, dependency.Version, filePath, positions),
+				LocationRole:   models.LocationRoleLockfile,
 			},
 			Dep:           dependency,
 			WorkspacePath: workspacePath,
@@ -156,7 +168,51 @@ func extractDirectDependencies(sourceFile PnpmLockfile, roots []PnpmDirectDepend
 	return roots
 }
 
-func parsePnpmLock(sourceFile PnpmLockfile) []lockfile.PackageDetails {
+// lookupPnpmPosition resolves the FilePosition for a package in the positions map.
+// It tries, in order:
+//  1. Exact key "name@version" (common case).
+//  2. Raw version key "name@rawVersion" for git/tarball deps where the packages: section
+//     stores the full URL (e.g. "ansi-regex@https://codeload.github.com/...") but the
+//     caller has already cleaned the version to a semver.
+//  3. Prefix match "name@version(" for peer-suffixed keys (e.g. "tsutils@3.21.0(typescript@4.9.5)").
+//     When multiple peer variants exist for the same base version, picks the earliest by line number.
+func lookupPnpmPosition(name, version, rawVersion, filePath string, positions map[string]models.FilePosition) models.FilePosition {
+	key := name + "@" + version
+	if pos, ok := positions[key]; ok {
+		pos.Filename = filePath
+		return pos
+	}
+
+	// Fallback for git/tarball deps: try the raw (pre-cleaning) version.
+	if rawVersion != version {
+		rawKey := name + "@" + rawVersion
+		if pos, ok := positions[rawKey]; ok {
+			pos.Filename = filePath
+			return pos
+		}
+	}
+
+	// Fallback for peer-suffixed keys (e.g. "tsutils@3.21.0(typescript@4.9.5)").
+	// When multiple peer variants exist for the same base version, pick the earliest by line number.
+	prefix := key + "("
+	var best *models.FilePosition
+	for k, pos := range positions {
+		if strings.HasPrefix(k, prefix) {
+			p := pos
+			if best == nil || p.Line.Start < best.Line.Start {
+				best = &p
+			}
+		}
+	}
+	if best != nil {
+		best.Filename = filePath
+		return *best
+	}
+
+	return models.FilePosition{}
+}
+
+func parsePnpmLock(sourceFile PnpmLockfile, positions map[string]models.FilePosition, filePath string) []lockfile.PackageDetails {
 	// First create the deps tree
 	// To do so, first look at the packages list, for each package, look into the importers
 	// If present in the importers => its direct and we know its scope
@@ -165,15 +221,15 @@ func parsePnpmLock(sourceFile PnpmLockfile) []lockfile.PackageDetails {
 	// Going through the importers to get a direct (prod or dev), then finding the transitives in the snapshot
 	directDependencies := make([]PnpmDirectDependency, 0)
 	for workspacePath, importer := range sourceFile.Importers {
-		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.Dependencies, "prod", workspacePath)
-		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.OptionalDependencies, "optional", workspacePath)
-		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.DevDependencies, "dev", workspacePath)
+		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.Dependencies, "prod", workspacePath, positions, filePath)
+		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.OptionalDependencies, "optional", workspacePath, positions, filePath)
+		directDependencies = extractDirectDependencies(sourceFile, directDependencies, importer.DevDependencies, "dev", workspacePath, positions, filePath)
 	}
 
 	packages := make(map[string]lockfile.PackageDetails)
 	for _, direct := range directDependencies {
 		packages = addDependencyToPackageDetails(direct.Pkg, getPnpmWorkspaceDependencyKey(direct), packages)
-		packages = extractTransitiveDeps(sourceFile, direct, direct.Pkg.Name+"@"+direct.Dep.Version, packages)
+		packages = extractTransitiveDeps(sourceFile, direct, direct.Pkg.Name+"@"+direct.Dep.Version, packages, positions, filePath)
 	}
 
 	return slices.Collect(maps.Values(packages))
@@ -187,10 +243,120 @@ func getPnpmDependencyKey(pkg lockfile.PackageDetails) string {
 	return getWorkspaceDependencyKey(pkg.Name, pkg.Version, "") // this has no workspace path
 }
 
+// closePnpmBlock closes a package block by finding the last non-empty line before index i.
+func closePnpmBlock(positions map[string]models.FilePosition, key string, beforeIndex int, lines []string) {
+	pos := positions[key]
+	// Find last non-empty line before beforeIndex
+	lastNonEmpty := beforeIndex - 1
+	for lastNonEmpty >= 0 && strings.TrimSpace(lines[lastNonEmpty]) == "" {
+		lastNonEmpty--
+	}
+
+	if lastNonEmpty >= 0 {
+		pos.Line.End = lastNonEmpty + 1 // 1-indexed
+		pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastNonEmpty])
+	} else {
+		pos.Line.End = pos.Line.Start
+	}
+
+	positions[key] = pos
+}
+
+// extractPnpmV9PackagePositions scans YAML lines for package entries under "packages:".
+// Package keys appear at 2-space indent (e.g. "  acorn@8.11.3:"), and their blocks extend
+// until the next entry at the same indent or end of the packages section.
+func extractPnpmV9PackagePositions(lines []string) map[string]models.FilePosition {
+	positions := make(map[string]models.FilePosition)
+
+	inPackages := false
+	var currentKey string
+	var startLine int
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// Detect the "packages:" top-level key
+		if trimmed == "packages:" {
+			inPackages = true
+
+			continue
+		}
+
+		if !inPackages {
+			continue
+		}
+
+		// A line with no leading spaces means we've exited the packages block
+		if len(line) > 0 && line[0] != ' ' {
+			if currentKey != "" {
+				closePnpmBlock(positions, currentKey, i, lines)
+				currentKey = ""
+			}
+
+			inPackages = false
+
+			continue
+		}
+
+		// 2-space indent: package entry (e.g. "  acorn@8.11.3:")
+		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' && strings.HasSuffix(trimmed, ":") {
+			// Close previous package
+			if currentKey != "" {
+				closePnpmBlock(positions, currentKey, i, lines)
+			}
+
+			// Strip trailing ":" and surrounding single quotes (YAML quotes scoped package
+			// names starting with "@", e.g. "'@scope/pkg@1.0.0':" → "@scope/pkg@1.0.0").
+			pkgKey := strings.Trim(strings.TrimSuffix(trimmed, ":"), "'")
+			currentKey = pkgKey
+			startLine = lineNum
+
+			colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+
+			positions[currentKey] = models.FilePosition{
+				Line:   models.Position{Start: startLine, End: 0},
+				Column: models.Position{Start: colStart, End: 0},
+			}
+
+			continue
+		}
+	}
+
+	// Close last package if file ended within packages section
+	if currentKey != "" {
+		pos := positions[currentKey]
+		lastIdx := len(lines) - 1
+		for lastIdx >= 0 && strings.TrimSpace(lines[lastIdx]) == "" {
+			lastIdx--
+		}
+
+		if lastIdx >= 0 {
+			pos.Line.End = lastIdx + 1
+			pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastIdx])
+		} else {
+			pos.Line.End = pos.Line.Start
+		}
+
+		positions[currentKey] = pos
+	}
+
+	return positions
+}
+
 func (e PnpmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PnpmLockfile
 
-	err := yaml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = yaml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil && !errors.Is(err, io.EOF) {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -213,7 +379,10 @@ func (e PnpmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCont
 		return e.extractLegacyPnpm(file)
 	}
 
-	return parsePnpmLock(*parsedLockfile), nil
+	lines := fileposition.BytesToLines(content)
+	positions := extractPnpmV9PackagePositions(lines)
+
+	return parsePnpmLock(*parsedLockfile, positions, f.Path()), nil
 }
 
 var PnpmExtractor = PnpmLockExtractor{

--- a/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
@@ -80,10 +80,10 @@ func TestParseYarnLock_v1_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	pkg := packages[0]
-	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0")
 	assert.Equal(t, path, pkg.BlockLocation.Filename)
 
 	// balanced-match@^1.0.0 block is at lines 5-8 in one-package.v1.lock
@@ -105,10 +105,10 @@ func TestParseYarnLock_v1_TwoPackages_BlockLocation(t *testing.T) {
 	}
 
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
 		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
 	}
 }
@@ -1171,6 +1171,7 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 						Column:   models.Position{Start: 1, End: 108},
 						Filename: lockfilePath,
 					},
+					LocationRole: models.LocationRoleLockfile,
 					Dependencies: make([]*lockfile.PackageDetails, 0),
 				},
 			},
@@ -1186,6 +1187,7 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 				Column:   models.Position{Start: 1, End: 108},
 				Filename: lockfilePath,
 			},
+			LocationRole: models.LocationRoleLockfile,
 			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
 			DepGroups:    []string{"dev"},
 			Dependencies: make([]*lockfile.PackageDetails, 0),

--- a/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v1_test.go
@@ -62,6 +62,57 @@ func TestParseYarnLock_v1_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseYarnLock_v1_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/yarn/one-package.v1.lock"))
+	packages, err := javascript.ParseYarnLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Equal(t, path, pkg.BlockLocation.Filename)
+
+	// balanced-match@^1.0.0 block is at lines 5-8 in one-package.v1.lock
+	assert.Equal(t, 5, pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 8, pkg.BlockLocation.Line.End)
+}
+
+func TestParseYarnLock_v1_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/yarn/two-packages.v1.lock"))
+	packages, err := javascript.ParseYarnLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
 //nolint:paralleltest
 func TestParseYarnLock_v1_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()
@@ -1076,6 +1127,7 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
+	lockfilePath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/yarn-v1.lock"))
 	rootPath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/package.json"))
 	workspace1Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/workspace-1/package.json"))
 	workspace2Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/nested/workspace-2/package.json"))
@@ -1114,7 +1166,12 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 					PackageManager: models.Yarn,
 					Ecosystem:      models.EcosystemNPM,
 					DepGroups:      []string{"dev"},
-					Dependencies:   make([]*lockfile.PackageDetails, 0),
+					BlockLocation: models.FilePosition{
+						Line:     models.Position{Start: 5, End: 8},
+						Column:   models.Position{Start: 1, End: 108},
+						Filename: lockfilePath,
+					},
+					Dependencies: make([]*lockfile.PackageDetails, 0),
 				},
 			},
 		},
@@ -1124,10 +1181,14 @@ func TestParseYarnLock_v1_WorkspacesComplex(t *testing.T) {
 			TargetVersions: []string{"^1.4.0"},
 			PackageManager: models.Yarn,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
-			Dependencies:   make([]*lockfile.PackageDetails, 0),
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 5, End: 8},
+				Column:   models.Position{Start: 1, End: 108},
+				Filename: lockfilePath,
+			},
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
+			Dependencies: make([]*lockfile.PackageDetails, 0),
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
@@ -80,10 +80,10 @@ func TestParseYarnLock_v2_OnePackage_BlockLocation(t *testing.T) {
 	}
 
 	pkg := packages[0]
-	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
-	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0")
+	assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0")
 	assert.Equal(t, path, pkg.BlockLocation.Filename)
 
 	// "balanced-match@npm:^1.0.0" block is at lines 8-13 in one-package.v2.lock
@@ -105,10 +105,10 @@ func TestParseYarnLock_v2_TwoPackages_BlockLocation(t *testing.T) {
 	}
 
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.Start, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Line.End, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.Start, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Positive(t, pkg.BlockLocation.Column.End, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
 		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
 	}
 }
@@ -915,6 +915,7 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 						Column:   models.Position{Start: 1, End: 17},
 						Filename: lockfilePath,
 					},
+					LocationRole: models.LocationRoleLockfile,
 					Dependencies: make([]*lockfile.PackageDetails, 0),
 				},
 			},
@@ -930,6 +931,7 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 				Column:   models.Position{Start: 1, End: 17},
 				Filename: lockfilePath,
 			},
+			LocationRole: models.LocationRoleLockfile,
 			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
 			DepGroups:    []string{"dev"},
 			Dependencies: make([]*lockfile.PackageDetails, 0),

--- a/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock-v2_test.go
@@ -62,6 +62,57 @@ func TestParseYarnLock_v2_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseYarnLock_v2_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/yarn/one-package.v2.lock"))
+	packages, err := javascript.ParseYarnLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0")
+	assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0")
+	assert.Equal(t, path, pkg.BlockLocation.Filename)
+
+	// "balanced-match@npm:^1.0.0" block is at lines 8-13 in one-package.v2.lock
+	assert.Equal(t, 8, pkg.BlockLocation.Line.Start)
+	assert.Equal(t, 13, pkg.BlockLocation.Line.End)
+}
+
+func TestParseYarnLock_v2_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/yarn/two-packages.v2.lock"))
+	packages, err := javascript.ParseYarnLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0, "BlockLocation.Line.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0, "BlockLocation.Line.End should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0, "BlockLocation.Column.Start should be > 0 for %s", pkg.Name)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0, "BlockLocation.Column.End should be > 0 for %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename, "BlockLocation.Filename should match for %s", pkg.Name)
+	}
+}
+
 //nolint:paralleltest
 func TestParseYarnLock_v2_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()
@@ -820,6 +871,7 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
+	lockfilePath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/yarn.lock"))
 	rootPath := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/package.json"))
 	workspace1Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/workspace-1/package.json"))
 	workspace2Path := filepath.FromSlash(filepath.Join(dir, "../fixtures/package-json/workspace-complex/nested/workspace-2/package.json"))
@@ -858,7 +910,12 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 					PackageManager: models.Yarn,
 					Ecosystem:      models.EcosystemNPM,
 					DepGroups:      []string{"dev"},
-					Dependencies:   make([]*lockfile.PackageDetails, 0),
+					BlockLocation: models.FilePosition{
+						Line:     models.Position{Start: 8, End: 13},
+						Column:   models.Position{Start: 1, End: 17},
+						Filename: lockfilePath,
+					},
+					Dependencies: make([]*lockfile.PackageDetails, 0),
 				},
 			},
 		},
@@ -868,10 +925,14 @@ func TestParseYarnLock_v2_WorkspacesComplex(t *testing.T) {
 			TargetVersions: []string{"^1.4.0"},
 			PackageManager: models.Yarn,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
-			Dependencies:   make([]*lockfile.PackageDetails, 0),
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 8, End: 13},
+				Column:   models.Position{Start: 1, End: 17},
+				Filename: lockfilePath,
+			},
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
+			Dependencies: make([]*lockfile.PackageDetails, 0),
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-yarn-lock.go
+++ b/pkg/lockfile/javascript/parse-yarn-lock.go
@@ -3,7 +3,6 @@ package javascript
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -12,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -53,12 +53,42 @@ func parseYarnPackageBlock(block []string) []YarnPackage {
 	return packages
 }
 
-func groupYarnPackageLines(scanner *bufio.Scanner) []YarnPackage {
+// findLastNonEmptyLineInRange finds the 1-indexed line number of the last non-empty line
+// within the 0-indexed range [startIdx, endIdx].
+func findLastNonEmptyLineInRange(lines []string, startIdx, endIdx int) int {
+	if endIdx >= len(lines) {
+		endIdx = len(lines) - 1
+	}
+
+	for i := endIdx; i >= startIdx; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return i + 1 // 1-indexed
+		}
+	}
+
+	return startIdx + 1
+}
+
+// buildYarnBlockPosition creates a FilePosition from 1-indexed start and end line numbers.
+func buildYarnBlockPosition(lines []string, startLine, endLine int) models.FilePosition {
+	colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(lines[startLine-1])
+	colEnd := fileposition.GetLastNonEmptyCharacterIndexInLine(lines[endLine-1])
+
+	return models.FilePosition{
+		Line:   models.Position{Start: startLine, End: endLine},
+		Column: models.Position{Start: colStart, End: colEnd},
+	}
+}
+
+func groupYarnPackageLines(scanner *bufio.Scanner, lines []string) []YarnPackage {
 	var groups []YarnPackage
 	var group []string
+	var blockStartLine int // 1-indexed line number of block start
 
+	lineNum := 0
 	var line string
 	for scanner.Scan() {
+		lineNum++
 		line = scanner.Text()
 
 		if shouldSkipYarnLine(line) {
@@ -69,9 +99,15 @@ func groupYarnPackageLines(scanner *bufio.Scanner) []YarnPackage {
 		if !strings.HasPrefix(line, " ") {
 			if len(group) > 0 {
 				packages := parseYarnPackageBlock(group)
+				// Set BlockLocation on each package
+				blockEndLine := findLastNonEmptyLineInRange(lines, blockStartLine-1, lineNum-2)
+				for i := range packages {
+					packages[i].BlockLocation = buildYarnBlockPosition(lines, blockStartLine, blockEndLine)
+				}
 				groups = append(groups, packages...)
 			}
 			group = make([]string, 0)
+			blockStartLine = lineNum
 		}
 
 		group = append(group, line)
@@ -79,6 +115,10 @@ func groupYarnPackageLines(scanner *bufio.Scanner) []YarnPackage {
 
 	if len(group) > 0 {
 		packages := parseYarnPackageBlock(group)
+		blockEndLine := findLastNonEmptyLineInRange(lines, blockStartLine-1, len(lines)-1)
+		for i := range packages {
+			packages[i].BlockLocation = buildYarnBlockPosition(lines, blockStartLine, blockEndLine)
+		}
 		groups = append(groups, packages...)
 	}
 
@@ -336,7 +376,7 @@ func buildDependencyTree(rootPkgName, rootPkgTargetVersion, rootPkgRegistry stri
 	return results
 }
 
-func parseYarnPackage(dependency YarnPackage) lockfile.PackageDetails {
+func parseYarnPackage(dependency YarnPackage, filePath string) lockfile.PackageDetails {
 	if dependency.Version == "" {
 		_, _ = fmt.Fprintf(
 			os.Stderr,
@@ -350,6 +390,9 @@ func parseYarnPackage(dependency YarnPackage) lockfile.PackageDetails {
 		nameLocation = &models.FilePosition{Filename: dependency.WorkspacePath}
 	}
 
+	blockLocation := dependency.BlockLocation
+	blockLocation.Filename = filePath
+
 	return lockfile.PackageDetails{
 		Name:           dependency.Name,
 		Version:        dependency.Version,
@@ -358,6 +401,8 @@ func parseYarnPackage(dependency YarnPackage) lockfile.PackageDetails {
 		Ecosystem:      models.EcosystemNPM,
 		Commit:         tryExtractCommit(dependency.Resolution),
 		NameLocation:   nameLocation,
+		BlockLocation:  blockLocation,
+		LocationRole:   models.LocationRoleLockfile,
 	}
 }
 
@@ -450,12 +495,110 @@ func isJSONFormat(content []byte) bool {
 //
 // Returns a slice of YarnPackage structs compatible with the existing YAML parser output,
 // allowing the rest of the extraction logic to work identically for both formats.
-func parseYarnBerryJSON(content []byte) ([]YarnPackage, error) {
+// extractYarnBerryJSONPositions scans JSON lines for entry keys within the "entries" object.
+// Entry keys appear as "    \"package@npm:^1.0.0\": {" at 4-space indent inside "entries".
+func extractYarnBerryJSONPositions(lines []string) map[string]models.FilePosition {
+	positions := make(map[string]models.FilePosition)
+
+	inEntries := false
+	var currentKey string
+	braceDepth := 0
+
+	for i, line := range lines {
+		lineNum := i + 1
+		trimmed := strings.TrimSpace(line)
+
+		// Detect "entries": {
+		if !inEntries && strings.Contains(trimmed, `"entries"`) && strings.HasSuffix(trimmed, "{") {
+			inEntries = true
+			braceDepth = 1
+
+			continue
+		}
+
+		if !inEntries {
+			continue
+		}
+
+		// Track brace depth
+		for _, ch := range trimmed {
+			if ch == '{' {
+				braceDepth++
+			} else if ch == '}' {
+				braceDepth--
+			}
+		}
+
+		if braceDepth <= 0 {
+			// Close last entry
+			if currentKey != "" {
+				closeBerryEntry(positions, currentKey, i, lines)
+				currentKey = ""
+			}
+
+			inEntries = false
+
+			continue
+		}
+
+		// Entry key at depth 1 (exactly 4-space indent, opens an object): "    \"package@npm:^1.0.0\": {"
+		// Require HasSuffix("{") to avoid false positives on internal fields like "checksum": "..."
+		// which also sit at depth 2 but do not open a new brace.
+		if braceDepth == 2 && strings.HasSuffix(trimmed, "{") && strings.HasPrefix(line, "    ") {
+			// This is a new entry key
+			if currentKey != "" {
+				closeBerryEntry(positions, currentKey, i, lines)
+			}
+
+			// Extract the key between quotes
+			firstQuote := strings.Index(trimmed, `"`)
+			lastQuote := strings.Index(trimmed[firstQuote+1:], `"`)
+
+			if firstQuote >= 0 && lastQuote >= 0 {
+				key := trimmed[firstQuote+1 : firstQuote+1+lastQuote]
+				currentKey = key
+
+				colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+
+				positions[currentKey] = models.FilePosition{
+					Line:   models.Position{Start: lineNum, End: 0},
+					Column: models.Position{Start: colStart, End: 0},
+				}
+			}
+		}
+	}
+
+	if currentKey != "" {
+		closeBerryEntry(positions, currentKey, len(lines), lines)
+	}
+
+	return positions
+}
+
+func closeBerryEntry(positions map[string]models.FilePosition, key string, beforeIndex int, lines []string) {
+	pos := positions[key]
+	lastNonEmpty := beforeIndex - 1
+	for lastNonEmpty >= 0 && strings.TrimSpace(lines[lastNonEmpty]) == "" {
+		lastNonEmpty--
+	}
+
+	if lastNonEmpty >= 0 {
+		pos.Line.End = lastNonEmpty + 1
+		pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastNonEmpty])
+	} else {
+		pos.Line.End = pos.Line.Start
+	}
+
+	positions[key] = pos
+}
+
+func parseYarnBerryJSON(content []byte, lines []string) ([]YarnPackage, error) {
 	var berryJSON YarnBerryJSON
 	if err := json.Unmarshal(content, &berryJSON); err != nil {
 		return nil, fmt.Errorf("failed to parse yarn.lock JSON: %w", err)
 	}
 
+	positions := extractYarnBerryJSONPositions(lines)
 	packages := make([]YarnPackage, 0, len(berryJSON.Entries))
 
 	for entryKey, entry := range berryJSON.Entries {
@@ -484,6 +627,12 @@ func parseYarnBerryJSON(content []byte) ([]YarnPackage, error) {
 			})
 		}
 
+		// Look up position by entry key
+		var blockPos models.FilePosition
+		if pos, ok := positions[entryKey]; ok {
+			blockPos = pos
+		}
+
 		// Create one YarnPackage per target version
 		for _, targetVersion := range targetVersions {
 			packages = append(packages, YarnPackage{
@@ -493,6 +642,7 @@ func parseYarnBerryJSON(content []byte) ([]YarnPackage, error) {
 				Resolution:    resolution,
 				Dependencies:  dependencies,
 				WorkspacePath: workspacePath,
+				BlockLocation: blockPos,
 			})
 		}
 	}
@@ -501,41 +651,24 @@ func parseYarnBerryJSON(content []byte) ([]YarnPackage, error) {
 }
 
 func (e YarnLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
-	// Peek first bytes to detect format without loading entire file into memory
-	buf := make([]byte, 200)
-	n, err := f.Read(buf)
-	if err != nil && !errors.Is(err, io.EOF) {
+	content, err := io.ReadAll(f)
+	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("error reading yarn.lock: %w", err)
 	}
 
-	// Try to reset file position for streaming
-	var reader io.Reader = f
-	if seeker, ok := f.(io.Seeker); ok {
-		if _, err := seeker.Seek(0, 0); err != nil {
-			return []lockfile.PackageDetails{}, fmt.Errorf("error seeking yarn.lock: %w", err)
-		}
-	} else {
-		// If we can't seek, prepend the peeked bytes back to the reader
-		reader = io.MultiReader(strings.NewReader(string(buf[:n])), f)
-	}
+	lines := fileposition.BytesToLines(content)
 
 	var yarnPackages []YarnPackage
-	if isJSONFormat(buf[:n]) {
+	if isJSONFormat(content) {
 		// Parse JSON format (Yarn v4+)
-		// JSON requires loading entire file into memory for parsing
-		content, err := io.ReadAll(reader)
-		if err != nil {
-			return []lockfile.PackageDetails{}, fmt.Errorf("error reading yarn.lock JSON: %w", err)
-		}
-		yarnPackages, err = parseYarnBerryJSON(content)
+		yarnPackages, err = parseYarnBerryJSON(content, lines)
 		if err != nil {
 			return []lockfile.PackageDetails{}, err
 		}
 	} else {
-		// Parse YAML format (Yarn v1-3) using streaming scanner
-		// This avoids loading the entire file into memory
-		scanner := bufio.NewScanner(reader)
-		yarnPackages = groupYarnPackageLines(scanner)
+		// Parse YAML-like format (Yarn v1-3)
+		scanner := bufio.NewScanner(strings.NewReader(string(content)))
+		yarnPackages = groupYarnPackageLines(scanner, lines)
 
 		if err := scanner.Err(); err != nil {
 			return []lockfile.PackageDetails{}, fmt.Errorf("error while scanning %s: %w", f.Path(), err)
@@ -561,7 +694,7 @@ func (e YarnLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCont
 	}
 
 	dependencyWorkspaces := createDependencyWorkspaceMap(workspaces, allResolvedPackages)
-	packages := createPackageDetails(allResolvedPackages, dependencyWorkspaces)
+	packages := createPackageDetails(allResolvedPackages, dependencyWorkspaces, f.Path())
 
 	pkgIndex := indexByNameAndVersions(packages)
 	for index, pkg := range packages {
@@ -608,12 +741,12 @@ func createDependencyWorkspaceMap(workspaces []YarnPackage, allResolvedPackages 
 	return dependencyWorkspaces
 }
 
-func createPackageDetails(allResolvedPackages []YarnPackage, dependencyWorkspaces map[string][]string) []lockfile.PackageDetails {
+func createPackageDetails(allResolvedPackages []YarnPackage, dependencyWorkspaces map[string][]string, filePath string) []lockfile.PackageDetails {
 	packages := make([]lockfile.PackageDetails, 0, len(allResolvedPackages))
 
 	// Create lockfile.PackageDetails for regular packages, with workspace information where applicable
 	for _, yarnPackage := range allResolvedPackages {
-		basePackage := parseYarnPackage(yarnPackage)
+		basePackage := parseYarnPackage(yarnPackage, filePath)
 		depKey := getWorkspaceDependencyKey(yarnPackage.Name, yarnPackage.Version, yarnPackage.TargetVersion)
 
 		if workspacePaths, exists := dependencyWorkspaces[depKey]; exists {

--- a/pkg/lockfile/javascript/pnpm-legacy-lock.go
+++ b/pkg/lockfile/javascript/pnpm-legacy-lock.go
@@ -1,6 +1,7 @@
 package javascript
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -104,7 +106,88 @@ func getVersionInfo(name string, maps ...map[string]PnpmLegacyLockDependency) (s
 	return "", "", false
 }
 
-func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile) []lockfile.PackageDetails {
+// extractPnpmLegacyPackagePositions scans YAML lines for package entries under "packages:".
+// Legacy pnpm package keys appear at 2-space indent (e.g. "  /acorn/8.7.0:").
+func extractPnpmLegacyPackagePositions(lines []string) map[string]models.FilePosition {
+	positions := make(map[string]models.FilePosition)
+
+	inPackages := false
+	var currentKey string
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// Detect the "packages:" top-level key
+		if trimmed == "packages:" {
+			inPackages = true
+
+			continue
+		}
+
+		if !inPackages {
+			continue
+		}
+
+		// A line with no leading spaces means we've exited the packages block
+		if len(line) > 0 && line[0] != ' ' {
+			if currentKey != "" {
+				closePnpmBlock(positions, currentKey, i, lines)
+				currentKey = ""
+			}
+
+			inPackages = false
+
+			continue
+		}
+
+		// 2-space indent: package entry (e.g. "  /acorn/8.7.0:")
+		if len(line) >= 3 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' && strings.HasSuffix(trimmed, ":") {
+			// Close previous package
+			if currentKey != "" {
+				closePnpmBlock(positions, currentKey, i, lines)
+			}
+
+			pkgKey := strings.TrimSuffix(trimmed, ":")
+			currentKey = pkgKey
+
+			colStart := fileposition.GetFirstNonEmptyCharacterIndexInLine(line)
+
+			positions[currentKey] = models.FilePosition{
+				Line:   models.Position{Start: lineNum, End: 0},
+				Column: models.Position{Start: colStart, End: 0},
+			}
+
+			continue
+		}
+	}
+
+	// Close last package if file ended within packages section
+	if currentKey != "" {
+		pos := positions[currentKey]
+		lastIdx := len(lines) - 1
+		for lastIdx >= 0 && strings.TrimSpace(lines[lastIdx]) == "" {
+			lastIdx--
+		}
+
+		if lastIdx >= 0 {
+			pos.Line.End = lastIdx + 1
+			pos.Column.End = fileposition.GetLastNonEmptyCharacterIndexInLine(lines[lastIdx])
+		} else {
+			pos.Line.End = pos.Line.Start
+		}
+
+		positions[currentKey] = pos
+	}
+
+	return positions
+}
+
+func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile, positions map[string]models.FilePosition, filePath string) []lockfile.PackageDetails {
 	packages := make([]lockfile.PackageDetails, 0, len(sourceFile.Packages))
 
 	for s, pkg := range sourceFile.Packages {
@@ -186,6 +269,12 @@ func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile) []lockfile.PackageDetail
 			targetVersions = []string{targetVersion}
 		}
 
+		blockLocation := models.FilePosition{}
+		if pos, ok := positions[s]; ok {
+			pos.Filename = filePath
+			blockLocation = pos
+		}
+
 		packages = append(packages, lockfile.PackageDetails{
 			Name:           name,
 			Version:        version,
@@ -195,6 +284,7 @@ func parsePnpmLegacyLock(sourceFile PnpmLegacyLockfile) []lockfile.PackageDetail
 			Commit:         commit,
 			DepGroups:      depGroups,
 			IsDirect:       isDirect,
+			BlockLocation:  blockLocation,
 		})
 	}
 
@@ -216,7 +306,12 @@ func (e PnpmLockExtractor) PackageManager() models.PackageManager {
 func (e PnpmLockExtractor) extractLegacyPnpm(f lockfile.DepFile) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PnpmLegacyLockfile
 
-	err := yaml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = yaml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil && !errors.Is(err, io.EOF) {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -227,5 +322,8 @@ func (e PnpmLockExtractor) extractLegacyPnpm(f lockfile.DepFile) ([]lockfile.Pac
 		parsedLockfile = &PnpmLegacyLockfile{}
 	}
 
-	return parsePnpmLegacyLock(*parsedLockfile), nil
+	lines := fileposition.BytesToLines(content)
+	positions := extractPnpmLegacyPackagePositions(lines)
+
+	return parsePnpmLegacyLock(*parsedLockfile, positions, f.Path()), nil
 }

--- a/pkg/lockfile/javascript/types.go
+++ b/pkg/lockfile/javascript/types.go
@@ -217,6 +217,7 @@ type YarnPackage struct {
 	Resolution    string
 	Dependencies  []YarnDependency
 	WorkspacePath string
+	BlockLocation models.FilePosition
 }
 
 type YarnLockExtractor struct {

--- a/pkg/lockfile/php/match-composer.go
+++ b/pkg/lockfile/php/match-composer.go
@@ -35,9 +35,12 @@ func (depMap *ComposerMatcherDependencyMap) UnmarshalJSON(bytes []byte) error {
 	content := string(bytes)
 
 	for _, pkg := range depMap.Packages {
-		if depMap.RootType == typeRequireDev && pkg.BlockLocation.Line.Start != 0 {
-			// If it is dev dependency definition and we already found a package location,
-			// we skip it to prioritize non-dev dependencies
+		if depMap.RootType == typeRequireDev && pkg.BlockLocation.Filename == depMap.FilePath {
+			// If it is dev dependency definition and this package's BlockLocation already
+			// points to the current source file (meaning a prior section like "require"
+			// already set it), skip the location overwrite to prioritize non-dev dependencies.
+			// We compare Filename rather than checking Line.Start != 0 because extractors
+			// may now set BlockLocation from the lockfile for all packages.
 			continue
 		}
 		pkgIndexes := jsonUtils.ExtractPackageIndexes(pkg.Name, "", content)

--- a/pkg/lockfile/php/parse-composer-lock.go
+++ b/pkg/lockfile/php/parse-composer-lock.go
@@ -1,10 +1,14 @@
 package php
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -43,13 +47,73 @@ func (e ComposerLockExtractor) PackageManager() models.PackageManager {
 	return composerPackageManager
 }
 
+// computeComposerBlockPositions scans JSON lines to find the start/end
+// positions of each object in the "packages" and "packages-dev" arrays.
+// Returns positions in order: packages first, then packages-dev.
+func computeComposerBlockPositions(lines []string) []models.FilePosition {
+	var positions []models.FilePosition
+
+	packagesKeyRe := cachedregexp.MustCompile(`^\s*"packages(-dev)?"\s*:\s*\[`)
+	inArray := false
+	braceDepth := 0
+	var currentStart int
+
+	for i, line := range lines {
+		lineNum := i + 1 // 1-indexed
+
+		if !inArray {
+			if packagesKeyRe.MatchString(line) {
+				inArray = true
+				braceDepth = 0
+			}
+
+			continue
+		}
+
+		// Count braces on this line
+		for _, ch := range line {
+			switch ch {
+			case '{':
+				braceDepth++
+				if braceDepth == 1 {
+					currentStart = lineNum
+				}
+			case '}':
+				if braceDepth == 1 {
+					positions = append(positions, models.FilePosition{
+						Line:   models.Position{Start: currentStart, End: lineNum},
+						Column: models.Position{Start: strings.IndexByte(lines[currentStart-1], '{') + 1, End: strings.IndexByte(line, '}') + 2},
+					})
+				}
+				braceDepth--
+			}
+		}
+
+		// Check if array is closed (line has ']' at depth 0)
+		if braceDepth == 0 && strings.Contains(line, "]") {
+			inArray = false
+		}
+	}
+
+	return positions
+}
+
 func (e ComposerLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *ComposerLock
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
+
+	// Compute block positions for all packages in both arrays
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	blockPositions := computeComposerBlockPositions(lines)
 
 	packages := make(
 		[]lockfile.PackageDetails,
@@ -58,25 +122,40 @@ func (e ComposerLockExtractor) Extract(f lockfile.DepFile, context lockfile.Scan
 		uint64(len(parsedLockfile.Packages))+uint64(len(parsedLockfile.PackagesDev)),
 	)
 
+	posIdx := 0
 	for _, composerPackage := range parsedLockfile.Packages {
-		packages = append(packages, lockfile.PackageDetails{
+		pkg := lockfile.PackageDetails{
 			Name:           composerPackage.Name,
 			Version:        composerPackage.Version,
 			Commit:         composerPackage.Dist.Reference,
 			PackageManager: composerPackageManager,
 			Ecosystem:      models.EcosystemPackagist,
-		})
+			LocationRole:   models.LocationRoleLockfile,
+		}
+		if posIdx < len(blockPositions) {
+			pkg.BlockLocation = blockPositions[posIdx]
+			pkg.BlockLocation.Filename = f.Path()
+			posIdx++
+		}
+		packages = append(packages, pkg)
 	}
 
 	for _, composerPackage := range parsedLockfile.PackagesDev {
-		packages = append(packages, lockfile.PackageDetails{
+		pkg := lockfile.PackageDetails{
 			Name:           composerPackage.Name,
 			Version:        composerPackage.Version,
 			Commit:         composerPackage.Dist.Reference,
 			PackageManager: composerPackageManager,
 			Ecosystem:      models.EcosystemPackagist,
 			DepGroups:      []string{"dev"},
-		})
+			LocationRole:   models.LocationRoleLockfile,
+		}
+		if posIdx < len(blockPositions) {
+			pkg.BlockLocation = blockPositions[posIdx]
+			pkg.BlockLocation.Filename = f.Path()
+			posIdx++
+		}
+		packages = append(packages, pkg)
 	}
 
 	return packages, nil

--- a/pkg/lockfile/php/parse-composer-lock_test.go
+++ b/pkg/lockfile/php/parse-composer-lock_test.go
@@ -202,7 +202,7 @@ func TestParseComposerLock_TwoPackages_BlockLocation(t *testing.T) {
 	// two-packages.json has:
 	// "packages" array with sentry/sdk at lines 9-39
 	// "packages-dev" array with theseer/tokenizer at lines 42-77
-	assert.Equal(t, 2, len(packages), "expected 2 packages")
+	assert.Len(t, packages, 2, "expected 2 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/php/parse-composer-lock_test.go
+++ b/pkg/lockfile/php/parse-composer-lock_test.go
@@ -2,7 +2,10 @@ package php_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/php"
 
@@ -99,7 +102,7 @@ func TestParseComposerLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "sentry/sdk",
 			Version:        "2.0.4",
@@ -118,7 +121,7 @@ func TestParseComposerLock_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "sentry/sdk",
 			Version:        "2.0.4",
@@ -138,7 +141,7 @@ func TestParseComposerLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "sentry/sdk",
 			Version:        "2.0.4",
@@ -165,7 +168,7 @@ func TestParseComposerLock_TwoPackagesAlt(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "sentry/sdk",
 			Version:        "2.0.4",
@@ -181,4 +184,49 @@ func TestParseComposerLock_TwoPackagesAlt(t *testing.T) {
 			Ecosystem:      models.EcosystemPackagist,
 		},
 	})
+}
+
+func TestParseComposerLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/composer/two-packages.json")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := php.ParseComposerLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// two-packages.json has:
+	// "packages" array with sentry/sdk at lines 9-39
+	// "packages-dev" array with theseer/tokenizer at lines 42-77
+	assert.Equal(t, 2, len(packages), "expected 2 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// sentry/sdk starts at line 9 (opening {) and ends at line 39 (closing })
+	assert.Equal(t, 9, pkgMap["sentry/sdk"].BlockLocation.Line.Start)
+	assert.Equal(t, 39, pkgMap["sentry/sdk"].BlockLocation.Line.End)
+
+	// theseer/tokenizer starts at line 42 and ends at line 77
+	assert.Equal(t, 42, pkgMap["theseer/tokenizer"].BlockLocation.Line.Start)
+	assert.Equal(t, 77, pkgMap["theseer/tokenizer"].BlockLocation.Line.End)
+
+	// Verify path is absolute
+	assert.True(t, filepath.IsAbs(path), "path should be absolute")
 }

--- a/pkg/lockfile/python/parse-pdm-lock.go
+++ b/pkg/lockfile/python/parse-pdm-lock.go
@@ -1,9 +1,13 @@
 package python
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -25,7 +29,12 @@ func (p PdmLockExtractor) PackageManager() models.PackageManager {
 func (p PdmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockFile *PdmLockFile
 
-	_, err := toml.NewDecoder(f).Decode(&parsedLockFile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	_, err = toml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockFile)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
@@ -57,6 +66,20 @@ func (p PdmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 		}
 
 		packages = append(packages, details)
+	}
+
+	// Set BlockLocation for each package using the InTOML utility
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	positions := make([]*models.FilePosition, len(packages))
+	for i := range packages {
+		positions[i] = &packages[i].BlockLocation
+	}
+
+	fileposition.InTOML("[[package]]", "", positions, lines)
+
+	for i := range packages {
+		packages[i].BlockLocation.Filename = f.Path()
+		packages[i].LocationRole = models.LocationRoleLockfile
 	}
 
 	return packages, nil

--- a/pkg/lockfile/python/parse-pdm-lock_test.go
+++ b/pkg/lockfile/python/parse-pdm-lock_test.go
@@ -238,7 +238,7 @@ func TestParsePdmLock_TwoPackages_BlockLocation(t *testing.T) {
 	// line 4: [metadata]
 	// line 10: [[package]] (six, lines 10-19)
 	// line 21: [[package]] (toml, lines 21-30)
-	assert.Equal(t, 2, len(packages), "expected 2 packages")
+	assert.Len(t, packages, 2, "expected 2 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/python/parse-pdm-lock_test.go
+++ b/pkg/lockfile/python/parse-pdm-lock_test.go
@@ -2,7 +2,10 @@ package python_test
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/python"
 
@@ -109,7 +112,7 @@ func TestParsePdmLock_SinglePackage(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/single-package.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -125,7 +128,7 @@ func TestParsePdmLock_TwoPackages(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/two-packages.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -147,7 +150,7 @@ func TestParsePdmLock_PackageWithDevDependencies(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/dev-dependency.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -177,7 +180,7 @@ func TestParsePdmLock_PackageWithOptionalDependency(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/optional-dependency.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -207,7 +210,7 @@ func TestParsePdmLock_PackageWithGitDependency(t *testing.T) {
 	packages, err := python.ParsePdmLock("../fixtures/pdm/git-dependency.toml")
 
 	expectNilErr(t, err)
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "toml",
 			Version:        "0.10.2",
@@ -216,4 +219,48 @@ func TestParsePdmLock_PackageWithGitDependency(t *testing.T) {
 			Commit:         "65bab7582ce14c55cdeec2244c65ea23039c9e6f",
 		},
 	})
+}
+
+func TestParsePdmLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/pdm/two-packages.toml")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := python.ParsePdmLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// two-packages.toml has:
+	// line 4: [metadata]
+	// line 10: [[package]] (six, lines 10-19)
+	// line 21: [[package]] (toml, lines 21-30)
+	assert.Equal(t, 2, len(packages), "expected 2 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// six starts at line 10 ("[[package]]")
+	assert.Equal(t, 10, pkgMap["six"].BlockLocation.Line.Start)
+
+	// toml starts at line 21 ("[[package]]")
+	assert.Equal(t, 21, pkgMap["toml"].BlockLocation.Line.Start)
+
+	// Verify path is absolute
+	assert.True(t, filepath.IsAbs(path), "path should be absolute")
 }

--- a/pkg/lockfile/python/parse-pipenv-lock.go
+++ b/pkg/lockfile/python/parse-pipenv-lock.go
@@ -1,11 +1,15 @@
 package python
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"slices"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -27,21 +31,48 @@ func (e PipenvLockExtractor) PackageManager() models.PackageManager {
 func (e PipenvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PipenvLock
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	// Build position maps for InJSON
+	defaultPositions := make(map[string]*models.FilePosition, len(parsedLockfile.Packages))
+	for name := range parsedLockfile.Packages {
+		defaultPositions[name] = &models.FilePosition{}
+	}
+
+	developPositions := make(map[string]*models.FilePosition, len(parsedLockfile.PackagesDev))
+	for name := range parsedLockfile.PackagesDev {
+		developPositions[name] = &models.FilePosition{}
+	}
+
+	fileposition.InJSON("default", defaultPositions, lines, 0)
+	fileposition.InJSON("develop", developPositions, lines, 0)
+
 	details := make(map[string]lockfile.PackageDetails)
 
-	addPkgDetails(details, parsedLockfile.Packages, "")
-	addPkgDetails(details, parsedLockfile.PackagesDev, "dev")
+	addPkgDetails(details, parsedLockfile.Packages, "", defaultPositions, f.Path())
+	addPkgDetails(details, parsedLockfile.PackagesDev, "dev", developPositions, f.Path())
 
 	return slices.Collect(maps.Values(details)), nil
 }
 
-func addPkgDetails(details map[string]lockfile.PackageDetails, packages map[string]PipenvPackage, group string) {
+func addPkgDetails(
+	details map[string]lockfile.PackageDetails,
+	packages map[string]PipenvPackage,
+	group string,
+	positions map[string]*models.FilePosition,
+	filePath string,
+) {
 	for name, pipenvPackage := range packages {
 		if pipenvPackage.Version == "" {
 			continue
@@ -55,9 +86,15 @@ func addPkgDetails(details map[string]lockfile.PackageDetails, packages map[stri
 				Version:        version,
 				PackageManager: pipenvPackageManager,
 				Ecosystem:      models.EcosystemPyPI,
+				LocationRole:   models.LocationRoleLockfile,
 			}
 			if group != "" {
 				pkgDetails.DepGroups = append(pkgDetails.DepGroups, group)
+			}
+			if pos, ok := positions[name]; ok {
+				blockLocation := *pos
+				blockLocation.Filename = filePath
+				pkgDetails.BlockLocation = blockLocation
 			}
 			details[name+"@"+version] = pkgDetails
 		}

--- a/pkg/lockfile/python/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/python/parse-pipenv-lock_test.go
@@ -112,7 +112,7 @@ func TestParsePipenvLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markupsafe",
 			Version:        "2.1.1",
@@ -157,7 +157,7 @@ func TestParsePipenvLock_OnePackage_MatcherFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markupsafe",
 			Version:        "2.1.1",
@@ -183,7 +183,7 @@ func TestParsePipenvLock_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markupsafe",
 			Version:        "2.1.1",
@@ -207,7 +207,7 @@ func TestParsePipenvLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "itsdangerous",
 			Version:        "2.1.2",
@@ -237,7 +237,7 @@ func TestParsePipenvLock_TwoPackagesAlt(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "itsdangerous",
 			Version:        "2.1.2",
@@ -266,7 +266,7 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "itsdangerous",
 			Version:        "2.1.2",
@@ -293,6 +293,41 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Ecosystem:      models.EcosystemPyPI,
 		},
 	})
+}
+
+func TestParsePipenvLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/pipenv/two-packages.json"))
+	packages, err := python.ParsePipenvLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	// itsdangerous is in "default" section, lines 19-26
+	itsdangerous := packagesByName["itsdangerous"]
+	assert.Equal(t, 19, itsdangerous.BlockLocation.Line.Start)
+	assert.Equal(t, 26, itsdangerous.BlockLocation.Line.End)
+	assert.Equal(t, 7, itsdangerous.BlockLocation.Column.Start)
+	assert.Equal(t, 8, itsdangerous.BlockLocation.Column.End)
+	assert.Equal(t, path, itsdangerous.BlockLocation.Filename)
+
+	// markupsafe is in "develop" section, lines 29-74
+	markupsafe := packagesByName["markupsafe"]
+	assert.Equal(t, 29, markupsafe.BlockLocation.Line.Start)
+	assert.Equal(t, 74, markupsafe.BlockLocation.Line.End)
+	assert.Equal(t, 7, markupsafe.BlockLocation.Column.Start)
+	assert.Equal(t, 8, markupsafe.BlockLocation.Column.End)
+	assert.Equal(t, path, markupsafe.BlockLocation.Filename)
 }
 
 func TestParsePipenvLock_PackageWithoutVersion(t *testing.T) {

--- a/pkg/lockfile/python/parse-poetry-lock.go
+++ b/pkg/lockfile/python/parse-poetry-lock.go
@@ -1,9 +1,13 @@
 package python
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -25,7 +29,12 @@ func (e PoetryLockExtractor) PackageManager() models.PackageManager {
 func (e PoetryLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *PoetryLockFile
 
-	_, err := toml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	_, err = toml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -45,6 +54,20 @@ func (e PoetryLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCo
 			pkgDetails.DepGroups = append(pkgDetails.DepGroups, "optional")
 		}
 		packages = append(packages, pkgDetails)
+	}
+
+	// Set BlockLocation for each package using the InTOML utility
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	positions := make([]*models.FilePosition, len(packages))
+	for i := range packages {
+		positions[i] = &packages[i].BlockLocation
+	}
+
+	fileposition.InTOML("[[package]]", "[metadata]", positions, lines)
+
+	for i := range packages {
+		packages[i].BlockLocation.Filename = f.Path()
+		packages[i].LocationRole = models.LocationRoleLockfile
 	}
 
 	return packages, nil

--- a/pkg/lockfile/python/parse-poetry-lock_test.go
+++ b/pkg/lockfile/python/parse-poetry-lock_test.go
@@ -311,7 +311,7 @@ func TestParsePoetryLock_TwoPackages_BlockLocation(t *testing.T) {
 	// line 1: "[[package]]"  (proto-plus block, lines 1-13)
 	// line 15: "[[package]]" (protobuf block, lines 15-21)
 	// line 23: "[metadata]"  (not a package)
-	assert.Equal(t, 2, len(packages), "expected 2 packages")
+	assert.Len(t, packages, 2, "expected 2 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/python/parse-poetry-lock_test.go
+++ b/pkg/lockfile/python/parse-poetry-lock_test.go
@@ -112,7 +112,7 @@ func TestParsePoetryLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "numpy",
 			Version:        "1.23.3",
@@ -157,7 +157,7 @@ func TestParsePoetryLock_OnePackage_MatcherFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "numpy",
 			Version:        "1.23.3",
@@ -183,7 +183,7 @@ func TestParsePoetryLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "proto-plus",
 			Version:        "1.22.0",
@@ -212,7 +212,7 @@ func TestParsePoetryLock_PackageWithMetadata(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "emoji",
 			Version:        "2.0.0",
@@ -235,7 +235,7 @@ func TestParsePoetryLock_PackageWithGitSource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ike",
 			Version:        "0.2.0",
@@ -259,7 +259,7 @@ func TestParsePoetryLock_PackageWithLegacySource(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "appdirs",
 			Version:        "1.4.4",
@@ -283,7 +283,7 @@ func TestParsePoetryLock_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "numpy",
 			Version:        "1.23.3",
@@ -292,4 +292,48 @@ func TestParsePoetryLock_OptionalPackage(t *testing.T) {
 			DepGroups:      []string{"optional"},
 		},
 	})
+}
+
+func TestParsePoetryLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/poetry/two-packages.lock")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := python.ParsePoetryLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// two-packages.lock has:
+	// line 1: "[[package]]"  (proto-plus block, lines 1-13)
+	// line 15: "[[package]]" (protobuf block, lines 15-21)
+	// line 23: "[metadata]"  (not a package)
+	assert.Equal(t, 2, len(packages), "expected 2 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// proto-plus starts at line 1
+	assert.Equal(t, 1, pkgMap["proto-plus"].BlockLocation.Line.Start)
+
+	// protobuf starts at line 15
+	assert.Equal(t, 15, pkgMap["protobuf"].BlockLocation.Line.Start)
+
+	// Verify path is absolute
+	assert.True(t, filepath.IsAbs(path), "path should be absolute")
 }

--- a/pkg/lockfile/python/parse-uv-lock.go
+++ b/pkg/lockfile/python/parse-uv-lock.go
@@ -1,11 +1,14 @@
 package python
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -62,7 +65,12 @@ func findRootPackage(allPackages []*UvLockPackage) (*UvLockPackage, error) {
 func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *UvLockFile
 
-	_, err := toml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	_, err = toml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
@@ -71,6 +79,16 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 	if err != nil {
 		return []lockfile.PackageDetails{}, errors.New("error getting root package")
 	}
+
+	// Compute BlockLocation for ALL toml packages (including root) using InTOML
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	allPositions := make([]models.FilePosition, len(parsedLockfile.Packages))
+	positionPtrs := make([]*models.FilePosition, len(parsedLockfile.Packages))
+	for i := range allPositions {
+		positionPtrs[i] = &allPositions[i]
+	}
+
+	fileposition.InTOML("[[package]]", "", positionPtrs, lines)
 
 	// This will hold packages we will return
 	packages := make([]lockfile.PackageDetails, 0, len(parsedLockfile.Packages))
@@ -84,7 +102,7 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 			}
 		}
 
-		for _, lockPackage := range parsedLockfile.Packages {
+		for i, lockPackage := range parsedLockfile.Packages {
 			// Skip root package because root files describe what it depends on, but isn't itself a dependency
 			// https://docs.astral.sh/uv/concepts/projects/layout/
 			if isRoot(lockPackage) {
@@ -100,6 +118,9 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 				depGroups = append(depGroups, "dev")
 			}
 
+			blockLocation := allPositions[i]
+			blockLocation.Filename = f.Path()
+
 			pkgDetails := lockfile.PackageDetails{
 				Name:           lockPackage.Name,
 				Version:        lockPackage.Version,
@@ -107,6 +128,8 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 				PackageManager: uvPackageManager,
 				Ecosystem:      models.EcosystemPyPI,
 				IsDirect:       isDirect || isDevDependency,
+				BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 			}
 
 			if len(depGroups) > 0 {

--- a/pkg/lockfile/python/parse-uv-lock.go
+++ b/pkg/lockfile/python/parse-uv-lock.go
@@ -129,7 +129,7 @@ func (e UvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContex
 				Ecosystem:      models.EcosystemPyPI,
 				IsDirect:       isDirect || isDevDependency,
 				BlockLocation:  blockLocation,
-			LocationRole:   models.LocationRoleLockfile,
+				LocationRole:   models.LocationRoleLockfile,
 			}
 
 			if len(depGroups) > 0 {

--- a/pkg/lockfile/python/parse-uv-lock_test.go
+++ b/pkg/lockfile/python/parse-uv-lock_test.go
@@ -248,7 +248,7 @@ func TestParseUvLock_SinglePackage_BlockLocation(t *testing.T) {
 	// line 5: certifi, line 14: charset-normalizer, line 36: idna,
 	// line 45: requests, line 60: urllib3, line 69: uv (root, skipped)
 	// Root package "uv" is skipped, so 5 packages returned.
-	assert.Equal(t, 5, len(packages), "expected 5 packages (root skipped)")
+	assert.Len(t, packages, 5, "expected 5 packages (root skipped)")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/python/parse-uv-lock_test.go
+++ b/pkg/lockfile/python/parse-uv-lock_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/python"
@@ -24,7 +26,7 @@ func TestParseUvLock_SinglePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "requests",
 			Version:        "2.32.3",
@@ -72,7 +74,7 @@ func TestParseUvLock_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseUvLock_MultiplePackage(t *testing.T) {
@@ -88,7 +90,7 @@ func TestParseUvLock_MultiplePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "bottle",
 			Version:        "0.13.3",
@@ -147,7 +149,7 @@ func TestParseUvLock_DevPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "requests",
 			Version:        "2.32.3",
@@ -227,4 +229,51 @@ func TestParseUvLock_DevPackage(t *testing.T) {
 			IsDirect:       false,
 		},
 	})
+}
+
+func TestParseUvLock_SinglePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/uv/single-package.lock")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := python.ParseUvLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// single-package.lock has 6 [[package]] sections:
+	// line 5: certifi, line 14: charset-normalizer, line 36: idna,
+	// line 45: requests, line 60: urllib3, line 69: uv (root, skipped)
+	// Root package "uv" is skipped, so 5 packages returned.
+	assert.Equal(t, 5, len(packages), "expected 5 packages (root skipped)")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// certifi starts at line 5
+	assert.Equal(t, 5, pkgMap["certifi"].BlockLocation.Line.Start)
+
+	// idna starts at line 36
+	assert.Equal(t, 36, pkgMap["idna"].BlockLocation.Line.Start)
+
+	// requests starts at line 45
+	assert.Equal(t, 45, pkgMap["requests"].BlockLocation.Line.Start)
+
+	// Verify path is absolute
+	assert.True(t, filepath.IsAbs(path), "path should be absolute")
 }

--- a/pkg/lockfile/renv/parse-renv-lock.go
+++ b/pkg/lockfile/renv/parse-renv-lock.go
@@ -1,10 +1,14 @@
 package renv
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -41,26 +45,48 @@ func (e RenvLockExtractor) PackageManager() models.PackageManager {
 func (e RenvLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *RenvLockfile
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	err = json.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	// Build position map for InJSON keyed by package name
+	positions := make(map[string]*models.FilePosition, len(parsedLockfile.Packages))
+	for name := range parsedLockfile.Packages {
+		positions[name] = &models.FilePosition{}
+	}
+
+	fileposition.InJSON("Packages", positions, lines, 0)
+
 	packages := make([]lockfile.PackageDetails, 0, len(parsedLockfile.Packages))
 
-	for _, pkg := range parsedLockfile.Packages {
+	for name, pkg := range parsedLockfile.Packages {
 		// currently we only support CRAN
 		if pkg.Repository != string(models.EcosystemCRAN) {
 			continue
 		}
 
-		packages = append(packages, lockfile.PackageDetails{
+		pkgDetails := lockfile.PackageDetails{
 			Name:           pkg.Package,
 			Version:        pkg.Version,
 			PackageManager: renvPackageManager,
 			Ecosystem:      models.EcosystemCRAN,
-		})
+			LocationRole:   models.LocationRoleLockfile,
+		}
+		if pos, ok := positions[name]; ok {
+			blockLocation := *pos
+			blockLocation.Filename = f.Path()
+			pkgDetails.BlockLocation = blockLocation
+		}
+		packages = append(packages, pkgDetails)
 	}
 
 	return packages, nil

--- a/pkg/lockfile/renv/parse-renv-lock_test.go
+++ b/pkg/lockfile/renv/parse-renv-lock_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseRenvLock_FileDoesNotExist(t *testing.T) {
@@ -50,7 +52,7 @@ func TestParseRenvLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "morning",
 			Version:        "0.1.0",
@@ -69,7 +71,7 @@ func TestParseRenvLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markdown",
 			Version:        "1.0",
@@ -94,7 +96,7 @@ func TestParseRenvLock_WithMixedSources(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "markdown",
 			Version:        "1.0",
@@ -114,7 +116,7 @@ func TestParseRenvLock_WithBioconductor(t *testing.T) {
 	}
 
 	// currently Bioconductor is not supported
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "BH",
 			Version:        "1.75.0-0",
@@ -122,6 +124,37 @@ func TestParseRenvLock_WithBioconductor(t *testing.T) {
 			Ecosystem:      models.EcosystemCRAN,
 		},
 	})
+}
+
+func TestParseRenvLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := renv.ParseRenvLock("../fixtures/renv/two-packages.lock")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packagesByName := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		packagesByName[pkg.Name] = pkg
+	}
+
+	// markdown block: lines 12-18 in "Packages" section
+	markdown := packagesByName["markdown"]
+	assert.Equal(t, 12, markdown.BlockLocation.Line.Start)
+	assert.Equal(t, 18, markdown.BlockLocation.Line.End)
+	assert.Equal(t, 5, markdown.BlockLocation.Column.Start)
+	assert.Equal(t, 6, markdown.BlockLocation.Column.End)
+	assert.Contains(t, markdown.BlockLocation.Filename, "two-packages.lock")
+
+	// mime block: lines 19-25 in "Packages" section
+	mime := packagesByName["mime"]
+	assert.Equal(t, 19, mime.BlockLocation.Line.Start)
+	assert.Equal(t, 25, mime.BlockLocation.Line.End)
+	assert.Equal(t, 5, mime.BlockLocation.Column.Start)
+	assert.Equal(t, 6, mime.BlockLocation.Column.End)
+	assert.Contains(t, mime.BlockLocation.Filename, "two-packages.lock")
 }
 
 func TestParseRenvLock_WithoutRepository(t *testing.T) {

--- a/pkg/lockfile/ruby/parse-gemfile-lock.go
+++ b/pkg/lockfile/ruby/parse-gemfile-lock.go
@@ -31,6 +31,12 @@ func (parser *gemfileLockfileParser) isSourceSection(line string) bool {
 }
 
 func (parser *gemfileLockfileParser) addDependency(name string, version string) {
+	blockLocation := models.FilePosition{
+		Line:     models.Position{Start: parser.lineNumber, End: parser.lineNumber},
+		Column:   models.Position{Start: 1, End: len(parser.currentLine) + 1},
+		Filename: parser.sourceFile,
+	}
+
 	if !parser.isInDepSection {
 		parser.dependencies = append(parser.dependencies, lockfile.PackageDetails{
 			Name:           name,
@@ -38,6 +44,8 @@ func (parser *gemfileLockfileParser) addDependency(name string, version string) 
 			PackageManager: gemfilePackageManager,
 			Ecosystem:      models.EcosystemRubyGems,
 			Commit:         parser.currentGemCommit,
+			BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 		})
 
 		return
@@ -63,6 +71,8 @@ func (parser *gemfileLockfileParser) addDependency(name string, version string) 
 			Ecosystem:      models.EcosystemRubyGems,
 			Commit:         parser.currentGemCommit,
 			IsDirect:       true,
+			BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 		})
 	}
 }
@@ -184,11 +194,15 @@ func (e GemfileLockExtractor) PackageManager() models.PackageManager {
 
 func (e GemfileLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parser gemfileLockfileParser
+	parser.sourceFile = f.Path()
 
 	scanner := bufio.NewScanner(f)
 
 	for scanner.Scan() {
-		parser.parse(scanner.Text())
+		parser.lineNumber++
+		line := scanner.Text()
+		parser.currentLine = line
+		parser.parse(line)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/pkg/lockfile/ruby/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/ruby/parse-gemfile-lock_test.go
@@ -2,7 +2,11 @@ package ruby_test
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/ruby"
 
@@ -112,7 +116,7 @@ func TestParseGemfileLock_OneGem(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ast",
 			Version:        "2.4.2",
@@ -131,7 +135,7 @@ func TestParseGemfileLock_SomeGems(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "coderay",
 			Version:        "1.1.3",
@@ -162,7 +166,7 @@ func TestParseGemfileLock_MultipleGems(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "bundler-audit",
 			Version:        "0.9.0.1",
@@ -213,7 +217,7 @@ func TestParseGemfileLock_Rails(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "actioncable",
 			Version:        "7.0.2.2",
@@ -502,7 +506,7 @@ func TestParseGemfileLock_Rubocop(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ast",
 			Version:        "2.4.2",
@@ -575,7 +579,7 @@ func TestParseGemfileLock_HasLocalGem(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "backbone-on-rails",
 			Version:        "1.2.0.0",
@@ -768,7 +772,7 @@ func TestParseGemfileLock_HasGitGem(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "hanami-controller",
 			Version:        "2.0.0.alpha1",
@@ -832,4 +836,56 @@ func TestParseGemfileLock_PlatformSpecificDependencyIsParsed(t *testing.T) {
 			IsDirect:       true,
 		},
 	})
+}
+
+func TestParseGemfileLock_SomeGems_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/bundler/some-gems.lock")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := ruby.ParseGemfileLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// some-gems.lock has:
+	// line 4: "    coderay (1.1.3)"
+	// line 5: "    method_source (1.0.0)"
+	// line 6: "    pry (0.14.1)"
+	assert.Equal(t, len(packages), 3, "expected 3 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific line numbers
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// coderay is at line 4: "    coderay (1.1.3)"
+	assert.Equal(t, 4, pkgMap["coderay"].BlockLocation.Line.Start)
+	assert.Equal(t, 4, pkgMap["coderay"].BlockLocation.Line.End)
+	assert.Equal(t, 1, pkgMap["coderay"].BlockLocation.Column.Start)
+
+	// method_source is at line 5: "    method_source (1.0.0)"
+	assert.Equal(t, 5, pkgMap["method_source"].BlockLocation.Line.Start)
+	assert.Equal(t, 5, pkgMap["method_source"].BlockLocation.Line.End)
+
+	// pry is at line 6: "    pry (0.14.1)"
+	assert.Equal(t, 6, pkgMap["pry"].BlockLocation.Line.Start)
+	assert.Equal(t, 6, pkgMap["pry"].BlockLocation.Line.End)
+
+	// Verify path is absolute (from lockfile, not relative)
+	assert.True(t, os.IsPathSeparator(path[0]) || filepath.IsAbs(path),
+		"path should be absolute")
 }

--- a/pkg/lockfile/ruby/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/ruby/parse-gemfile-lock_test.go
@@ -855,7 +855,7 @@ func TestParseGemfileLock_SomeGems_BlockLocation(t *testing.T) {
 	// line 4: "    coderay (1.1.3)"
 	// line 5: "    method_source (1.0.0)"
 	// line 6: "    pry (0.14.1)"
-	assert.Equal(t, len(packages), 3, "expected 3 packages")
+	assert.Len(t, packages, 3, "expected 3 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,

--- a/pkg/lockfile/ruby/types.go
+++ b/pkg/lockfile/ruby/types.go
@@ -67,6 +67,13 @@ type gemfileLockfileParser struct {
 
 	// whether or not the parser is in the `DEPENDENCIES` section
 	isInDepSection bool
+
+	// current line number being parsed (1-indexed)
+	lineNumber int
+	// current line text being parsed
+	currentLine string
+	// absolute path of the lockfile being parsed
+	sourceFile string
 }
 
 type GemfileLockExtractor struct {

--- a/pkg/lockfile/rust/parse-cargo-lock.go
+++ b/pkg/lockfile/rust/parse-cargo-lock.go
@@ -1,9 +1,13 @@
 package rust
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -25,7 +29,12 @@ func (e CargoLockExtractor) PackageManager() models.PackageManager {
 func (e CargoLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
 	var parsedLockfile *CargoLockFile
 
-	_, err := toml.NewDecoder(f).Decode(&parsedLockfile)
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return []lockfile.PackageDetails{}, fmt.Errorf("could not read %s: %w", f.Path(), err)
+	}
+
+	_, err = toml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
 	if err != nil {
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
@@ -40,6 +49,20 @@ func (e CargoLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanCon
 			PackageManager: cargoPackageManager,
 			Ecosystem:      models.EcosystemCratesIO,
 		})
+	}
+
+	// Set BlockLocation for each package using the InTOML utility
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	positions := make([]*models.FilePosition, len(packages))
+	for i := range packages {
+		positions[i] = &packages[i].BlockLocation
+	}
+
+	fileposition.InTOML("[[package]]", "", positions, lines)
+
+	for i := range packages {
+		packages[i].BlockLocation.Filename = f.Path()
+		packages[i].LocationRole = models.LocationRoleLockfile
 	}
 
 	return packages, nil

--- a/pkg/lockfile/rust/parse-cargo-lock_test.go
+++ b/pkg/lockfile/rust/parse-cargo-lock_test.go
@@ -2,7 +2,11 @@ package rust_test
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
@@ -100,7 +104,7 @@ func TestParseCargoLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "addr2line",
 			Version:        "0.15.2",
@@ -119,7 +123,7 @@ func TestParseCargoLock_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "addr2line",
 			Version:        "0.15.2",
@@ -144,7 +148,7 @@ func TestParseCargoLock_TwoPackagesWithLocal(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "addr2line",
 			Version:        "0.15.2",
@@ -169,7 +173,7 @@ func TestParseCargoLock_PackageWithBuildString(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wasi",
 			Version:        "0.10.2+wasi-snapshot-preview1",
@@ -177,4 +181,50 @@ func TestParseCargoLock_PackageWithBuildString(t *testing.T) {
 			Ecosystem:      models.EcosystemCratesIO,
 		},
 	})
+}
+
+func TestParseCargoLock_TwoPackages_BlockLocation(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs("../fixtures/cargo/two-packages.lock")
+	if err != nil {
+		t.Fatalf("could not get absolute path: %v", err)
+	}
+
+	packages, err := rust.ParseCargoLock(path)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	// two-packages.lock has:
+	// line 5: "[[package]]"  (addr2line block, lines 5-12)
+	// line 14: "[[package]]" (syn block, lines 14-23)
+	assert.Equal(t, 2, len(packages), "expected 2 packages")
+
+	for _, pkg := range packages {
+		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,
+			"expected BlockLocation.Line.Start to be set for package %s", pkg.Name)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to be set for package %s", pkg.Name)
+		assert.Equal(t, path, pkg.BlockLocation.Filename,
+			"expected BlockLocation.Filename to match the lockfile path for package %s", pkg.Name)
+	}
+
+	// Verify specific positions
+	pkgMap := make(map[string]lockfile.PackageDetails)
+	for _, pkg := range packages {
+		pkgMap[pkg.Name] = pkg
+	}
+
+	// addr2line starts at line 5 ("[[package]]"), ends before the blank line at line 13
+	assert.Equal(t, 5, pkgMap["addr2line"].BlockLocation.Line.Start)
+	assert.Equal(t, 12, pkgMap["addr2line"].BlockLocation.Line.End)
+
+	// syn starts at line 14 ("[[package]]"), ends at line 24 (last package includes trailing content)
+	assert.Equal(t, 14, pkgMap["syn"].BlockLocation.Line.Start)
+	assert.Equal(t, 24, pkgMap["syn"].BlockLocation.Line.End)
+
+	// Verify path is absolute
+	assert.True(t, os.IsPathSeparator(path[0]) || filepath.IsAbs(path),
+		"path should be absolute")
 }

--- a/pkg/lockfile/rust/parse-cargo-lock_test.go
+++ b/pkg/lockfile/rust/parse-cargo-lock_test.go
@@ -199,7 +199,7 @@ func TestParseCargoLock_TwoPackages_BlockLocation(t *testing.T) {
 	// two-packages.lock has:
 	// line 5: "[[package]]"  (addr2line block, lines 5-12)
 	// line 14: "[[package]]" (syn block, lines 14-23)
-	assert.Equal(t, 2, len(packages), "expected 2 packages")
+	assert.Len(t, packages, 2, "expected 2 packages")
 
 	for _, pkg := range packages {
 		assert.NotEqual(t, 0, pkg.BlockLocation.Line.Start,


### PR DESCRIPTION
## Summary

- Rebases the `ander/transitive-dep-locations` branch (36 commits adding `BlockLocation` to 17 lockfile extractors) onto latest main which includes `LocationRole` support
- Sets `LocationRole = models.LocationRoleLockfile` in every extractor that sets `BlockLocation`, so lockfile positions are tagged with the correct role
- Updates test expectations and snapshot files for the new field

## Affected Extractors (17)

npm-lock, gradle-lock, mix-lock, gemfile-lock, cargo-lock, poetry-lock, pdm-lock, uv-lock, composer-lock, pipenv-lock, renv-lock, nuget-lock, conan-lock (v1+v2), gradle-verification-metadata, pubspec-lock, pnpm-lock, yarn-lock

## Changes Per Commit

Each of the 17 extractor implementation commits now includes both `BlockLocation` and `LocationRole` assignments (achieved via fixup+autosquash to maintain clean history).

## Test plan

- [x] `./scripts/run_tests.sh` passes
- [x] `./scripts/run_lints.sh` passes
- [x] `./scripts/build.sh` succeeds
- [x] All 17 extractors verified to set `LocationRole: models.LocationRoleLockfile`
- [x] Test helper `HasPackage` updated to ignore `LocationRole` when `ignoreLocations=true`
- [x] Workspace complex tests updated with `LocationRoleLockfile` for transitive deps