### PR TITLE
test(lockfile): add invariant — LocationRole must be set when BlockLocation is valid

### DIFF
--- a/pkg/lockfile/location_role_invariant_test.go
+++ b/pkg/lockfile/location_role_invariant_test.go
@@ -28,12 +28,19 @@ func TestLocationRoleSetWhenBlockLocationIsValid(t *testing.T) {
 	fixturesRoot := "fixtures"
 	context := testutil.GetTestContext()
 
+	// Enable all registered parsers so FindExtractor can match fixture files.
+	// An empty map disables every parser (FindExtractor checks enabledParsers[name] == true).
+	allParsers := make(map[string]bool)
+	for name := range lockfile.ListSupportedExtractors() {
+		allParsers[name] = true
+	}
+
 	err := filepath.WalkDir(fixturesRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err
 		}
 
-		extractor, _ := lockfile.FindExtractor(path, map[string]bool{})
+		extractor, _ := lockfile.FindExtractor(path, allParsers)
 		if extractor == nil {
 			return nil
 		}

--- a/pkg/lockfile/location_role_invariant_test.go
+++ b/pkg/lockfile/location_role_invariant_test.go
@@ -1,0 +1,67 @@
+package lockfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile"
+	"github.com/DataDog/datadog-sbom-generator/pkg/lockfile/internal/testutil"
+	_ "github.com/DataDog/datadog-sbom-generator/pkg/lockfile/parsers" // Register all extractors
+)
+
+// TestLocationRoleSetWhenBlockLocationIsValid verifies that every extractor sets
+// LocationRole whenever it also sets a valid BlockLocation.
+//
+// This is an invariant that the reporter relies on: vulnerability_result.go uses
+// LocationRole to populate the "role" field in the emitted PackageLocation. If an
+// extractor populates BlockLocation but leaves LocationRole empty, the role will be
+// blank in the SBOM output even though the location is meaningful.
+//
+// The test walks pkg/lockfile/fixtures/, runs the registered extractor for each
+// fixture file, and fails if any returned PackageDetails has a valid BlockLocation
+// but an empty LocationRole.
+func TestLocationRoleSetWhenBlockLocationIsValid(t *testing.T) {
+	t.Parallel()
+
+	fixturesRoot := "fixtures"
+	context := testutil.GetTestContext()
+
+	err := filepath.WalkDir(fixturesRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+
+		extractor, _ := lockfile.FindExtractor(path, map[string]bool{})
+		if extractor == nil {
+			return nil
+		}
+
+		f, err := lockfile.OpenLocalDepFile(path)
+		if err != nil {
+			return nil // skip unreadable files
+		}
+		defer f.Close()
+
+		packages, err := extractor.Extract(f, context)
+		if err != nil {
+			return nil // skip files that fail to parse (invalid fixtures are intentional)
+		}
+
+		for _, pkg := range packages {
+			if fileposition.IsFilePositionExtractedSuccessfully(pkg.BlockLocation) && pkg.LocationRole == "" {
+				t.Errorf(
+					"extractor for %q returned package %s@%s with a valid BlockLocation but empty LocationRole",
+					path, pkg.Name, pkg.Version,
+				)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("error walking fixtures: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a cross-extractor invariant test that walks all fixtures under \`pkg/lockfile/fixtures/\`, runs the registered extractor for each file, and fails if any \`PackageDetails\` has a valid \`BlockLocation\` (file + line + column all set) but an empty \`LocationRole\`.

## Motivation

Identified while reviewing PR #126 (\`PackageJSONExtractor\`): the extractor sets \`BlockLocation\` for every package but omits \`LocationRole\`, so the \`role\` field in the SBOM output is blank. Since \`LocationRole\` is a plain \`string\` field, the compiler cannot enforce it — a test is the right safety net.

**How the test catches PR #126 as-is:** when that PR merges, \`PackageJSONExtractor\` is registered and its \`package.json\` fixtures are picked up by this test. The extractor sets a valid \`BlockLocation\` but leaves \`LocationRole\` empty → the test fails. After adding \`LocationRole: models.LocationRoleManifest\` (the fix) the test passes again.

## Test plan
- [x] Passes on \`main\` (all current extractors already set \`LocationRole\` correctly)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)