### PR TITLE
[K9VULN-14985] Ignore test directories from SCA scans

### DIFF
--- a/code-security.datadog.yaml
+++ b/code-security.datadog.yaml
@@ -1,0 +1,5 @@
+schema-version: v1.1
+sca:
+  ignore-paths:
+    - pkg/lockfile/fixtures/**
+    - cmd/datadog-sbom-generator/fixtures/**


### PR DESCRIPTION
## What problem are you trying to solve?
- The SCA scanner was picking up lockfiles inside test directories and reporting their dependencies as real vulnerabilities for this project.

- [K9VULN-14985](https://datadoghq.atlassian.net/browse/K9VULN-14985)

## What is your solution?
- Add a config file at the repo's root using the new in-app configuration file feature.

<img width="1512" height="827" alt="Screenshot 2026-05-22 at 8 47 29 AM" src="https://github.com/user-attachments/assets/58f8f173-6259-494d-8d0a-0a4de44ff07c" />

<img width="1508" height="824" alt="Screenshot 2026-05-21 at 5 21 23 PM" src="https://github.com/user-attachments/assets/9b21d1e8-ccad-443d-b7c0-4997768824d6" />

## Alternatives considered
- Defining the ignores at the org-level or repo-level config in Datadog instead of in the repo file. 
     - Org-level: too broad for repo-specific paths
     - Repo-level: harder to review and keep in sync with code changes
     - Repo-level (config in repo): chosen since fixture paths are an implementation detail of this repo and since this file also takes precedence over org- and repo-level Datadog configs, so these exclusions always apply.

## What the reviewer should know
- Any future fixture directories added will need to be explicitly added to `code-security.datadog.yaml` to be excluded from SCA scans.

[K9VULN-14985]: https://datadoghq.atlassian.net/browse/K9VULN-14985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ