### PR TITLE
[K9VULN-14431] Add Bun lockfile parser

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -150,6 +150,7 @@ core,github.com/russross/blackfriday/v2,BSD-2-Clause,Copyright © 2011 Russ Ross
 core,github.com/sergi/go-diff/diffmatchpatch,MIT,Copyright (c) 2012-2016 The go-diff Authors. All rights reserved | Danny Yoo <dannyyoo@google.com> | James Kolb <jkolb@google.com> | Jonathan Amsterdam <jba@google.com> | Markus Zimmermann <markus.zimmermann@nethead.at> <markus.zimmermann@symflower.com> <zimmski@gmail.com> | Matt Kovars <akaskik@gmail.com> | Osman Masood <oamasood@gmail.com> | Robert Carlsen <rwcarlsen@gmail.com> | Rory Flynn <roryflynn@users.noreply.github.com> | Sergi Mansilla <sergi.mansilla@gmail.com> | Shatrugna Sadhu <ssadhu@apcera.com> | Shawn Smith <shawnpsmith@gmail.com> | Stas Maksimov <maksimov@gmail.com> | Tor Arvid Lund <torarvid@gmail.com> | Zac Bergquist <zbergquist99@gmail.com> | Örjan Persson <orjan@spotify.com>
 core,github.com/skeema/knownhosts,Apache-2.0,Copyright 2025 Skeema LLC and the Skeema Knownhosts authors | copyright 2025 Skeema LLC and the Skeema Knownhosts authors**
 core,github.com/tidwall/gjson,MIT,Copyright (c) 2016 Josh Baker
+core,github.com/tidwall/jsonc,MIT,Copyright (c) 2021 Josh Baker
 core,github.com/tidwall/match,MIT,Copyright (c) 2016 Josh Baker
 core,github.com/tidwall/pretty,MIT,Copyright (c) 2017 Josh Baker
 core,github.com/tidwall/sjson,MIT,Copyright (c) 2016 Josh Baker

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This tool sources all dependencies by parsing package manager files. As new pack
 | C++        | Conan                                     |
 | Go         | Golang                                    |
 | Java       | Gradle, Maven, Bazel (rules_jvm_external) |
-| JavaScript | NPM, PNPM, Yarn                           |
+| JavaScript | Bun, NPM, PNPM, Yarn                      |
 | PHP        | Composer                                  |
 | Python     | Pdm, Pipenv, Poetry, Requirements, uv     |
 | Ruby       | Bundler                                   |
@@ -91,6 +91,11 @@ This tool only supports enriching information from the following package manager
 ### Javascript and Typescript
 
 NPM, Yarn and PNPM have workspace support
+
+#### Bun
+
+- This tool only supports extracting packages from `bun.lock` (the text JSONC lockfile introduced in Bun 1.2). The legacy binary `bun.lockb` format is not supported.
+- This tool only supports package information enrichment from `package.json`.
 
 #### NPM
 

--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -247,6 +247,88 @@ Scanned <rootdir>/fixtures/integration-jar/one-package.jar file and found 1 pack
 [reachability] Reachability analysis is disabled
 ---
 
+[TestRun/Scan_bun_with_ranged_package.json_dependencies - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "datadog",
+          "name": "datadog-sbom-generator",
+          "version": "set at build time, see .goreleaser.yml ldflags section"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:npm/lodash@4.17.21",
+      "type": "library",
+      "name": "lodash",
+      "version": "4.17.21",
+      "purl": "pkg:npm/lodash@4.17.21",
+      "properties": [
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "Bun"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":5,/"column_end/":25,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":6,/"column_end/":12,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":16,/"column_end/":24,/"role/":/"manifest/"}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:npm/typescript@5.3.3",
+      "type": "library",
+      "name": "typescript",
+      "version": "5.3.3",
+      "purl": "pkg:npm/typescript@5.3.3",
+      "properties": [
+        {
+          "name": "datadog:is-dev",
+          "value": "true"
+        },
+        {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
+          "name": "datadog:package-manager",
+          "value": "Bun"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":7,/"line_end/":7,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+---
+
+[TestRun/Scan_bun_with_ranged_package.json_dependencies - 2]
+Scanning directory './fixtures/integration-bun/ranges', resolved absolute path '<rootdir>/fixtures/integration-bun/ranges'
+Scanned <rootdir>/fixtures/integration-bun/ranges/bun.lock file and found 2 packages
+[reachability] Reachability analysis is disabled
+---
+
 [TestRun/Scan_cargo_project_with_multiple_dependency_types - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
@@ -11566,6 +11648,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
 | Java       | Gradle          | gradle/verification-metadata.xml |
 | Java       | Maven           | maven_install.json               |
 | Java       | Maven           | pom.xml                          |
+| Javascript | Bun             | bun.lock                         |
 | Javascript | NPM             | package-lock.json                |
 | Javascript | Pnpm            | pnpm-lock.yaml                   |
 | Javascript | Yarn            | yarn.lock                        |

--- a/cmd/datadog-sbom-generator/fixtures/integration-bun/ranges/bun.lock
+++ b/cmd/datadog-sbom-generator/fixtures/integration-bun/ranges/bun.lock
@@ -1,0 +1,18 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "bun-ranges",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      }
+    }
+  },
+  "packages": {
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-aaa"],
+    "typescript": ["typescript@5.3.3", "", {}, "sha512-bbb"]
+  }
+}

--- a/cmd/datadog-sbom-generator/fixtures/integration-bun/ranges/bun.lock
+++ b/cmd/datadog-sbom-generator/fixtures/integration-bun/ranges/bun.lock
@@ -4,15 +4,20 @@
     "": {
       "name": "bun-ranges",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "workspace-a": "workspace:packages/a"
       },
       "devDependencies": {
         "typescript": "^5.0.0"
       }
+    },
+    "packages/a": {
+      "name": "workspace-a"
     }
   },
   "packages": {
     "lodash": ["lodash@4.17.21", "", {}, "sha512-aaa"],
-    "typescript": ["typescript@5.3.3", "", {}, "sha512-bbb"]
+    "typescript": ["typescript@5.3.3", "", {}, "sha512-bbb"],
+    "workspace-a": ["workspace-a@workspace:packages/a", "", {}, ""]
   }
 }

--- a/cmd/datadog-sbom-generator/fixtures/integration-bun/ranges/package.json
+++ b/cmd/datadog-sbom-generator/fixtures/integration-bun/ranges/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bun-ranges",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/cmd/datadog-sbom-generator/main_test.go
+++ b/cmd/datadog-sbom-generator/main_test.go
@@ -276,6 +276,11 @@ func TestRun(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "Scan bun with ranged package.json dependencies",
+			args: []string{"", "--pretty", "--verbosity", "verbose", "./fixtures/integration-bun/ranges"},
+			exit: 0,
+		},
+		{
 			name: "Scan csproj project",
 			args: []string{"", "--pretty", "--verbosity", "verbose", "./fixtures/integration-nuget/csproj-sample-app"},
 			exit: 0,

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/CycloneDX/cyclonedx-go v0.9.2
 	github.com/DataDog/jsonapi v0.12.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/bmatcuk/doublestar/v4 v4.9.0
 	github.com/gkampitakis/go-snaps v0.5.11
 	github.com/go-git/go-billy/v5 v5.6.2
@@ -14,6 +15,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/stretchr/testify v1.10.0
+	github.com/tidwall/jsonc v0.3.3
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-java v0.23.5
 	github.com/tree-sitter/tree-sitter-ruby v0.23.1
@@ -27,7 +29,6 @@ require (
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=
-github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
 github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
@@ -112,6 +110,8 @@ github.com/terminalstatic/go-xsd-validate v0.1.6/go.mod h1:18lsvYFofBflqCrvo1ump
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/jsonc v0.3.3 h1:RVQqL3xFfDkKKXIDsrBiVQiEpBtxoKbmMXONb2H/y2w=
+github.com/tidwall/jsonc v0.3.3/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/pkg/lockfile/extract_test.go
+++ b/pkg/lockfile/extract_test.go
@@ -115,6 +115,7 @@ func TestListExtractors(t *testing.T) {
 	t.Parallel()
 
 	expectedOrder := []string{
+		"bun.lock",
 		"Cargo.lock",
 		"composer.lock",
 		"conan.lock",
@@ -207,7 +208,7 @@ func TestExpandLanguagesAndPackageManagersToExtractors(t *testing.T) {
 
 	// Test language expansion
 	result = lockfile.ExpandLanguagesAndPackageManagersToExtractors([]string{"javascript"})
-	expected := []string{"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
+	expected := []string{"bun.lock", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
 	assert.Equal(t, expected, result)
 
 	// Test direct parser name
@@ -223,7 +224,7 @@ func TestExpandLanguagesAndPackageManagersToExtractors(t *testing.T) {
 	// Test case insensitivity for language names
 	result1 := lockfile.ExpandLanguagesAndPackageManagersToExtractors([]string{"javascript"})
 	result2 := lockfile.ExpandLanguagesAndPackageManagersToExtractors([]string{"JAVASCRIPT"})
-	expected = []string{"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
+	expected = []string{"bun.lock", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
 	assert.Equal(t, expected, result1)
 	assert.Equal(t, expected, result2)
 
@@ -272,6 +273,7 @@ func expectNumberOfParsersCalled(t *testing.T, numberOfParsersCalled int) {
 func filesToParsers() map[string]string {
 	return map[string]string{
 		"buildscript-gradle.lockfile":      "gradle.lockfile",
+		"bun.lock":                         "bun.lock",
 		"Cargo.lock":                       "Cargo.lock",
 		"composer.lock":                    "composer.lock",
 		"conan.lock":                       "conan.lock",

--- a/pkg/lockfile/fixtures/bun/commits.lock
+++ b/pkg/lockfile/fixtures/bun/commits.lock
@@ -1,0 +1,14 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "commits-fixture",
+      "devDependencies": {
+        "raven-js": "getsentry/raven-js#3.23.1"
+      }
+    }
+  },
+  "packages": {
+    "raven-js": ["raven-js@github:getsentry/raven-js#91ef2d4", {}, "getsentry-raven-js-91ef2d4"]
+  }
+}

--- a/pkg/lockfile/fixtures/bun/empty-tuple.lock
+++ b/pkg/lockfile/fixtures/bun/empty-tuple.lock
@@ -1,0 +1,6 @@
+{
+  "lockfileVersion": 0,
+  "packages": {
+    "broken": []
+  }
+}

--- a/pkg/lockfile/fixtures/bun/empty.lock
+++ b/pkg/lockfile/fixtures/bun/empty.lock
@@ -1,0 +1,9 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "empty-fixture"
+    }
+  },
+  "packages": {}
+}

--- a/pkg/lockfile/fixtures/bun/files.lock
+++ b/pkg/lockfile/fixtures/bun/files.lock
@@ -1,0 +1,14 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "files-fixture",
+      "dependencies": {
+        "local-pkg": "file:../local-pkg"
+      }
+    }
+  },
+  "packages": {
+    "local-pkg": ["local-pkg@file:../local-pkg", {}, "local-pkg"]
+  }
+}

--- a/pkg/lockfile/fixtures/bun/multiple-packages.lock
+++ b/pkg/lockfile/fixtures/bun/multiple-packages.lock
@@ -1,0 +1,18 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "multiple-packages-fixture",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      }
+    }
+  },
+  "packages": {
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-aaa"],
+    "typescript": ["typescript@5.3.3", "", { "bin": { "tsc": "bin/tsc" } }, "sha512-bbb"]
+  }
+}

--- a/pkg/lockfile/fixtures/bun/non-string-spec.lock
+++ b/pkg/lockfile/fixtures/bun/non-string-spec.lock
@@ -1,0 +1,6 @@
+{
+  "lockfileVersion": 0,
+  "packages": {
+    "broken": [42, "", {}, "sha512-aaa"]
+  }
+}

--- a/pkg/lockfile/fixtures/bun/not-json.lock
+++ b/pkg/lockfile/fixtures/bun/not-json.lock
@@ -1,0 +1,1 @@
+this is not json at all

--- a/pkg/lockfile/fixtures/bun/one-package.lock
+++ b/pkg/lockfile/fixtures/bun/one-package.lock
@@ -1,0 +1,14 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "one-package-fixture",
+      "dependencies": {
+        "wrappy": "^1.0.0"
+      }
+    }
+  },
+  "packages": {
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-aaa"]
+  }
+}

--- a/pkg/lockfile/fixtures/bun/scoped-package.lock
+++ b/pkg/lockfile/fixtures/bun/scoped-package.lock
@@ -1,0 +1,14 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "scoped-package-fixture",
+      "dependencies": {
+        "@typescript-eslint/types": "^5.0.0"
+      }
+    }
+  },
+  "packages": {
+    "@typescript-eslint/types": ["@typescript-eslint/types@5.62.0", "", {}, "sha512-bbb"]
+  }
+}

--- a/pkg/lockfile/fixtures/bun/workspace-package.lock
+++ b/pkg/lockfile/fixtures/bun/workspace-package.lock
@@ -18,6 +18,6 @@
   "packages": {
     "workspace-a": ["workspace-a@workspace:packages/a", "", {}, ""],
     "lodash": ["lodash@4.17.21", "", {}, "sha512-aaa"],
-    "typescript": ["typescript@5.3.3", "", {}, "sha512-bbb"]
+    "packages/a/typescript": ["typescript@5.3.3", "", {}, "sha512-bbb"]
   }
 }

--- a/pkg/lockfile/fixtures/bun/workspace-package.lock
+++ b/pkg/lockfile/fixtures/bun/workspace-package.lock
@@ -1,0 +1,23 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "bun-workspace-fixture",
+      "dependencies": {
+        "workspace-a": "workspace:packages/a",
+        "lodash": "^4.17.21"
+      }
+    },
+    "packages/a": {
+      "name": "workspace-a",
+      "dependencies": {
+        "typescript": "^5.0.0"
+      }
+    }
+  },
+  "packages": {
+    "workspace-a": ["workspace-a@workspace:packages/a", "", {}, ""],
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-aaa"],
+    "typescript": ["typescript@5.3.3", "", {}, "sha512-bbb"]
+  }
+}

--- a/pkg/lockfile/javascript/parse-bun-lock.go
+++ b/pkg/lockfile/javascript/parse-bun-lock.go
@@ -103,6 +103,9 @@ func (e BunLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 		if err != nil || name == "" {
 			continue
 		}
+		if strings.HasPrefix(version, "workspace:") {
+			continue
+		}
 
 		packages = append(packages, lockfile.PackageDetails{
 			Name:           name,

--- a/pkg/lockfile/javascript/parse-bun-lock.go
+++ b/pkg/lockfile/javascript/parse-bun-lock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -61,11 +62,15 @@ func structureBunPackageDetails(tuple []json.RawMessage) (string, string, string
 	return name, version, commit, nil
 }
 
-func collectBunTargetVersions(workspaces map[string]BunLockWorkspace, name string) []string {
+func collectBunTargetVersions(workspaces map[string]BunLockWorkspace, packageKey string, name string) []string {
 	seen := make(map[string]bool)
 	targetVersions := make([]string, 0)
 
-	for _, workspace := range workspaces {
+	for workspacePath, workspace := range workspaces {
+		if packageKey != bunWorkspacePackageKey(workspacePath, name) {
+			continue
+		}
+
 		targetVersions = appendBunTargetVersion(targetVersions, seen, workspace.Dependencies[name])
 		targetVersions = appendBunTargetVersion(targetVersions, seen, workspace.OptionalDependencies[name])
 		targetVersions = appendBunTargetVersion(targetVersions, seen, workspace.DevDependencies[name])
@@ -74,6 +79,14 @@ func collectBunTargetVersions(workspaces map[string]BunLockWorkspace, name strin
 	slices.Sort(targetVersions)
 
 	return targetVersions
+}
+
+func bunWorkspacePackageKey(workspacePath string, name string) string {
+	if workspacePath == "" || workspacePath == "." {
+		return name
+	}
+
+	return path.Join(workspacePath, name)
 }
 
 func appendBunTargetVersion(targetVersions []string, seen map[string]bool, version string) []string {
@@ -98,7 +111,7 @@ func (e BunLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 	}
 
 	packages := make([]lockfile.PackageDetails, 0, len(parsed.Packages))
-	for _, tuple := range parsed.Packages {
+	for packageKey, tuple := range parsed.Packages {
 		name, version, commit, err := structureBunPackageDetails(tuple)
 		if err != nil || name == "" {
 			continue
@@ -111,7 +124,7 @@ func (e BunLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanConte
 			Name:           name,
 			Version:        version,
 			Commit:         commit,
-			TargetVersions: collectBunTargetVersions(parsed.Workspaces, name),
+			TargetVersions: collectBunTargetVersions(parsed.Workspaces, packageKey, name),
 			Ecosystem:      models.EcosystemNPM,
 			PackageManager: bunPackageManager,
 		})

--- a/pkg/lockfile/javascript/parse-bun-lock.go
+++ b/pkg/lockfile/javascript/parse-bun-lock.go
@@ -1,0 +1,131 @@
+package javascript
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/tidwall/jsonc"
+)
+
+func (e BunLockExtractor) ShouldExtract(path string) bool {
+	if filepath.Base(path) != models.BunFilePath.String() {
+		return false
+	}
+	// Skip lockfiles nested in node_modules — they belong to a dependency, not the project.
+	dir := filepath.ToSlash(filepath.Dir(path))
+
+	return !strings.Contains("/"+dir+"/", "/node_modules/")
+}
+
+func (e BunLockExtractor) IsOfficiallySupported() bool {
+	return bunOfficiallySupported
+}
+
+func (e BunLockExtractor) PackageManager() models.PackageManager {
+	return bunPackageManager
+}
+
+// Adapted from github.com/google/osv-scalibr@ec4239d (Apache-2.0).
+// https://github.com/google/osv-scalibr/blob/ec4239d68fb9375123197cf1e37de296061b9e57/extractor/filesystem/language/javascript/bunlock/bunlock.go
+func structureBunPackageDetails(tuple []json.RawMessage) (string, string, string, error) {
+	if len(tuple) == 0 {
+		return "", "", "", errors.New("empty package tuple")
+	}
+
+	var str string
+	if err := json.Unmarshal(tuple[0], &str); err != nil {
+		return "", "", "", errors.New("first element of package tuple is not a string")
+	}
+
+	str, isScoped := strings.CutPrefix(str, "@")
+	name, version, _ := strings.Cut(str, "@")
+	if isScoped {
+		name = "@" + name
+	}
+
+	version, commit, _ := strings.Cut(version, "#")
+	if commit != "" {
+		version = ""
+	}
+	if strings.HasPrefix(version, "file:") {
+		version = ""
+	}
+
+	return name, version, commit, nil
+}
+
+func collectBunTargetVersions(workspaces map[string]BunLockWorkspace, name string) []string {
+	seen := make(map[string]bool)
+	targetVersions := make([]string, 0)
+
+	for _, workspace := range workspaces {
+		targetVersions = appendBunTargetVersion(targetVersions, seen, workspace.Dependencies[name])
+		targetVersions = appendBunTargetVersion(targetVersions, seen, workspace.OptionalDependencies[name])
+		targetVersions = appendBunTargetVersion(targetVersions, seen, workspace.DevDependencies[name])
+	}
+
+	slices.Sort(targetVersions)
+
+	return targetVersions
+}
+
+func appendBunTargetVersion(targetVersions []string, seen map[string]bool, version string) []string {
+	if version == "" || seen[version] {
+		return targetVersions
+	}
+
+	seen[version] = true
+
+	return append(targetVersions, version)
+}
+
+func (e BunLockExtractor) Extract(f lockfile.DepFile, context lockfile.ScanContext) ([]lockfile.PackageDetails, error) {
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("could not read bun.lock: %w", err)
+	}
+
+	var parsed BunLockfile
+	if err := json.Unmarshal(jsonc.ToJSONInPlace(content), &parsed); err != nil {
+		return nil, fmt.Errorf("could not parse bun.lock: %w", err)
+	}
+
+	packages := make([]lockfile.PackageDetails, 0, len(parsed.Packages))
+	for _, tuple := range parsed.Packages {
+		name, version, commit, err := structureBunPackageDetails(tuple)
+		if err != nil || name == "" {
+			continue
+		}
+
+		packages = append(packages, lockfile.PackageDetails{
+			Name:           name,
+			Version:        version,
+			Commit:         commit,
+			TargetVersions: collectBunTargetVersions(parsed.Workspaces, name),
+			Ecosystem:      models.EcosystemNPM,
+			PackageManager: bunPackageManager,
+		})
+	}
+
+	return packages, nil
+}
+
+var BunExtractor = BunLockExtractor{
+	lockfile.WithMatcher{Matchers: []lockfile.Matcher{&PackageJSONMatcher{}}},
+}
+
+func ParseBunLock(pathToLockfile string) ([]lockfile.PackageDetails, error) {
+	return lockfile.ExtractFromFile(pathToLockfile, BunExtractor)
+}
+
+//nolint:gochecknoinits
+func init() {
+	lockfile.RegisterExtractor(models.BunFilePath, BunExtractor)
+}

--- a/pkg/lockfile/javascript/parse-bun-lock_test.go
+++ b/pkg/lockfile/javascript/parse-bun-lock_test.go
@@ -255,6 +255,67 @@ func TestParseBunLock_MatchesPackageJSONRanges(t *testing.T) {
 	}
 }
 
+func TestParseBunLock_DoesNotApplyDirectRangeToTransitiveVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bunLockPath := filepath.Join(dir, models.BunFilePath.String())
+	packageJSONPath := filepath.Join(dir, "package.json")
+
+	err := os.WriteFile(bunLockPath, []byte(`{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "bun-duplicate-ranges",
+      "dependencies": {
+        "debug": "^4.3.4"
+      }
+    }
+  },
+  "packages": {
+    "debug": ["debug@4.3.4", "", {}, "sha512-direct"],
+    "compression/debug": ["debug@2.6.9", "", {}, "sha512-transitive"]
+  }
+}`), 0o600)
+	if err != nil {
+		t.Fatalf("could not write bun.lock fixture: %v", err)
+	}
+
+	err = os.WriteFile(packageJSONPath, []byte(`{
+  "name": "bun-duplicate-ranges",
+  "dependencies": {
+    "debug": "^4.3.4"
+  }
+}`), 0o600)
+	if err != nil {
+		t.Fatalf("could not write package.json fixture: %v", err)
+	}
+
+	packages, err := javascript.ParseBunLock(bunLockPath)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "debug",
+			Version:        "4.3.4",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^4.3.4"},
+			Ecosystem:      models.EcosystemNPM,
+			IsDirect:       true,
+			DepGroups:      []string{"prod"},
+		},
+		{
+			Name:           "debug",
+			Version:        "2.6.9",
+			PackageManager: models.Bun,
+			TargetVersions: []string{},
+			Ecosystem:      models.EcosystemNPM,
+		},
+	})
+}
+
 func TestParseBunLock_MalformedJSON(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lockfile/javascript/parse-bun-lock_test.go
+++ b/pkg/lockfile/javascript/parse-bun-lock_test.go
@@ -1,0 +1,261 @@
+package javascript_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/javascript"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+)
+
+func TestBunLockExtractor_ShouldExtract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "empty path", path: "", want: false},
+		{name: "bare bun.lock", path: "bun.lock", want: true},
+		{name: "nested bun.lock", path: "path/to/my/bun.lock", want: true},
+		{name: "wrong basename", path: "bun.lockb", want: false},
+		{name: "trailing junk", path: "path/to/my/bun.lock/file", want: false},
+		{name: "node_modules at root", path: "node_modules/dep/bun.lock", want: false},
+		{name: "node_modules nested", path: "app/node_modules/dep/bun.lock", want: false},
+		{name: "node_modules deep", path: "app/node_modules/dep/sub/bun.lock", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := javascript.BunExtractor.ShouldExtract(tt.path)
+			if got != tt.want {
+				t.Errorf("ShouldExtract(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseBunLock_NoPackages(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/empty.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+func TestParseBunLock_OnePackage(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/one-package.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "wrappy",
+			Version:        "1.0.2",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^1.0.0"},
+			Ecosystem:      models.EcosystemNPM,
+		},
+	})
+}
+
+func TestParseBunLock_ScopedPackage(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/scoped-package.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "@typescript-eslint/types",
+			Version:        "5.62.0",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^5.0.0"},
+			Ecosystem:      models.EcosystemNPM,
+		},
+	})
+}
+
+func TestParseBunLock_GitCommit(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/commits.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "raven-js",
+			Version:        "",
+			Commit:         "91ef2d4",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"getsentry/raven-js#3.23.1"},
+			Ecosystem:      models.EcosystemNPM,
+		},
+	})
+}
+
+func TestParseBunLock_FileDependency(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/files.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "local-pkg",
+			Version:        "",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"file:../local-pkg"},
+			Ecosystem:      models.EcosystemNPM,
+		},
+	})
+}
+
+func TestParseBunLock_MultiplePackages(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/multiple-packages.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "lodash",
+			Version:        "4.17.21",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^4.17.21"},
+			Ecosystem:      models.EcosystemNPM,
+		},
+		{
+			Name:           "typescript",
+			Version:        "5.3.3",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^5.0.0"},
+			Ecosystem:      models.EcosystemNPM,
+		},
+	})
+}
+
+func TestParseBunLock_MatchesPackageJSONRanges(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bunLockPath := filepath.Join(dir, models.BunFilePath.String())
+	packageJSONPath := filepath.Join(dir, "package.json")
+
+	err := os.WriteFile(bunLockPath, []byte(`{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "bun-ranges",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      }
+    }
+  },
+  "packages": {
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-aaa"],
+    "typescript": ["typescript@5.3.3", "", {}, "sha512-bbb"]
+  }
+}`), 0o600)
+	if err != nil {
+		t.Fatalf("could not write bun.lock fixture: %v", err)
+	}
+
+	err = os.WriteFile(packageJSONPath, []byte(`{
+  "name": "bun-ranges",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}`), 0o600)
+	if err != nil {
+		t.Fatalf("could not write package.json fixture: %v", err)
+	}
+
+	packages, err := javascript.ParseBunLock(bunLockPath)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "lodash",
+			Version:        "4.17.21",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^4.17.21"},
+			Ecosystem:      models.EcosystemNPM,
+			IsDirect:       true,
+			DepGroups:      []string{"prod"},
+		},
+		{
+			Name:           "typescript",
+			Version:        "5.3.3",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^5.0.0"},
+			Ecosystem:      models.EcosystemNPM,
+			IsDirect:       true,
+			DepGroups:      []string{"dev"},
+		},
+	})
+
+	for _, pkg := range packages {
+		if pkg.NameLocation == nil || pkg.VersionLocation == nil || pkg.BlockLocation.Filename != packageJSONPath {
+			t.Errorf("expected %s to have package.json locations, got block=%+v name=%+v version=%+v", pkg.Name, pkg.BlockLocation, pkg.NameLocation, pkg.VersionLocation)
+		}
+	}
+}
+
+func TestParseBunLock_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := javascript.ParseBunLock("../fixtures/bun/not-json.lock")
+	if err == nil {
+		t.Fatal("expected an error for malformed JSON, got nil")
+	}
+}
+
+func TestParseBunLock_EmptyTuple(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/empty-tuple.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+func TestParseBunLock_NonStringFirstElement(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/non-string-spec.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackages(t, packages, []lockfile.PackageDetails{})
+}

--- a/pkg/lockfile/javascript/parse-bun-lock_test.go
+++ b/pkg/lockfile/javascript/parse-bun-lock_test.go
@@ -154,6 +154,32 @@ func TestParseBunLock_MultiplePackages(t *testing.T) {
 	})
 }
 
+func TestParseBunLock_SkipsWorkspacePackages(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParseBunLock("../fixtures/bun/workspace-package.lock")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "lodash",
+			Version:        "4.17.21",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^4.17.21"},
+			Ecosystem:      models.EcosystemNPM,
+		},
+		{
+			Name:           "typescript",
+			Version:        "5.3.3",
+			PackageManager: models.Bun,
+			TargetVersions: []string{"^5.0.0"},
+			Ecosystem:      models.EcosystemNPM,
+		},
+	})
+}
+
 func TestParseBunLock_MatchesPackageJSONRanges(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lockfile/javascript/types.go
+++ b/pkg/lockfile/javascript/types.go
@@ -1,6 +1,8 @@
 package javascript
 
 import (
+	"encoding/json"
+
 	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
@@ -184,6 +186,35 @@ type PnpmLegacyLockfile struct {
 }
 
 type PnpmLockExtractor struct {
+	lockfile.WithMatcher
+}
+
+// ============================================================================
+// Bun Constants
+// ============================================================================
+
+const (
+	bunPackageManager      = models.Bun
+	bunOfficiallySupported = true
+)
+
+// ============================================================================
+// Bun Types
+// ============================================================================
+
+type BunLockfile struct {
+	Version    int                          `json:"lockfileVersion"`
+	Workspaces map[string]BunLockWorkspace  `json:"workspaces"`
+	Packages   map[string][]json.RawMessage `json:"packages"`
+}
+
+type BunLockWorkspace struct {
+	Dependencies         map[string]string `json:"dependencies"`
+	DevDependencies      map[string]string `json:"devDependencies"`
+	OptionalDependencies map[string]string `json:"optionalDependencies"`
+}
+
+type BunLockExtractor struct {
 	lockfile.WithMatcher
 }
 

--- a/pkg/models/lockfile.go
+++ b/pkg/models/lockfile.go
@@ -10,6 +10,7 @@ func (p ParsedFilePath) String() string {
 // Standard lockfile names used by extractors
 const (
 	ApkFilePath                ParsedFilePath = "/lib/apk/db/installed"
+	BunFilePath                ParsedFilePath = "bun.lock"
 	BundlerFilePath            ParsedFilePath = "Gemfile.lock"
 	ComposerFilePath           ParsedFilePath = "composer.lock"
 	ConanFilePath              ParsedFilePath = "conan.lock"

--- a/pkg/models/package_manager.go
+++ b/pkg/models/package_manager.go
@@ -3,6 +3,7 @@ package models
 type PackageManager string
 
 const (
+	Bun          PackageManager = "Bun"
 	Bundler      PackageManager = "Bundler"
 	Composer     PackageManager = "Composer"
 	Conan        PackageManager = "Conan"
@@ -32,6 +33,7 @@ var PackageManagerToLanguage = map[PackageManager]Language{
 	NPM:          Javascript,
 	Yarn:         Javascript,
 	Pnpm:         Javascript,
+	Bun:          Javascript,
 	Requirements: Python,
 	Pipfile:      Python,
 	Pdm:          Python,


### PR DESCRIPTION
## 🚀 Motivation

SCA currently does not extract dependencies from `bun.lock`, so Bun projects are missing SBOM coverage. This PR adds Bun lockfile support and preserves the manifest dependency specifiers needed to enrich direct dependencies from `package.json`.

## 📚 Documentation

**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [K9VULN-14431](https://datadoghq.atlassian.net/browse/K9VULN-14431)

## 📝 Summary

Adds a `bun.lock` extractor for JavaScript projects.

**Parser behavior:**
- Registers `bun.lock` and the Bun package manager
- Extracts package name, resolved version, and git commit details from Bun package tuples
- Handles scoped packages, file dependencies, malformed JSON, empty tuples, and non-string package specs
- Skips lockfiles nested under `node_modules`

**Package.json enrichment:**
- Reuses the existing `PackageJSONMatcher`
- Parses Bun `workspaces` dependency sections to preserve declared specifiers such as `^4.17.21`
- Uses those specifiers as `TargetVersions` so direct/dev dependencies receive `IsDirect`, dependency groups, and manifest locations

## 🧪 Testing

- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

**Cross-scanner verification:**
Compared this branch against [Trivy](https://trivy.dev/docs/latest/coverage/language/nodejs/) `0.70.0` on [`kriasoft/react-starter-kit`](https://github.com/kriasoft/react-starter-kit), a Bun monorepo with a 4,648-line `bun.lock`.

| Metric | Datadog | Trivy |
|---|---:|---:|
| Raw CycloneDX PURLs | 1,922 | 2,185 |
| Canonical `name@version` packages | 1,922 | 1,932 |

- After canonicalizing Trivy's Bun dependency-path PURLs to resolved `name@version`, every package emitted by Datadog is also emitted by Trivy (`0` Datadog-only canonical packages).
- Trivy's extra raw PURLs are modeling differences: it can emit a separate PURL for each nested lockfile path key, even when multiple paths resolve to the same `(name, version)`.
- The remaining `10` Trivy-only canonical packages were local workspace packages such as `@repo/api`, `@repo/web`, and `@repo/ui`, which we intentionally skips instead of reporting as third-party npm components.

## 🆘 Recovery

Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:

[K9VULN-14431]: https://datadoghq.atlassian.net/browse/K9VULN-14431
