### PR TITLE
feat(lockfile): add BlockLocation + LocationRole=lockfile to npm-lock (pilot)

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -1630,7 +1630,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -1794,7 +1801,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":37,/"line_end/":50,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40babel%2Fhelper-validator-identifier@7.28.5",
@@ -1807,7 +1821,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":57,/"line_end/":65,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fgen-mapping@0.3.13",
@@ -1820,7 +1841,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":75,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fresolve-uri@3.1.2",
@@ -1833,7 +1861,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":76,/"line_end/":84,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsource-map@0.3.11",
@@ -1846,7 +1881,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":85,/"line_end/":94,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Fsourcemap-codec@1.5.5",
@@ -1859,7 +1901,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":95,/"line_end/":100,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40jridgewell%2Ftrace-mapping@0.3.31",
@@ -1872,7 +1921,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":101,/"line_end/":110,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fnode@24.10.1",
@@ -1885,7 +1941,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":111,/"line_end/":119,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.15.0",
@@ -1898,7 +1961,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":120,/"line_end/":131,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/buffer-from@1.1.2",
@@ -1911,7 +1981,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":132,/"line_end/":137,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/colors@1.4.0",
@@ -1928,7 +2005,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":138,/"line_end/":147,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/commander@2.20.3",
@@ -1941,7 +2025,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":148,/"line_end/":153,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fsevents@2.3.3",
@@ -1954,7 +2045,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":168,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/group-dependencies@0.0.11",
@@ -1995,7 +2093,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":182,/"line_end/":190,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/jest-worker@26.6.2",
@@ -2008,7 +2113,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":191,/"line_end/":204,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-tokens@4.0.0",
@@ -2021,7 +2133,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":205,/"line_end/":210,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge-stream@2.0.0",
@@ -2034,7 +2153,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":211,/"line_end/":216,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picocolors@0.2.1",
@@ -2079,6 +2205,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":51,/"line_end/":56,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
           }
         ]
@@ -2095,7 +2224,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":231,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rollup-plugin-terser@7.0.2",
@@ -2132,7 +2268,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":232,/"line_end/":247,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/safe-buffer@5.2.1",
@@ -2145,7 +2288,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":264,/"line_end/":283,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@4.3.6",
@@ -2254,7 +2404,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":293,/"line_end/":301,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map-support@0.5.21",
@@ -2267,7 +2424,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":311,/"line_end/":320,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/source-map@0.6.1",
@@ -2280,7 +2444,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":310,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -2293,7 +2464,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":321,/"line_end/":332,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/terser@5.44.1",
@@ -2306,7 +2484,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":333,/"line_end/":350,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/undici-types@7.16.0",
@@ -2319,7 +2504,14 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":356,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3578,7 +3770,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -3813,7 +4012,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":7,/"line_end/":14,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -3826,7 +4032,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":15,/"line_end/":19,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -3839,7 +4052,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":20,/"line_end/":28,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -3852,7 +4072,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":29,/"line_end/":33,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -3865,7 +4092,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":34,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -3878,7 +4112,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":47,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -3891,7 +4132,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":48,/"line_end/":52,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -3904,7 +4152,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":53,/"line_end/":79,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -3917,7 +4172,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":80,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -3930,7 +4192,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":109,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -3943,7 +4212,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":110,/"line_end/":114,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -3956,7 +4232,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":115,/"line_end/":138,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -3969,7 +4252,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":139,/"line_end/":153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -3982,7 +4272,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -3995,7 +4292,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":163,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -4008,7 +4312,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -4025,7 +4336,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -4038,7 +4356,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":70,/"line_end/":77,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -4051,7 +4376,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -4064,7 +4396,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":201,/"line_end/":209,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -4077,7 +4416,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":210,/"line_end/":214,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -4090,7 +4436,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":215,/"line_end/":229,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -4103,7 +4456,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":230,/"line_end/":234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -4116,7 +4476,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":227,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -4129,7 +4496,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":235,/"line_end/":246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -4142,7 +4516,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":247,/"line_end/":254,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -4155,7 +4536,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":255,/"line_end/":262,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -4168,7 +4556,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":263,/"line_end/":270,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -4181,7 +4576,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":283,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -4194,7 +4596,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":284,/"line_end/":288,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -4207,7 +4616,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":289,/"line_end/":293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -4220,7 +4636,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":294,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -4233,7 +4656,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":299,/"line_end/":306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -4246,7 +4676,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":307,/"line_end/":311,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -4259,7 +4696,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":312,/"line_end/":316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -4272,7 +4716,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":317,/"line_end/":325,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -4289,7 +4740,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":185,/"line_end/":190,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -4302,7 +4760,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":326,/"line_end/":330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -4315,7 +4780,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":331,/"line_end/":335,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -4328,7 +4800,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":336,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -4341,7 +4820,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":345,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -4354,7 +4840,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":346,/"line_end/":350,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -4367,7 +4860,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":355,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -4380,7 +4880,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":356,/"line_end/":363,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -4393,7 +4900,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":364,/"line_end/":368,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -4406,7 +4920,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":369,/"line_end/":373,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -4419,7 +4940,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":374,/"line_end/":381,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -4432,7 +4960,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":382,/"line_end/":386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -4445,7 +4980,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":387,/"line_end/":394,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -4486,7 +5028,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -4499,7 +5048,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -4512,7 +5068,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -4525,7 +5088,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -4538,7 +5108,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -4551,7 +5128,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -4564,7 +5148,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -4577,7 +5168,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -4590,7 +5188,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -4603,7 +5208,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -4616,7 +5228,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -4629,7 +5248,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -4666,7 +5292,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -4679,7 +5312,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -4692,7 +5332,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -4705,7 +5352,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -4718,7 +5372,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -4731,7 +5392,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -4744,7 +5412,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -4757,7 +5432,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -4770,7 +5452,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -4783,7 +5472,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -4796,7 +5492,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -4809,7 +5512,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -4822,7 +5532,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -4835,7 +5552,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -4848,7 +5572,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -4861,7 +5592,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -4874,7 +5612,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -4887,7 +5632,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -4900,7 +5652,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -4913,7 +5672,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -4926,7 +5692,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -4939,7 +5712,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -4952,7 +5732,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -4965,7 +5752,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -5006,7 +5800,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -5019,7 +5820,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -5032,7 +5840,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -5045,7 +5860,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -5058,7 +5880,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -5071,7 +5900,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -5084,7 +5920,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -5097,7 +5940,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -5110,7 +5960,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -5123,7 +5980,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -5136,7 +6000,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -5149,7 +6020,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -5162,7 +6040,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -5175,7 +6060,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -5188,7 +6080,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -5201,7 +6100,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -5214,7 +6120,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -5227,7 +6140,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -5240,7 +6160,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -5253,7 +6180,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -5266,7 +6200,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -5279,7 +6220,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -5292,7 +6240,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -5305,7 +6260,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -5318,7 +6280,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -5331,7 +6300,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -5344,7 +6320,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -5357,7 +6340,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -5370,7 +6360,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -5383,7 +6380,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -5396,7 +6400,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -5409,7 +6420,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -5422,7 +6440,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -5435,7 +6460,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -5448,7 +6480,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -5461,7 +6500,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -5474,7 +6520,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -5487,7 +6540,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -5500,7 +6560,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -5513,7 +6580,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -5526,7 +6600,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -5539,7 +6620,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -5552,7 +6640,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -5565,7 +6660,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -5578,7 +6680,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -5591,7 +6700,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -5604,7 +6720,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -5617,7 +6740,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -5630,7 +6760,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -5643,7 +6780,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -5656,7 +6800,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -5669,7 +6820,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -5682,7 +6840,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -5695,7 +6860,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -5712,7 +6884,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -5725,7 +6904,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -5738,7 +6924,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -5751,7 +6944,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -5764,7 +6964,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -5777,7 +6984,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -5790,7 +7004,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -5803,7 +7024,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -5816,7 +7044,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -5829,7 +7064,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -5842,7 +7084,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -5855,7 +7104,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -5868,7 +7124,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -5881,7 +7144,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -5894,7 +7164,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -5907,7 +7184,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -5920,7 +7204,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -5933,7 +7224,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -5946,7 +7244,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -5959,7 +7264,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -5972,7 +7284,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -5985,7 +7304,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -5998,7 +7324,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -6011,7 +7344,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -6024,7 +7364,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -6037,7 +7384,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -6050,7 +7404,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -6063,7 +7424,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -6076,7 +7444,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -6089,7 +7464,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -6102,7 +7484,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -6115,7 +7504,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -6128,7 +7524,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -6141,7 +7544,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -6154,7 +7564,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -6167,7 +7584,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -6180,7 +7604,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -6193,7 +7624,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -6206,7 +7644,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -6219,7 +7664,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -6260,7 +7712,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -6273,7 +7732,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -6286,7 +7752,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -6299,7 +7772,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -6312,7 +7792,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -6325,7 +7812,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -6338,7 +7832,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -6351,7 +7852,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -6364,7 +7872,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -6377,7 +7892,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -6390,7 +7912,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -6403,7 +7932,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -6440,7 +7976,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -6453,7 +7996,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -6466,7 +8016,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -6479,7 +8036,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -6492,7 +8056,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -6505,7 +8076,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -6518,7 +8096,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -6531,7 +8116,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -6544,7 +8136,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -6557,7 +8156,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -6570,7 +8176,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -6583,7 +8196,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -6596,7 +8216,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -6609,7 +8236,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -6622,7 +8256,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -6635,7 +8276,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -6648,7 +8296,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -6661,7 +8316,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -6674,7 +8336,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -6687,7 +8356,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -6700,7 +8376,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -6713,7 +8396,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -6726,7 +8416,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -6739,7 +8436,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -6780,7 +8484,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -6793,7 +8504,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -6806,7 +8524,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -6819,7 +8544,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -6832,7 +8564,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -6845,7 +8584,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -6858,7 +8604,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -6871,7 +8624,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -6884,7 +8644,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -6897,7 +8664,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -6910,7 +8684,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -6923,7 +8704,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -6936,7 +8724,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -6949,7 +8744,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -6962,7 +8764,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -6975,7 +8784,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -6988,7 +8804,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -7001,7 +8824,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -7014,7 +8844,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -7027,7 +8864,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -7040,7 +8884,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -7053,7 +8904,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -7066,7 +8924,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -7079,7 +8944,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -7092,7 +8964,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -7105,7 +8984,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -7118,7 +9004,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -7131,7 +9024,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -7144,7 +9044,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -7157,7 +9064,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -7170,7 +9084,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -7183,7 +9104,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -7196,7 +9124,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -7209,7 +9144,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -7222,7 +9164,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -7235,7 +9184,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -7248,7 +9204,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -7261,7 +9224,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -7274,7 +9244,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -7287,7 +9264,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -7300,7 +9284,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -7313,7 +9304,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -7326,7 +9324,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -7339,7 +9344,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -7352,7 +9364,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -7365,7 +9384,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -7378,7 +9404,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -7391,7 +9424,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -7404,7 +9444,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -7417,7 +9464,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -7430,7 +9484,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -7443,7 +9504,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -7456,7 +9524,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -7469,7 +9544,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -7486,7 +9568,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -7499,7 +9588,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -7512,7 +9608,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -7525,7 +9628,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -7538,7 +9648,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -7551,7 +9668,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -7564,7 +9688,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -7577,7 +9708,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -7590,7 +9728,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -7603,7 +9748,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -7616,7 +9768,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -7629,7 +9788,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -7642,7 +9808,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -7655,7 +9828,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -7668,7 +9848,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -7681,7 +9868,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -7694,7 +9888,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -7707,7 +9908,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -7720,7 +9928,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -7733,7 +9948,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -7746,7 +9968,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -7759,7 +9988,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -7772,7 +10008,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -7785,7 +10028,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -7798,7 +10048,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -7811,7 +10068,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -7824,7 +10088,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -7837,7 +10108,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -7850,7 +10128,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -7863,7 +10148,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -7876,7 +10168,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -7889,7 +10188,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -7902,7 +10208,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -7915,7 +10228,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -7928,7 +10248,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -7941,7 +10268,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -7954,7 +10288,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -7967,7 +10308,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -7980,7 +10328,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -7993,7 +10348,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -8034,7 +10396,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -8047,7 +10416,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -8060,7 +10436,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -8073,7 +10456,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -8086,7 +10476,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -8099,7 +10496,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -8112,7 +10516,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -8125,7 +10536,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -8138,7 +10556,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -8151,7 +10576,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -8164,7 +10596,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -8177,7 +10616,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -8214,7 +10660,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -8227,7 +10680,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -8240,7 +10700,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -8253,7 +10720,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -8266,7 +10740,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -8279,7 +10760,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -8292,7 +10780,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -8305,7 +10800,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -8318,7 +10820,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -8331,7 +10840,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -8344,7 +10860,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -8357,7 +10880,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -8370,7 +10900,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -8383,7 +10920,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -8396,7 +10940,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -8409,7 +10960,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -8422,7 +10980,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -8435,7 +11000,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -8448,7 +11020,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -8461,7 +11040,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -8474,7 +11060,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -8487,7 +11080,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -8500,7 +11100,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -8513,7 +11120,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -8554,7 +11168,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -8567,7 +11188,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -8580,7 +11208,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -8593,7 +11228,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -8606,7 +11248,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -8619,7 +11268,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -8632,7 +11288,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -8645,7 +11308,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -8658,7 +11328,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -8671,7 +11348,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -8684,7 +11368,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -8697,7 +11388,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -8710,7 +11408,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -8723,7 +11428,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -8736,7 +11448,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -8749,7 +11468,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -8762,7 +11488,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -8775,7 +11508,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -8788,7 +11528,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -8801,7 +11548,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -8814,7 +11568,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -8827,7 +11588,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -8840,7 +11608,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -8853,7 +11628,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -8866,7 +11648,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -8879,7 +11668,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -8892,7 +11688,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -8905,7 +11708,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -8918,7 +11728,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -8931,7 +11748,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -8944,7 +11768,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -8957,7 +11788,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -8970,7 +11808,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -8983,7 +11828,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -8996,7 +11848,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -9009,7 +11868,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -9022,7 +11888,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -9035,7 +11908,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -9048,7 +11928,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -9061,7 +11948,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -9074,7 +11968,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -9087,7 +11988,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -9100,7 +12008,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -9113,7 +12028,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -9126,7 +12048,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -9139,7 +12068,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -9152,7 +12088,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -9165,7 +12108,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -9178,7 +12128,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -9191,7 +12148,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -9204,7 +12168,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -9217,7 +12188,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -9230,7 +12208,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -9243,7 +12228,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -9260,7 +12252,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -9273,7 +12272,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -9286,7 +12292,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -9299,7 +12312,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -9312,7 +12332,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -9325,7 +12352,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -9338,7 +12372,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -9351,7 +12392,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -9364,7 +12412,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -9377,7 +12432,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -9390,7 +12452,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -9403,7 +12472,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -9416,7 +12492,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -9429,7 +12512,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -9442,7 +12532,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -9455,7 +12552,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -9468,7 +12572,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -9481,7 +12592,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -9494,7 +12612,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -9507,7 +12632,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -9520,7 +12652,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -9533,7 +12672,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -9546,7 +12692,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -9559,7 +12712,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -9572,7 +12732,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -9585,7 +12752,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -9598,7 +12772,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -9611,7 +12792,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -9624,7 +12812,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -9637,7 +12832,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -9650,7 +12852,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -9663,7 +12872,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -9676,7 +12892,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -9689,7 +12912,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -9702,7 +12932,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -9715,7 +12952,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -9728,7 +12972,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -9741,7 +12992,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -9754,7 +13012,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -9767,7 +13032,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -9808,7 +13080,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":45,/"line_end/":68,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -9821,7 +13100,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":94,/"line_end/":103,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -9834,7 +13120,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":35,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -9847,7 +13140,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":36,/"line_end/":44,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -9860,7 +13160,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":104,/"line_end/":119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -9873,7 +13180,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":145,/"line_end/":158,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -9886,7 +13200,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":159,/"line_end/":166,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -9899,7 +13220,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":167,/"line_end/":179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -9912,7 +13240,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":180,/"line_end/":188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -9925,7 +13260,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":189,/"line_end/":201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -9938,7 +13280,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":202,/"line_end/":207,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -9951,7 +13300,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":208,/"line_end/":213,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -9988,7 +13344,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -10001,7 +13364,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":324,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -10014,7 +13384,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -10027,7 +13404,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":391,/"line_end/":403,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -10040,7 +13424,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":404,/"line_end/":430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -10053,7 +13444,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":454,/"line_end/":479,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -10066,7 +13464,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":480,/"line_end/":496,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -10079,7 +13484,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":497,/"line_end/":503,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -10092,7 +13504,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":526,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -10105,7 +13524,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":504,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -10118,7 +13544,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":527,/"line_end/":543,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -10131,7 +13564,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":544,/"line_end/":553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -10144,7 +13584,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":554,/"line_end/":569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -10157,7 +13604,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":570,/"line_end/":576,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -10170,7 +13624,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":577,/"line_end/":585,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -10183,7 +13644,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":586,/"line_end/":592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -10196,7 +13664,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":593,/"line_end/":603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -10209,7 +13684,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":604,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -10222,7 +13704,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":625,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -10235,7 +13724,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":626,/"line_end/":642,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -10248,7 +13744,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":643,/"line_end/":655,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -10261,7 +13764,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":656,/"line_end/":662,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -10274,7 +13784,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":663,/"line_end/":669,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -10287,7 +13804,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":670,/"line_end/":684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -10328,7 +13852,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":69,/"line_end/":86,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -10341,7 +13872,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":695,/"line_end/":701,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -10354,7 +13892,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":702,/"line_end/":713,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -10367,7 +13912,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":714,/"line_end/":726,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -10380,7 +13932,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":727,/"line_end/":739,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -10393,7 +13952,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":797,/"line_end/":809,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -10406,7 +13972,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":840,/"line_end/":856,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -10419,7 +13992,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":810,/"line_end/":821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -10432,7 +14012,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":740,/"line_end/":796,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -10445,7 +14032,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":874,/"line_end/":891,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -10458,7 +14052,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":892,/"line_end/":904,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -10471,7 +14072,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":915,/"line_end/":926,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -10484,7 +14092,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":936,/"line_end/":944,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -10497,7 +14112,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":857,/"line_end/":866,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -10510,7 +14132,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":945,/"line_end/":954,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -10523,7 +14152,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":955,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -10536,7 +14172,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -10549,7 +14192,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":990,/"line_end/":996,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -10562,7 +14212,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":997,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -10575,7 +14232,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1012,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -10588,7 +14252,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1013,/"line_end/":1025,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -10601,7 +14272,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1026,/"line_end/":1037,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -10614,7 +14292,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1038,/"line_end/":1054,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -10627,7 +14312,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1055,/"line_end/":1069,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -10640,7 +14332,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1070,/"line_end/":1076,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -10653,7 +14352,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1077,/"line_end/":1083,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -10666,7 +14372,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":989,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -10679,7 +14392,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1106,/"line_end/":1118,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -10692,7 +14412,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1084,/"line_end/":1105,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -10705,7 +14432,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1119,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -10718,7 +14452,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1154,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -10731,7 +14472,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1155,/"line_end/":1160,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -10744,7 +14492,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1161,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -10757,7 +14512,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -10770,7 +14532,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1180,/"line_end/":1196,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -10783,7 +14552,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1197,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -10796,7 +14572,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1218,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -10809,7 +14592,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1219,/"line_end/":1225,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -10822,7 +14612,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1226,/"line_end/":1234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -10835,7 +14632,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1235,/"line_end/":1246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -10848,7 +14652,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1247,/"line_end/":1255,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -10861,7 +14672,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1256,/"line_end/":1265,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -10874,7 +14692,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1266,/"line_end/":1272,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -10887,7 +14712,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1273,/"line_end/":1285,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -10900,7 +14732,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1286,/"line_end/":1292,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -10913,7 +14752,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1293,/"line_end/":1299,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -10926,7 +14772,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1300,/"line_end/":1306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -10939,7 +14792,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1307,/"line_end/":1316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -10952,7 +14812,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1317,/"line_end/":1330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -10965,7 +14832,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1331,/"line_end/":1346,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -10978,7 +14852,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1347,/"line_end/":1353,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -10991,7 +14872,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1354,/"line_end/":1362,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -11004,7 +14892,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1363,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -11017,7 +14912,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1388,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -11034,7 +14936,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1389,/"line_end/":1395,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -11047,7 +14956,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":87,/"line_end/":93,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -11060,7 +14976,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1403,/"line_end/":1408,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -11073,7 +14996,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1396,/"line_end/":1402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -11086,7 +15016,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1409,/"line_end/":1418,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -11099,7 +15036,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1419,/"line_end/":1436,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -11112,7 +15056,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1437,/"line_end/":1452,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -11125,7 +15076,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1453,/"line_end/":1468,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -11138,7 +15096,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1469,/"line_end/":1481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -11151,7 +15116,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1482,/"line_end/":1491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -11164,7 +15136,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1492,/"line_end/":1501,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -11177,7 +15156,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1502,/"line_end/":1511,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -11190,7 +15176,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1512,/"line_end/":1520,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -11203,7 +15196,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1521,/"line_end/":1532,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -11216,7 +15216,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1533,/"line_end/":1542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -11229,7 +15236,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1543,/"line_end/":1552,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -11242,7 +15256,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1553,/"line_end/":1572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -11255,7 +15276,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1573,/"line_end/":1582,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -11268,7 +15296,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1583,/"line_end/":1592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -11281,7 +15316,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1593,/"line_end/":1609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -11294,7 +15336,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1610,/"line_end/":1632,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -11307,7 +15356,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1633,/"line_end/":1644,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -11320,7 +15376,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1645,/"line_end/":1657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -11333,7 +15396,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1658,/"line_end/":1667,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -11346,7 +15416,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1668,/"line_end/":1676,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -11359,7 +15436,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1677,/"line_end/":1689,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -11372,7 +15456,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1690,/"line_end/":1702,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -11385,7 +15476,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1703,/"line_end/":1715,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -11398,7 +15496,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1716,/"line_end/":1722,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -11411,7 +15516,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1723,/"line_end/":1734,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -11424,7 +15536,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1735,/"line_end/":1740,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -11437,7 +15556,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1741,/"line_end/":1755,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -11450,7 +15576,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1756,/"line_end/":1768,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -11463,7 +15596,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1769,/"line_end/":1781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -11476,7 +15616,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1782,/"line_end/":1795,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -11489,7 +15636,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1796,/"line_end/":1805,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -11502,7 +15656,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1806,/"line_end/":1821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -11515,7 +15676,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1822,/"line_end/":1831,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -11528,7 +15696,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1832,/"line_end/":1838,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -11541,7 +15716,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1839,/"line_end/":1851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -100,6 +100,9 @@ func addLocations(component *cyclonedx.Component, details models.PackageVulns) {
 		seenLocations[jsonLocation] = struct{}{}
 	}
 	if len(occurrences) > 0 {
+		slices.SortFunc(occurrences, func(a, b cyclonedx.EvidenceOccurrence) int {
+			return strings.Compare(a.Location, b.Location)
+		})
 		component.Evidence = &cyclonedx.Evidence{Occurrences: &occurrences}
 	}
 }

--- a/pkg/lockfile/internal/testutil/helpers.go
+++ b/pkg/lockfile/internal/testutil/helpers.go
@@ -82,7 +82,7 @@ func HasPackage(t *testing.T, expectedPkgs []lockfile.PackageDetails, currentPkg
 	for _, expectedPkg := range expectedPkgs {
 		var ignore []string
 		if ignoreLocations {
-			ignore = []string{"BlockLocation", "NameLocation", "VersionLocation"}
+			ignore = []string{"BlockLocation", "LocationRole", "NameLocation", "VersionLocation"}
 		}
 
 		if cmp.Equal(expectedPkg, currentPkg, cmpopts.IgnoreFields(lockfile.PackageDetails{}, ignore...)) {

--- a/pkg/lockfile/javascript/match-package-json.go
+++ b/pkg/lockfile/javascript/match-package-json.go
@@ -63,9 +63,12 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 			depGroup = "optional"
 		}
 
-		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.BlockLocation.Line.Start != 0 {
-			// If it is a dev or optional dependency definition and we already found a package location,
-			// we skip it to prioritize non-dev dependencies
+		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.BlockLocation.Filename == depMap.FilePath {
+			// If it is a dev or optional dependency definition and this package's BlockLocation
+			// already points to the current source file (meaning a prior matcher section like
+			// "dependencies" already set it), skip the location overwrite to prioritize the
+			// non-dev location. We compare Filename rather than checking Line.Start != 0
+			// because extractors may now set BlockLocation from the lockfile for all packages.
 			pkgIndexes = []int{}
 		}
 		depMap.UpdatePackageDetails(pkg, packageJSONContent, pkgIndexes, depGroup)

--- a/pkg/lockfile/javascript/match-package-json.go
+++ b/pkg/lockfile/javascript/match-package-json.go
@@ -11,6 +11,7 @@ import (
 
 	jsonUtils "github.com/DataDog/datadog-sbom-generator/internal/json"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 	"github.com/bmatcuk/doublestar/v4"
 )
 
@@ -63,12 +64,14 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 			depGroup = "optional"
 		}
 
-		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.BlockLocation.Filename == depMap.FilePath {
-			// If it is a dev or optional dependency definition and this package's BlockLocation
-			// already points to the current source file (meaning a prior matcher section like
-			// "dependencies" already set it), skip the location overwrite to prioritize the
-			// non-dev location. We compare Filename rather than checking Line.Start != 0
-			// because extractors may now set BlockLocation from the lockfile for all packages.
+		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.LocationRole == models.LocationRoleManifest {
+			// If it is a dev or optional dependency definition and this package was already
+			// matched to a manifest location (e.g. the root package.json "dependencies" section,
+			// or an earlier workspace package.json), skip the overwrite to prioritize the
+			// non-dev/non-optional manifest location.
+			// We check LocationRole rather than BlockLocation.Filename so that cross-workspace
+			// matches are also guarded: a root prod-dep match sets LocationRole=manifest, and
+			// a subsequent workspace dev-dep section for the same package must not overwrite it.
 			pkgIndexes = []int{}
 		}
 		depMap.UpdatePackageDetails(pkg, packageJSONContent, pkgIndexes, depGroup)

--- a/pkg/lockfile/javascript/node-modules-npm-v1_test.go
+++ b/pkg/lockfile/javascript/node-modules-npm-v1_test.go
@@ -36,7 +36,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -55,7 +55,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -74,7 +74,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -100,7 +100,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -126,7 +126,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -178,29 +178,29 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 		t.Errorf("Expected to get 39 packages, but got %d", len(packages))
 	}
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "6.1.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "5.5.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "2.0.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 }
 
 func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
@@ -211,7 +211,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "",

--- a/pkg/lockfile/javascript/node-modules-npm-v2_test.go
+++ b/pkg/lockfile/javascript/node-modules-npm-v2_test.go
@@ -14,7 +14,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_InvalidJson(t *testing.T) {
 	packages, err := testParsingNodeModules(t, "../fixtures/npm/not-json.txt")
 
 	testutil.ExpectErrContaining(t, err, "could not extract from")
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestNodeModulesExtractor_Extract_npm_v2_NoPackages(t *testing.T) {
@@ -25,7 +25,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
@@ -36,7 +36,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -56,7 +56,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -76,7 +76,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -104,7 +104,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -130,7 +130,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -177,7 +177,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "supports-color",
 			Version:        "6.1.0",
@@ -203,7 +203,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "2.4.1",
@@ -339,7 +339,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "etag",
 			Version:        "1.8.0",
@@ -376,7 +376,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.0.0",
@@ -412,7 +412,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",

--- a/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/javascript"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseNpmLock_v1_FileDoesNotExist(t *testing.T) {
@@ -63,6 +65,34 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 			DepGroups:      []string{"prod"},
 		},
 	})
+}
+
+func TestParseNpmLock_v1_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/npm/one-package.v1.json"))
+	packages, err := javascript.ParseNpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// Every package must have a valid BlockLocation from the lockfile
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
 }
 
 func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {

--- a/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
@@ -56,7 +56,7 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -108,7 +108,7 @@ func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -132,7 +132,7 @@ func TestParseNpmLock_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -163,7 +163,7 @@ func TestParseNpmLock_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -194,7 +194,7 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -251,29 +251,29 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		t.Errorf("Expected to get 39 packages, but got %d", len(packages))
 	}
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "6.1.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "5.5.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, lockfile.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, lockfile.PackageDetails{
 		Name:           "supports-color",
 		Version:        "2.0.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 }
 
 func TestParseNpmLock_v1_Commits(t *testing.T) {
@@ -289,7 +289,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "",
@@ -426,7 +426,7 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "lodash",
 			Version:        "1.3.1",
@@ -459,7 +459,7 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.0.0",
@@ -497,7 +497,7 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",

--- a/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v1_test.go
@@ -82,13 +82,13 @@ func TestParseNpmLock_v1_OnePackage_BlockLocation(t *testing.T) {
 
 	// Every package must have a valid BlockLocation from the lockfile
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
 			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.End,
 			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
 			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.End,
 			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
 		assert.NotEmpty(t, pkg.BlockLocation.Filename,
 			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)

--- a/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
@@ -86,6 +86,34 @@ func TestParseNpmLock_v2_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseNpmLock_v2_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/npm/one-package.v2.json"))
+	packages, err := javascript.ParseNpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// Every package must have a valid BlockLocation from the lockfile
+	for _, pkg := range packages {
+		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
+}
+
 //nolint:paralleltest
 func TestParseNpmLock_v2_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()

--- a/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
@@ -987,9 +987,13 @@ func TestParseNpmLock_v2_WorkspacesComplex(t *testing.T) {
 			Version:        "1.4.0",
 			PackageManager: models.NPM,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 37, End: 46},
+				Column:   models.Position{Start: 5, End: 6},
+				Filename: path,
+			},
+			IsDirect:  false, // is a dependency of group-dependencies@0.0.11
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/javascript/parse-npm-lock-v2_test.go
@@ -101,13 +101,13 @@ func TestParseNpmLock_v2_OnePackage_BlockLocation(t *testing.T) {
 
 	// Every package must have a valid BlockLocation from the lockfile
 	for _, pkg := range packages {
-		assert.Greater(t, pkg.BlockLocation.Line.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
 			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Line.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Line.End,
 			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.Start, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
 			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
-		assert.Greater(t, pkg.BlockLocation.Column.End, 0,
+		assert.Positive(t, pkg.BlockLocation.Column.End,
 			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
 		assert.NotEmpty(t, pkg.BlockLocation.Filename,
 			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
@@ -992,8 +992,9 @@ func TestParseNpmLock_v2_WorkspacesComplex(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: path,
 			},
-			IsDirect:  false, // is a dependency of group-dependencies@0.0.11
-			DepGroups: []string{"dev"},
+			LocationRole: models.LocationRoleLockfile,
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
 		},
 		{
 			Name:           "semver",

--- a/pkg/lockfile/javascript/parse-npm-lock.go
+++ b/pkg/lockfile/javascript/parse-npm-lock.go
@@ -73,7 +73,7 @@ func (dep *NpmLockDependency) depGroups() []string {
 	return groups
 }
 
-func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[string]lockfile.PackageDetails {
+func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency, sourceFile string) map[string]lockfile.PackageDetails {
 	details := npmPackageDetailsMap{}
 
 	keys := reflect.ValueOf(dependencies).MapKeys()
@@ -84,7 +84,7 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 		name := key.Interface().(string)
 		detail := dependencies[name]
 		if detail.Dependencies != nil {
-			nestedDeps := parseNpmLockDependencies(detail.Dependencies)
+			nestedDeps := parseNpmLockDependencies(detail.Dependencies, sourceFile)
 			for k, v := range nestedDeps {
 				details.add(k, v)
 			}
@@ -118,6 +118,9 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 			}
 		}
 
+		blockLocation := detail.FilePosition
+		blockLocation.Filename = sourceFile
+
 		details.add(name+"@"+version, lockfile.PackageDetails{
 			Name:           name,
 			Version:        finalVersion,
@@ -125,6 +128,8 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 			Ecosystem:      models.EcosystemNPM,
 			Commit:         commit,
 			DepGroups:      detail.depGroups(),
+			BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 		})
 	}
 
@@ -244,6 +249,7 @@ func processWorkspacePackages(
 	declaredWorkspacePackages map[string]*NpmLockPackage,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for workspacePath, workspacePkg := range declaredWorkspacePackages {
 		allDeps := make(map[string]string)
@@ -266,6 +272,7 @@ func processWorkspacePackages(
 				TargetVersion:     targetVersion,
 				DeclarationPath:   workspacePath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			}
 
 			if resolvedPkg, exists := resolvedPackages[workspaceNodeModulesPath]; exists {
@@ -295,6 +302,7 @@ func processRootPackages(
 	declaredRootPackages map[string]string,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for depName, targetVersion := range declaredRootPackages {
 		rootNodeModulesPath := getRootResolvedPath(depName)
@@ -307,6 +315,7 @@ func processRootPackages(
 				DeclarationPath:   "",
 				PhysicalPath:      rootNodeModulesPath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			})
 		}
 	}
@@ -317,6 +326,7 @@ func processLocalPackages(
 	localPackages map[string]*NpmLockPackage,
 	declaredRootPackages map[string]string,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for localPath, localPkg := range localPackages {
 		depName := path.Base(localPath)
@@ -335,6 +345,7 @@ func processLocalPackages(
 			DeclarationPath:   "",
 			PhysicalPath:      localPath,
 			ProcessedPackages: processedPackages,
+			SourceFile:        sourceFile,
 		})
 	}
 }
@@ -343,6 +354,7 @@ func processRemainingPackages(
 	details npmPackageDetailsMap,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for physicalPath, pkg := range resolvedPackages {
 		if !(*processedPackages)[physicalPath] {
@@ -355,6 +367,7 @@ func processRemainingPackages(
 				DeclarationPath:   "",
 				PhysicalPath:      physicalPath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			})
 		}
 	}
@@ -368,6 +381,7 @@ type packageProcessingParams struct {
 	DeclarationPath   string
 	PhysicalPath      string
 	ProcessedPackages *map[string]bool
+	SourceFile        string
 }
 
 func processPackage(params packageProcessingParams) {
@@ -413,6 +427,9 @@ func processPackage(params packageProcessingParams) {
 		location = &models.FilePosition{Filename: params.DeclarationPath}
 	}
 
+	blockLocation := params.Pkg.FilePosition
+	blockLocation.Filename = params.SourceFile
+
 	packageUniqKey := getWorkspaceDependencyKey(finalName, finalVersion, params.DeclarationPath)
 	params.Details.add(packageUniqKey, lockfile.PackageDetails{
 		Name:           finalName,
@@ -422,6 +439,8 @@ func processPackage(params packageProcessingParams) {
 		Ecosystem:      models.EcosystemNPM,
 		Commit:         commit,
 		DepGroups:      params.Pkg.depGroups(),
+		BlockLocation:  blockLocation,
+		LocationRole:   models.LocationRoleLockfile,
 		NameLocation:   location,
 	})
 
@@ -429,7 +448,7 @@ func processPackage(params packageProcessingParams) {
 	(*params.ProcessedPackages)[params.PhysicalPath] = true
 }
 
-func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]lockfile.PackageDetails {
+func parseNpmLockPackages(packages map[string]*NpmLockPackage, sourceFile string) map[string]lockfile.PackageDetails {
 	details := npmPackageDetailsMap{}
 
 	workspacePatterns := extractWorkspacePatterns(packages)
@@ -437,10 +456,10 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]lockfi
 
 	processedPackages := make(map[string]bool) // makes sure we do not process the same package twice (meaningful with the support of workspaces)
 
-	processRootPackages(details, categorized.DeclaredRoot, categorized.Resolved, &processedPackages)
-	processWorkspacePackages(details, categorized.DeclaredWorkspace, categorized.Resolved, &processedPackages)
-	processLocalPackages(details, categorized.Local, categorized.DeclaredRoot, &processedPackages)
-	processRemainingPackages(details, categorized.Resolved, &processedPackages)
+	processRootPackages(details, categorized.DeclaredRoot, categorized.Resolved, &processedPackages, sourceFile)
+	processWorkspacePackages(details, categorized.DeclaredWorkspace, categorized.Resolved, &processedPackages, sourceFile)
+	processLocalPackages(details, categorized.Local, categorized.DeclaredRoot, &processedPackages, sourceFile)
+	processRemainingPackages(details, categorized.Resolved, &processedPackages, sourceFile)
 
 	return details
 }
@@ -449,12 +468,12 @@ func parseNpmLock(lockfile NpmLockfile, lines []string) map[string]lockfile.Pack
 	if lockfile.Packages != nil {
 		fileposition.InJSON("packages", lockfile.Packages, lines, 0)
 
-		return parseNpmLockPackages(lockfile.Packages)
+		return parseNpmLockPackages(lockfile.Packages, lockfile.SourceFile)
 	}
 
 	fileposition.InJSON("dependencies", lockfile.Dependencies, lines, 0)
 
-	return parseNpmLockDependencies(lockfile.Dependencies)
+	return parseNpmLockDependencies(lockfile.Dependencies, lockfile.SourceFile)
 }
 
 func getWorkspaceDependencyKey(pkgName string, pkgVersion string, workspace string) string {
@@ -488,7 +507,7 @@ func (e NpmLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 		return []lockfile.PackageDetails{}, fmt.Errorf("could not read from %s: %w", f.Path(), err)
 	}
 	contentString := string(contentBytes)
-	lines := strings.Split(contentString, "\n")
+	lines := strings.Split(strings.ReplaceAll(contentString, "\r\n", "\n"), "\n")
 	decoder := json.NewDecoder(strings.NewReader(contentString))
 
 	if err := decoder.Decode(&parsedLockfile); err != nil {

--- a/pkg/lockfile/javascript/parse-npm-lock.go
+++ b/pkg/lockfile/javascript/parse-npm-lock.go
@@ -54,6 +54,12 @@ func (pdm npmPackageDetailsMap) add(key string, details lockfile.PackageDetails)
 
 	if ok {
 		details.DepGroups = mergeNpmDepsGroups(existing, details)
+		// Keep the earlier lockfile location to ensure deterministic output
+		// (multiple node_modules paths may resolve to the same package key)
+		if existing.BlockLocation.Line.Start > 0 &&
+			(details.BlockLocation.Line.Start == 0 || existing.BlockLocation.Line.Start < details.BlockLocation.Line.Start) {
+			details.BlockLocation = existing.BlockLocation
+		}
 	}
 
 	pdm[key] = details

--- a/pkg/lockfile/php/match-composer.go
+++ b/pkg/lockfile/php/match-composer.go
@@ -35,9 +35,12 @@ func (depMap *ComposerMatcherDependencyMap) UnmarshalJSON(bytes []byte) error {
 	content := string(bytes)
 
 	for _, pkg := range depMap.Packages {
-		if depMap.RootType == typeRequireDev && pkg.BlockLocation.Line.Start != 0 {
-			// If it is dev dependency definition and we already found a package location,
-			// we skip it to prioritize non-dev dependencies
+		if depMap.RootType == typeRequireDev && pkg.BlockLocation.Filename == depMap.FilePath {
+			// If it is dev dependency definition and this package's BlockLocation already
+			// points to the current source file (meaning a prior section like "require"
+			// already set it), skip the location overwrite to prioritize non-dev dependencies.
+			// We compare Filename rather than checking Line.Start != 0 because extractors
+			// may now set BlockLocation from the lockfile for all packages.
 			continue
 		}
 		pkgIndexes := jsonUtils.ExtractPackageIndexes(pkg.Name, "", content)


### PR DESCRIPTION
## Summary

Pilot PR to validate `BlockLocation` extraction from npm lockfiles before rolling out to all 17 parsers in PR #127.

**Changes:**
- Set `BlockLocation` (line/column/filename) from the lockfile for all npm packages during extraction (v1 and v2)
- Set `LocationRole: "lockfile"` on all extracted npm packages (matchers override to `"manifest"` for direct dependencies)
- Sort CycloneDX evidence occurrences for deterministic SBOM output
- Adapt test helpers and expectations for the new `LocationRole` field interaction with `BlockLocation`

**Cherry-picked from** `ander/transitive-dep-locations` (PR #127):
- `fd8cd67` — Set BlockLocation from lockfile for all npm packages during extraction
- `769af54` — Update npm-lock tests for BlockLocation extraction
- `da74b0e` — fix(sbom): sort evidence occurrences and fix npm location determinism

Plus one adaptation commit to reconcile with `LocationRole` (merged via #138 on main).

**Next steps:** Once this pilot is validated, PR #127 will extend `BlockLocation` extraction to the remaining 16 parsers.

## Test plan
- [x] All unit tests pass (npm-lock v1, v2, node-modules)
- [x] Integration test snapshots regenerated and pass
- [x] Lint passes (golangci-lint v1.64.8)
- [x] Full test suite passes