### PR TITLE
feat(sbomgen): expose library API for programmatic SBOM generation (SCI Usage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,56 @@ NPM, Yarn and PNPM have workspace support
 - When Xcode writes the lockfile at `.swiftpm/configuration/Package.resolved`, `Package.swift` enrichment is not available because the manifest is two directory levels above the lockfile.
 - `IsDirect` is only set for packages declared with a URL in `Package.swift`. Registry-based dependencies (`.package(id: ...)`) are always reported as transitive.
 
+## Using as a Go library
+
+In addition to the CLI binary, `datadog-sbom-generator` can be imported as a Go library.
+
+### Installation
+
+```bash
+go get github.com/DataDog/datadog-sbom-generator/pkg/sbomgen
+```
+
+### Usage
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/DataDog/datadog-sbom-generator/pkg/sbomgen"
+)
+
+func main() {
+    result, err := sbomgen.GenerateSBOM([]string{"/path/to/repo"}, sbomgen.DefaultOptions())
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(string(result)) // CycloneDX 1.5 JSON
+}
+```
+
+### API
+
+#### `GenerateSBOM(dirs []string, opts Options) ([]byte, error)`
+
+Scans the given directories for lockfiles and returns a CycloneDX 1.5 SBOM as pretty-printed JSON bytes.
+
+Returns an error if `dirs` is empty or if the scan fails.
+
+#### `DefaultOptions() Options`
+
+Returns sensible defaults: recursive scanning enabled, no path exclusions.
+
+#### `Options`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Recursive` | `bool` | Scan subdirectories recursively (default: `true`) |
+| `ExcludePaths` | `[]string` | Glob patterns to exclude from scanning |
+
 ## Contributing
 
 Contributions are welcome! You can contribute by:

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,31 @@
+// This program demonstrates using the sbomgen library to generate a CycloneDX SBOM.
+//
+// Usage:
+//
+//	go run examples/main.go [directory]
+//
+// If no directory is provided, it scans pkg/sbomgen/testdata which contains a
+// sample Cargo.lock fixture.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-sbom-generator/pkg/sbomgen"
+)
+
+func main() {
+	dir := "pkg/sbomgen/testdata"
+	if len(os.Args) > 1 {
+		dir = os.Args[1]
+	}
+
+	result, err := sbomgen.GenerateSBOM([]string{dir}, sbomgen.DefaultOptions())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print(string(result))
+}

--- a/pkg/sbomgen/sbomgen.go
+++ b/pkg/sbomgen/sbomgen.go
@@ -1,0 +1,85 @@
+// Package sbomgen provides a library API for generating CycloneDX SBOMs.
+//
+// This package wraps the scanner and output internals to provide a simple,
+// programmatic interface for SBOM generation without requiring CLI dependencies.
+//
+// Usage:
+//
+//	result, err := sbomgen.GenerateSBOM([]string{"./my-project"}, sbomgen.DefaultOptions())
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	fmt.Println(string(result))
+package sbomgen
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/DataDog/datadog-sbom-generator/internal/output"
+	"github.com/DataDog/datadog-sbom-generator/internal/output/sbom"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
+	"github.com/DataDog/datadog-sbom-generator/pkg/scanner"
+)
+
+// Options controls the behavior of GenerateSBOM.
+type Options struct {
+	// Recursive controls whether subdirectories are scanned.
+	Recursive bool
+
+	// ExcludePaths is a list of glob patterns to exclude from scanning.
+	ExcludePaths []string
+}
+
+// DefaultOptions returns Options with sensible defaults:
+// recursive scanning enabled and no exclusions.
+func DefaultOptions() Options {
+	return Options{
+		Recursive:    true,
+		ExcludePaths: []string{},
+	}
+}
+
+// GenerateSBOM scans the given directories for lockfiles and returns a
+// CycloneDX 1.5 SBOM as pretty-printed JSON bytes.
+//
+// It returns an error if dirs is empty or if the scan finds no packages.
+func GenerateSBOM(dirs []string, opts Options) ([]byte, error) {
+	if len(dirs) == 0 {
+		return nil, errors.New("at least one directory must be provided")
+	}
+
+	actions := scanner.ScannerActions{
+		DirectoryPaths: dirs,
+		ExcludePaths:   opts.ExcludePaths,
+		Recursive:      opts.Recursive,
+	}
+
+	r := reporter.NewCycloneDXReporter(&bytes.Buffer{}, &bytes.Buffer{}, reporter.WarnLevel)
+
+	vulnResults, err := scanner.DoScan(actions, r)
+	if err != nil {
+		return nil, err
+	}
+
+	tool := sbom.Tool{
+		Name:    "datadog-sbom-generator",
+		Version: "library",
+	}
+
+	bom, bomErr := output.CreateCycloneDXBOM(tool, &vulnResults)
+	if bom == nil {
+		return nil, bomErr
+	}
+
+	var buf bytes.Buffer
+	encoder := cyclonedx.NewBOMEncoder(&buf, cyclonedx.BOMFileFormatJSON)
+	encoder.SetPretty(true)
+
+	if encErr := encoder.EncodeVersion(bom, bom.SpecVersion); encErr != nil {
+		return nil, errors.Join(encErr, bomErr)
+	}
+
+	return buf.Bytes(), bomErr
+}

--- a/pkg/sbomgen/sbomgen_test.go
+++ b/pkg/sbomgen/sbomgen_test.go
@@ -1,0 +1,67 @@
+package sbomgen
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGenerateSBOM_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	// Use a local testdata fixture with a single Cargo.lock dependency
+	dirs := []string{"testdata"}
+	opts := DefaultOptions()
+
+	result, err := GenerateSBOM(dirs, opts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(result) == 0 {
+		t.Fatal("expected non-empty SBOM output")
+	}
+
+	// Verify it's valid JSON
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("expected valid JSON output, got parse error: %v", err)
+	}
+
+	// Verify CycloneDX structure
+	if parsed["bomFormat"] != "CycloneDX" {
+		t.Errorf("expected bomFormat 'CycloneDX', got %v", parsed["bomFormat"])
+	}
+
+	// Verify components exist (the fixture has at least one package)
+	components, ok := parsed["components"].([]interface{})
+	if !ok || len(components) == 0 {
+		t.Error("expected at least one component in the SBOM")
+	}
+}
+
+func TestGenerateSBOM_EmptyDirs(t *testing.T) {
+	t.Parallel()
+
+	_, err := GenerateSBOM([]string{}, DefaultOptions())
+	if err == nil {
+		t.Fatal("expected error for empty dirs slice, got nil")
+	}
+}
+
+func TestDefaultOptions(t *testing.T) {
+	t.Parallel()
+
+	opts := DefaultOptions()
+
+	if !opts.Recursive {
+		t.Error("expected Recursive to be true by default")
+	}
+
+	if opts.ExcludePaths == nil {
+		t.Error("expected ExcludePaths to be non-nil")
+	}
+
+	if len(opts.ExcludePaths) != 0 {
+		t.Errorf("expected ExcludePaths to be empty, got %v", opts.ExcludePaths)
+	}
+}

--- a/pkg/sbomgen/testdata/Cargo.lock
+++ b/pkg/sbomgen/testdata/Cargo.lock
@@ -1,0 +1,6 @@
+version = 3
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
## Summary

- Add `pkg/sbomgen` package with a `GenerateSBOM(dirs []string, opts Options) ([]byte, error)` function that wraps the scanner + CycloneDX output for external consumers
- Add `Options` struct and `DefaultOptions()` with recursive scanning enabled by default
- Add `examples/main.go` demonstrating library usage (temporary reference implementation)

## Motivation

The tool was previously only usable as a CLI binary. Any Go project wanting to generate SBOMs programmatically had to shell out to the binary. This change exposes a clean public API in `pkg/sbomgen/` that can be imported directly.

## Usage

```go
import "github.com/DataDog/datadog-sbom-generator/pkg/sbomgen"

sbom, err := sbomgen.GenerateSBOM([]string{"./my-project"}, sbomgen.DefaultOptions())
if err != nil {
    log.Fatal(err)
}
fmt.Println(string(sbom)) // CycloneDX 1.5 JSON
```

## Test plan

- [x] `TestGenerateSBOM_HappyPath` — scans a Cargo.lock fixture, validates CycloneDX output
- [x] `TestGenerateSBOM_EmptyDirs` — returns error on empty dirs slice  
- [x] `TestDefaultOptions` — validates default option values
- [x] `examples/main.go` compiles and runs, printing valid CycloneDX JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)