### PR TITLE
feat(sbomgen): add Gradle build file tree support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,16 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
-    fmt.Println(string(result)) // CycloneDX 1.5 JSON
+    fmt.Println(string(sbom)) // CycloneDX 1.5 JSON
+
+    // Extract the manifest build files and their transitive dependencies.
+    buildFiles := sbomgen.GetBuildFileTrees(sbom)
+    for bf, rels := range buildFiles {
+        fmt.Printf("[%s] %s (id: %s)\n", bf.FileType, bf.FilePath, rels.ID)
+        for _, dep := range rels.Dependencies {
+            fmt.Printf("  dep: %s\n", dep.FilePath)
+        }
+    }
 }
 ```
 
@@ -213,16 +222,31 @@ Scans the given directories for lockfiles and returns a CycloneDX 1.5 SBOM as pr
 
 Returns an error if `dirs` is empty or if the scan fails.
 
+#### `GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile]BuildFileRelations`
+
+Parses a CycloneDX SBOM (as returned by `GenerateSBOM`) and returns all manifest build files enriched with their transitive dependencies.
+
+Each `BuildFile` carries the file type (e.g. `FileTypePomXML`) and its path relative to the repository root. Each `BuildFileRelations` value holds an `ID` string (ecosystem-specific identifier, e.g. Maven "groupId:artifactId") and a `Dependencies` slice containing all transitively reachable build files sorted by file path.
+
+Pass one or more `FileType` constants to restrict the result to a specific ecosystem:
+
+```go
+// Only pom.xml files, with Maven transitive dependencies resolved.
+mavenFiles := sbomgen.GetBuildFileTrees(sbom, sbomgen.FileTypePomXML)
+```
+
+
 #### `DefaultOptions() Options`
 
 Returns sensible defaults: recursive scanning enabled, no path exclusions.
 
 #### `Options`
 
-| Field          | Type       | Description                                       |
-| -------------- | ---------- | ------------------------------------------------- |
-| `Recursive`    | `bool`     | Scan subdirectories recursively (default: `true`) |
-| `ExcludePaths` | `[]string` | Glob patterns to exclude from scanning            |
+| Field                      | Type       | Description                                                                                  |
+| -------------------------- | ---------- | -------------------------------------------------------------------------------------------- |
+| `Recursive`                | `bool`     | Scan subdirectories recursively (default: `true`)                                            |
+| `ExcludePaths`             | `[]string` | Glob patterns to exclude from scanning                                                       |
+| `ExtractMavenPomArtifactIds` | `bool`   | Emit file-type components and dependency edges for Maven POMs, enabling `GetBuildFileTrees` dependency and ID resolution (default: `true`) |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,20 @@ NPM, Yarn and PNPM have workspace support
 
 In addition to the CLI binary, `datadog-sbom-generator` can be imported as a Go library.
 
+### Quick start — run the bundled example
+
+The repository ships with a ready-made example program at `examples/main.go` that you can run directly against any local directory to see the full library output:
+
+```bash
+# Scan the built-in Cargo.lock fixture (no arguments needed)
+go run examples/main.go
+
+# Scan your own repository
+go run examples/main.go /path/to/your/repo
+```
+
+The program prints the generated CycloneDX SBOM JSON to stdout and a summary of all manifest build files (with their dependencies) to stderr. It is the fastest way to verify library behaviour end-to-end without writing any code.
+
 ### Installation
 
 ```bash
@@ -235,18 +249,17 @@ Pass one or more `FileType` constants to restrict the result to a specific ecosy
 mavenFiles := sbomgen.GetBuildFileTrees(sbom, sbomgen.FileTypePomXML)
 ```
 
-
 #### `DefaultOptions() Options`
 
 Returns sensible defaults: recursive scanning enabled, no path exclusions.
 
 #### `Options`
 
-| Field                      | Type       | Description                                                                                  |
-| -------------------------- | ---------- | -------------------------------------------------------------------------------------------- |
-| `Recursive`                | `bool`     | Scan subdirectories recursively (default: `true`)                                            |
-| `ExcludePaths`             | `[]string` | Glob patterns to exclude from scanning                                                       |
-| `ExtractMavenPomArtifactIds` | `bool`   | Emit file-type components and dependency edges for Maven POMs, enabling `GetBuildFileTrees` dependency and ID resolution (default: `true`) |
+| Field                        | Type       | Description                                                                                                                                |
+| ---------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Recursive`                  | `bool`     | Scan subdirectories recursively (default: `true`)                                                                                          |
+| `ExcludePaths`               | `[]string` | Glob patterns to exclude from scanning                                                                                                     |
+| `ExtractMavenPomArtifactIds` | `bool`     | Emit file-type components and dependency edges for Maven POMs, enabling `GetBuildFileTrees` dependency and ID resolution (default: `true`) |
 
 ## Contributing
 

--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -12619,28 +12619,6 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
   },
   "components": [
     {
-      "bom-ref": "libs/pom.xml",
-      "type": "file",
-      "name": "libs/pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/com.foobar/common@1.0-SNAPSHOT"
-        }
-      ]
-    },
-    {
-      "bom-ref": "other-dir/pom.xml",
-      "type": "file",
-      "name": "other-dir/pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/kafka-commons-client@1.0-SNAPSHOT"
-        }
-      ]
-    },
-    {
       "bom-ref": "pkg:maven/com.foobar/common@1.0-SNAPSHOT",
       "type": "library",
       "name": "com.foobar:common",
@@ -12711,26 +12689,6 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           }
         ]
       }
-    },
-    {
-      "bom-ref": "pom.xml",
-      "type": "file",
-      "name": "pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/integration-tests@1.0-SNAPSHOT"
-        }
-      ]
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "other-dir/pom.xml",
-      "dependsOn": [
-        "libs/pom.xml",
-        "pom.xml"
-      ]
     }
   ]
 }
@@ -12787,17 +12745,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
     }
   },
   "components": [
-    {
-      "bom-ref": "maven-spring/pom.xml",
-      "type": "file",
-      "name": "maven-spring/pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/com.example/my-project@0.0.1-SNAPSHOT"
-        }
-      ]
-    },
     {
       "bom-ref": "pkg:cargo/addr2line@0.15.2",
       "type": "library",
@@ -18743,25 +18690,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           }
         ]
       }
-    },
-    {
-      "bom-ref": "pom.xml",
-      "type": "file",
-      "name": "pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/test/foobar"
-        }
-      ]
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "maven-spring/pom.xml",
-      "dependsOn": [
-        "pom.xml"
-      ]
     }
   ]
 }
@@ -18792,17 +18720,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
   },
   "components": [
     {
-      "bom-ref": "maven-spring/pom.xml",
-      "type": "file",
-      "name": "maven-spring/pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/com.example/my-project@0.0.1-SNAPSHOT"
-        }
-      ]
-    },
-    {
       "bom-ref": "pkg:cargo/addr2line@0.15.2",
       "type": "library",
       "name": "addr2line",
@@ -24672,25 +24589,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           }
         ]
       }
-    },
-    {
-      "bom-ref": "pom.xml",
-      "type": "file",
-      "name": "pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/test/foobar"
-        }
-      ]
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "maven-spring/pom.xml",
-      "dependsOn": [
-        "pom.xml"
-      ]
     }
   ]
 }
@@ -24721,17 +24619,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
   },
   "components": [
     {
-      "bom-ref": "maven-spring/pom.xml",
-      "type": "file",
-      "name": "maven-spring/pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/com.example/my-project@0.0.1-SNAPSHOT"
-        }
-      ]
-    },
-    {
       "bom-ref": "pkg:cargo/addr2line@0.15.2",
       "type": "library",
       "name": "addr2line",
@@ -30601,25 +30488,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           }
         ]
       }
-    },
-    {
-      "bom-ref": "pom.xml",
-      "type": "file",
-      "name": "pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/test/foobar"
-        }
-      ]
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "maven-spring/pom.xml",
-      "dependsOn": [
-        "pom.xml"
-      ]
     }
   ]
 }
@@ -30649,28 +30517,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
     }
   },
   "components": [
-    {
-      "bom-ref": "libs/pom.xml",
-      "type": "file",
-      "name": "libs/pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/com.foobar/common@1.0-SNAPSHOT"
-        }
-      ]
-    },
-    {
-      "bom-ref": "other-dir/pom.xml",
-      "type": "file",
-      "name": "other-dir/pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/kafka-commons-client@1.0-SNAPSHOT"
-        }
-      ]
-    },
     {
       "bom-ref": "pkg:maven/com.foobar/common@1.0-SNAPSHOT",
       "type": "library",
@@ -30718,26 +30564,6 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           }
         ]
       }
-    },
-    {
-      "bom-ref": "pom.xml",
-      "type": "file",
-      "name": "pom.xml",
-      "properties": [
-        {
-          "name": "osv-scanner:package",
-          "value": "pkg:maven/integration-tests@1.0-SNAPSHOT"
-        }
-      ]
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "other-dir/pom.xml",
-      "dependsOn": [
-        "libs/pom.xml",
-        "pom.xml"
-      ]
     }
   ]
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,4 +1,5 @@
-// This program demonstrates using the sbomgen library to generate a CycloneDX SBOM.
+// This program demonstrates using the sbomgen library to generate a CycloneDX SBOM
+// and extract build file information from it.
 //
 // Usage:
 //
@@ -6,11 +7,15 @@
 //
 // If no directory is provided, it scans pkg/sbomgen/testdata which contains a
 // sample Cargo.lock fixture.
+//
+// The program prints the generated SBOM JSON, then lists all manifest build files
+// found in the SBOM via GetBuildFileTrees.
 package main
 
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/sbomgen"
 )
@@ -23,9 +28,38 @@ func main() {
 
 	result, err := sbomgen.GenerateSBOM([]string{dir}, sbomgen.DefaultOptions())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error generating SBOM: %v\n", err)
 		os.Exit(1)
 	}
 
 	fmt.Print(string(result))
+
+	// Extract build files from the generated SBOM.
+	buildFiles := sbomgen.GetBuildFileTrees(result)
+
+	fmt.Fprintf(os.Stderr, "\n--- Build Files (%d found) ---\n", len(buildFiles))
+	if len(buildFiles) == 0 {
+		fmt.Fprintln(os.Stderr, "(none)")
+		return
+	}
+
+	// Sort for deterministic output.
+	keys := make([]sbomgen.BuildFile, 0, len(buildFiles))
+	for bf := range buildFiles {
+		keys = append(keys, bf)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].FilePath != keys[j].FilePath {
+			return keys[i].FilePath < keys[j].FilePath
+		}
+		return string(keys[i].FileType) < string(keys[j].FileType)
+	})
+
+	for _, bf := range keys {
+		if bf.RepoPath != "" {
+			fmt.Fprintf(os.Stderr, "  [%s] %s (repo: %s)\n", bf.FileType, bf.FilePath, bf.RepoPath)
+		} else {
+			fmt.Fprintf(os.Stderr, "  [%s] %s\n", bf.FileType, bf.FilePath)
+		}
+	}
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,5 +1,5 @@
 // This program demonstrates using the sbomgen library to generate a CycloneDX SBOM
-// and extract build file information from it.
+// and extract build file dependencies from it.
 //
 // Usage:
 //
@@ -56,10 +56,17 @@ func main() {
 	})
 
 	for _, bf := range keys {
+		rels := buildFiles[bf]
 		if bf.RepoPath != "" {
 			fmt.Fprintf(os.Stderr, "  [%s] %s (repo: %s)\n", bf.FileType, bf.FilePath, bf.RepoPath)
 		} else {
 			fmt.Fprintf(os.Stderr, "  [%s] %s\n", bf.FileType, bf.FilePath)
+		}
+		if rels.ID != "" {
+			fmt.Fprintf(os.Stderr, "    id: %s\n", rels.ID)
+		}
+		for _, dep := range rels.Dependencies {
+			fmt.Fprintf(os.Stderr, "    dep: %s\n", dep.FilePath)
 		}
 	}
 }

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -162,7 +162,7 @@ func buildDatadogProperty(metadataKey string, value string) cyclonedx.Property {
 
 func findArtifact(name string, version string, artifacts []models.ScannedArtifact) *models.ScannedArtifact {
 	for _, artifact := range artifacts {
-		if artifact.Name == name && artifact.Version == version {
+		if artifact.Name == name && (version == "" || artifact.Version == version) {
 			return &artifact
 		}
 	}

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -284,19 +284,22 @@ func addFileDependencies(artifacts []models.ScannedArtifact) (map[string]cyclone
 		}
 
 		component := cyclonedx.Component{}
-		properties := make([]cyclonedx.Property, 1)
 		component.Name = artifact.Filename
 		component.BOMRef = artifact.Filename
 		component.Type = fileComponentType
-		properties[0] = cyclonedx.Property{
-			Name:  "osv-scanner:package",
-			Value: artifactPURL.String(),
+		properties := []cyclonedx.Property{
+			{Name: "osv-scanner:package", Value: artifactPURL.String()},
 		}
-		component.Properties = &properties
-		components[component.BOMRef] = component
-
 		// Computing parent dependency
 		if artifact.DependsOn != nil {
+			// Record the parent POM as an explicit property so consumers can
+			// unambiguously identify the <parent> relationship without confusing
+			// it with ordinary module-dependency edges added by createFileComponents.
+			properties = append(properties, cyclonedx.Property{
+				Name:  mavenParentPomProperty,
+				Value: artifact.DependsOn.Filename,
+			})
+
 			if dependency, ok := dependsOn[artifact.Filename]; ok {
 				dependencies := append(*dependency.Dependencies, artifact.DependsOn.Filename)
 				slices.Sort(dependencies)
@@ -312,6 +315,9 @@ func addFileDependencies(artifacts []models.ScannedArtifact) (map[string]cyclone
 				}
 			}
 		}
+
+		component.Properties = &properties
+		components[component.BOMRef] = component
 	}
 
 	return components, dependsOn

--- a/internal/output/sbom/models.go
+++ b/internal/output/sbom/models.go
@@ -19,6 +19,14 @@ const (
 	fileComponentType    = "file"
 )
 
+const (
+	// mavenParentPomProperty is a CycloneDX component property that records the
+	// path of the parent POM for a Maven file-type component. It unambiguously
+	// identifies the <parent> relationship, as opposed to ordinary module
+	// dependencies that also appear in the bom.Dependencies section.
+	mavenParentPomProperty = "maven:parentPom"
+)
+
 var SeverityMapper = map[models.SeverityType]cyclonedx.ScoringMethod{
 	models.SeverityCVSSV2: cyclonedx.ScoringMethodCVSSv2,
 	models.SeverityCVSSV3: cyclonedx.ScoringMethodCVSSv3,

--- a/pkg/extractor/extract.go
+++ b/pkg/extractor/extract.go
@@ -149,9 +149,10 @@ var ErrExtractorNotFound = errors.New("could not determine extractor")
 // ScanContext is used to pass context to extractors
 // It is passed to extractors to allow them to access the root directory of the scan as well as the reporter
 type ScanContext struct {
-	EnabledParsers map[string]bool
-	RootDir        string
-	Reporter       reporter.Reporter
+	EnabledParsers             map[string]bool
+	RootDir                    string
+	Reporter                   reporter.Reporter
+	ExtractMavenPomArtifactIds bool
 }
 
 func ExtractDeps(f DepFile, context ScanContext) (Lockfile, error) {
@@ -200,10 +201,12 @@ func ExtractDeps(f DepFile, context ScanContext) (Lockfile, error) {
 		return parsedLockfile, err
 	}
 	defer depFile.Close()
-	if e, ok := extractor.(ArtifactExtractor); ok {
-		artifact, err := e.GetArtifact(depFile, context)
-		if err == nil {
-			parsedLockfile.Artifact = artifact
+	if context.ExtractMavenPomArtifactIds {
+		if e, ok := extractor.(ArtifactExtractor); ok {
+			artifact, err := e.GetArtifact(depFile, context)
+			if err == nil {
+				parsedLockfile.Artifact = artifact
+			}
 		}
 	}
 

--- a/pkg/extractor/fixtures/build-gradle/with-group-groovy/build.gradle
+++ b/pkg/extractor/fixtures/build-gradle/with-group-groovy/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+  id 'java-library'
+}
+
+group = 'com.example'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'org.springframework.security:spring-security-crypto:5.7.3'
+}
+
+dependencyLocking {
+  lockAllConfigurations()
+}

--- a/pkg/extractor/fixtures/build-gradle/with-group-groovy/gradle.lockfile
+++ b/pkg/extractor/fixtures/build-gradle/with-group-groovy/gradle.lockfile
@@ -1,0 +1,5 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can mess up your build.
+# This file is expected to be part of source control.
+org.springframework.security:spring-security-crypto:5.7.3=compileClasspath,runtimeClasspath
+empty=

--- a/pkg/extractor/fixtures/build-gradle/with-group-kotlin/build.gradle.kts
+++ b/pkg/extractor/fixtures/build-gradle/with-group-kotlin/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+  `java-library`
+}
+
+group = "com.example"
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation("org.springframework.security:spring-security-crypto:5.7.3")
+}
+
+dependencyLocking {
+  lockAllConfigurations()
+}

--- a/pkg/extractor/fixtures/build-gradle/with-group-kotlin/gradle.lockfile
+++ b/pkg/extractor/fixtures/build-gradle/with-group-kotlin/gradle.lockfile
@@ -1,0 +1,5 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can mess up your build.
+# This file is expected to be part of source control.
+org.springframework.security:spring-security-crypto:5.7.3=compileClasspath,runtimeClasspath
+empty=

--- a/pkg/extractor/java/parse-gradle-lock.go
+++ b/pkg/extractor/java/parse-gradle-lock.go
@@ -3,9 +3,11 @@ package java
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -92,6 +94,59 @@ func (e GradleLockExtractor) Extract(f extractor.DepFile, context extractor.Scan
 	}
 
 	return pkgs, nil
+}
+
+// GetArtifact extracts a ScannedArtifact from a Gradle lockfile by reading the
+// project-level group assignment from the accompanying build.gradle or
+// build.gradle.kts file. The artifact name is "group:projectDirName".
+func (e GradleLockExtractor) GetArtifact(f extractor.DepFile, ctx extractor.ScanContext) (*models.ScannedArtifact, error) {
+	if !ctx.ExtractMavenPomArtifactIds {
+		return nil, nil
+	}
+
+	group, buildFilePath := extractGradleGroup(f)
+	if group == "" {
+		return nil, nil
+	}
+
+	projectName := filepath.Base(filepath.Dir(f.Path()))
+
+	return &models.ScannedArtifact{
+		ArtifactDetail: models.ArtifactDetail{
+			Name:      group + ":" + projectName,
+			Filename:  buildFilePath,
+			Ecosystem: models.EcosystemMaven,
+		},
+	}, nil
+}
+
+// extractGradleGroup reads the project-level group assignment from a
+// build.gradle or build.gradle.kts file adjacent to the lockfile.
+// It matches only top-level "group = 'value'" or 'group = "value"' assignments,
+// NOT dependency kwargs like "group: 'x'" or method calls like "group("x")".
+func extractGradleGroup(f extractor.DepFile) (group string, buildFilePath string) {
+	groupRegex := cachedregexp.MustCompile(`(?m)^[\t ]*group\s*=\s*['"]([^'"]+)['"]`)
+
+	for _, name := range []string{buildGradleFilename, buildGradleKtsFilename} {
+		candidate := filepath.Join(filepath.Dir(f.Path()), name)
+		df, err := f.Open(candidate)
+		if err != nil {
+			continue
+		}
+
+		content, err := io.ReadAll(df)
+		_ = df.Close()
+		if err != nil {
+			continue
+		}
+
+		matches := groupRegex.FindSubmatch(content)
+		if matches != nil {
+			return string(matches[1]), candidate
+		}
+	}
+
+	return "", ""
 }
 
 var GradleExtractor = GradleLockExtractor{

--- a/pkg/extractor/java/parse-gradle-lock_test.go
+++ b/pkg/extractor/java/parse-gradle-lock_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGradleLockExtractor_ShouldExtract(t *testing.T) {
@@ -277,6 +278,81 @@ func TestParseGradleLock_MultiplePackage(t *testing.T) {
 			Ecosystem:      models.EcosystemMaven,
 		},
 	})
+}
+
+func TestGradleLockExtractor_GetArtifact(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name             string
+		fixturePath      string
+		expectNil        bool
+		expectedName     string
+		expectedFilename string // just the basename to check
+	}{
+		{
+			name:             "groovy_with_group",
+			fixturePath:      "../fixtures/build-gradle/with-group-groovy/gradle.lockfile",
+			expectNil:        false,
+			expectedName:     "com.example:with-group-groovy",
+			expectedFilename: "build.gradle",
+		},
+		{
+			name:             "kotlin_with_group",
+			fixturePath:      "../fixtures/build-gradle/with-group-kotlin/gradle.lockfile",
+			expectNil:        false,
+			expectedName:     "com.example:with-group-kotlin",
+			expectedFilename: "build.gradle.kts",
+		},
+		{
+			name:        "no_group",
+			fixturePath: "../fixtures/build-gradle/one-package-groovy/gradle.lockfile",
+			expectNil:   true,
+		},
+		{
+			name:        "missing_build_file",
+			fixturePath: "../fixtures/gradle-lockfile/one-pkg",
+			expectNil:   true,
+		},
+		{
+			name:        "group_in_dependency_kwarg_only",
+			fixturePath: "../fixtures/build-gradle/one-package-kotlin-extended/gradle.lockfile",
+			expectNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			absPath := filepath.FromSlash(filepath.Join(dir, tt.fixturePath))
+			f, err := extractor.OpenLocalDepFile(absPath)
+			if err != nil {
+				t.Fatalf("failed to open fixture %s: %v", tt.fixturePath, err)
+			}
+			defer f.Close()
+
+			ctx := extractor.ScanContext{ExtractMavenPomArtifactIds: true}
+			e := java.GradleLockExtractor{}
+			artifact, err := e.GetArtifact(f, ctx)
+
+			require.NoError(t, err)
+
+			if tt.expectNil {
+				assert.Nil(t, artifact, "expected nil artifact")
+			} else if assert.NotNil(t, artifact, "expected non-nil artifact") {
+				assert.Equal(t, tt.expectedName, artifact.Name)
+				assert.Contains(t, artifact.Filename, tt.expectedFilename)
+				assert.Equal(t, models.EcosystemMaven, artifact.Ecosystem)
+				assert.Nil(t, artifact.DependsOn)
+			}
+		})
+	}
 }
 
 func TestParseGradleLock_WithInvalidLines(t *testing.T) {

--- a/pkg/sbomgen/build_file_processor.go
+++ b/pkg/sbomgen/build_file_processor.go
@@ -1,33 +1,69 @@
 package sbomgen
 
+// BuildFileRelations holds the resolved relationships of a build file.
+//
+// ID is an ecosystem-specific identifier (e.g. Maven "groupId:artifactId").
+// Dependencies lists ALL transitively reachable build files, sorted by
+// FilePath. For Maven, this is the transitive closure walking up the parent
+// chain (parent, grandparent, etc.). For ecosystems without a registered
+// processor the slice is empty.
+type BuildFileRelations struct {
+	// ID is an ecosystem-specific identifier for the build file.
+	// For Maven this is "groupId:artifactId"; for other ecosystems it is empty.
+	ID string
+	// Dependencies lists all transitively reachable build files, sorted by
+	// FilePath.
+	Dependencies []BuildFile
+}
+
+// ProcessorContext carries SBOM-derived data that processors can use for
+// enrichment without needing filesystem access.
+type ProcessorContext struct {
+	// FileDependencies maps each file's path to the paths it directly depends
+	// on, as declared in the SBOM dependencies section.
+	FileDependencies map[string][]string
+
+	// MavenParents maps each Maven child POM path to its parent POM path, as
+	// recorded by the "maven:parentPom" property on file-type components.
+	// This is the authoritative source for <parent> relationships because the
+	// bom.Dependencies section can mix parent edges with ordinary module
+	// dependency edges, making them indistinguishable.
+	MavenParents map[string]string
+
+	// MavenArtifactIDs maps each Maven file path to its "groupId:artifactId"
+	// string, extracted from the "osv-scanner:package" purl property on
+	// file-type components.
+	MavenArtifactIDs map[string]string
+}
+
 // BuildFileProcessor enriches a group of build files of the same FileType.
-// Implementations receive all deduplicated BuildFiles of one type found in
-// the SBOM and return a map of each file to its related build files (e.g.
-// sub-modules, parent POMs).
+// Implementations receive all deduplicated BuildFiles of one type and a
+// ProcessorContext derived from the SBOM, and return a map of each file to
+// its resolved relationships.
 //
 // Processors are registered per FileType via RegisterBuildFileProcessor,
-// typically from an init() function in a sub-package.
+// typically from an init() function.
 type BuildFileProcessor interface {
-	Process(files []BuildFile) map[BuildFile][]BuildFile
+	Process(files []BuildFile, ctx ProcessorContext) map[BuildFile]BuildFileRelations
 }
 
 // processors is the registry of per-FileType processors.
 var processors = map[FileType]BuildFileProcessor{}
 
 // RegisterBuildFileProcessor registers a processor for the given FileType.
-// It is intended to be called from init() functions in processor packages.
+// It is intended to be called from init() functions.
 func RegisterBuildFileProcessor(ft FileType, p BuildFileProcessor) {
 	processors[ft] = p
 }
 
 // noopProcessor is the fallback for FileTypes with no registered processor.
-// It returns each file as a key with an empty children slice.
+// It returns each file with empty relations.
 type noopProcessor struct{}
 
-func (noopProcessor) Process(files []BuildFile) map[BuildFile][]BuildFile {
-	result := make(map[BuildFile][]BuildFile, len(files))
+func (noopProcessor) Process(files []BuildFile, _ ProcessorContext) map[BuildFile]BuildFileRelations {
+	result := make(map[BuildFile]BuildFileRelations, len(files))
 	for _, f := range files {
-		result[f] = []BuildFile{}
+		result[f] = BuildFileRelations{Dependencies: []BuildFile{}}
 	}
 
 	return result

--- a/pkg/sbomgen/build_file_processor.go
+++ b/pkg/sbomgen/build_file_processor.go
@@ -1,0 +1,34 @@
+package sbomgen
+
+// BuildFileProcessor enriches a group of build files of the same FileType.
+// Implementations receive all deduplicated BuildFiles of one type found in
+// the SBOM and return a map of each file to its related build files (e.g.
+// sub-modules, parent POMs).
+//
+// Processors are registered per FileType via RegisterBuildFileProcessor,
+// typically from an init() function in a sub-package.
+type BuildFileProcessor interface {
+	Process(files []BuildFile) map[BuildFile][]BuildFile
+}
+
+// processors is the registry of per-FileType processors.
+var processors = map[FileType]BuildFileProcessor{}
+
+// RegisterBuildFileProcessor registers a processor for the given FileType.
+// It is intended to be called from init() functions in processor packages.
+func RegisterBuildFileProcessor(ft FileType, p BuildFileProcessor) {
+	processors[ft] = p
+}
+
+// noopProcessor is the fallback for FileTypes with no registered processor.
+// It returns each file as a key with an empty children slice.
+type noopProcessor struct{}
+
+func (noopProcessor) Process(files []BuildFile) map[BuildFile][]BuildFile {
+	result := make(map[BuildFile][]BuildFile, len(files))
+	for _, f := range files {
+		result[f] = []BuildFile{}
+	}
+
+	return result
+}

--- a/pkg/sbomgen/build_files.go
+++ b/pkg/sbomgen/build_files.go
@@ -1,0 +1,142 @@
+package sbomgen
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/CycloneDX/cyclonedx-go"
+)
+
+// FileType represents a recognized build/manifest file type.
+type FileType string
+
+const (
+	FileTypePomXML          FileType = "pom.xml"
+	FileTypeCargoToml       FileType = "Cargo.toml"
+	FileTypePackageJSON     FileType = "package.json"
+	FileTypeBuildGradle     FileType = "build.gradle"
+	FileTypeBuildGradleKts  FileType = "build.gradle.kts"
+	FileTypeComposerJSON    FileType = "composer.json"
+	FileTypeGemfile         FileType = "Gemfile"
+	FileTypePackageSwift    FileType = "Package.swift"
+	FileTypePyprojectToml   FileType = "pyproject.toml"
+	FileTypePipfile         FileType = "Pipfile"
+	FileTypeRequirementsTxt FileType = "requirements.txt"
+	FileTypeCsproj          FileType = "*.csproj"
+)
+
+// exactFileTypes maps exact basenames to their FileType.
+// build.gradle.kts is checked before build.gradle to avoid false matches.
+var exactFileTypes = map[string]FileType{
+	"pom.xml":          FileTypePomXML,
+	"Cargo.toml":       FileTypeCargoToml,
+	"package.json":     FileTypePackageJSON,
+	"build.gradle.kts": FileTypeBuildGradleKts,
+	"build.gradle":     FileTypeBuildGradle,
+	"composer.json":    FileTypeComposerJSON,
+	"Gemfile":          FileTypeGemfile,
+	"Package.swift":    FileTypePackageSwift,
+	"pyproject.toml":   FileTypePyprojectToml,
+	"Pipfile":          FileTypePipfile,
+	"requirements.txt": FileTypeRequirementsTxt,
+}
+
+// BuildFile identifies a build/manifest file within a repository.
+type BuildFile struct {
+	FileType FileType
+	FilePath string // relative path within the repo (e.g. "backend/Cargo.toml")
+	RepoPath string // absolute filesystem path of the repo root (empty when not available)
+}
+
+// fileTypeFromBasename returns the FileType for the given filename base,
+// or ("", false) if the filename is not a recognized manifest type.
+func fileTypeFromBasename(basename string) (FileType, bool) {
+	// Check exact matches first.
+	if ft, ok := exactFileTypes[basename]; ok {
+		return ft, true
+	}
+	// Wildcard: *.csproj
+	if strings.HasSuffix(basename, ".csproj") {
+		return FileTypeCsproj, true
+	}
+
+	return "", false
+}
+
+// occurrenceLocation is the subset of models.PackageLocations we need to parse
+// from the SBOM occurrence location JSON string.
+type occurrenceLocation struct {
+	Block struct {
+		FileName string `json:"file_name"`
+		Role     string `json:"role"`
+	} `json:"block"`
+}
+
+// GetBuildFileTrees parses a CycloneDX JSON SBOM and returns a map of all
+// manifest build files found in component evidence occurrences.
+//
+// Each map key is a deduplicated BuildFile. Map values are empty slices
+// (reserved for future transitive dependency tree support).
+//
+// If filters are provided, only BuildFiles whose FileType matches one of
+// the filters are included.
+func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile][]BuildFile {
+	result := make(map[BuildFile][]BuildFile)
+
+	if len(sbom) == 0 {
+		return result
+	}
+
+	var bom cyclonedx.BOM
+	if err := json.Unmarshal(sbom, &bom); err != nil {
+		return result
+	}
+
+	if bom.Components == nil {
+		return result
+	}
+
+	filterSet := make(map[FileType]struct{}, len(filters))
+	for _, f := range filters {
+		filterSet[f] = struct{}{}
+	}
+
+	for _, comp := range *bom.Components {
+		if comp.Evidence == nil || comp.Evidence.Occurrences == nil {
+			continue
+		}
+		for _, occ := range *comp.Evidence.Occurrences {
+			var loc occurrenceLocation
+			if err := json.Unmarshal([]byte(occ.Location), &loc); err != nil {
+				continue
+			}
+
+			if loc.Block.Role == "lockfile" || loc.Block.FileName == "" {
+				continue
+			}
+
+			basename := filepath.Base(loc.Block.FileName)
+			ft, ok := fileTypeFromBasename(basename)
+			if !ok {
+				continue
+			}
+
+			if len(filterSet) > 0 {
+				if _, match := filterSet[ft]; !match {
+					continue
+				}
+			}
+
+			bf := BuildFile{
+				FileType: ft,
+				FilePath: loc.Block.FileName,
+			}
+			if _, exists := result[bf]; !exists {
+				result[bf] = []BuildFile{}
+			}
+		}
+	}
+
+	return result
+}

--- a/pkg/sbomgen/build_files.go
+++ b/pkg/sbomgen/build_files.go
@@ -63,8 +63,14 @@ type occurrenceLocation struct {
 // GetBuildFileTrees parses a CycloneDX JSON SBOM and returns a map of all
 // manifest build files found in component evidence occurrences.
 //
-// Each map key is a deduplicated BuildFile. Map values are empty slices
-// (reserved for future transitive dependency tree support).
+// Build files are grouped by FileType and dispatched to a registered
+// BuildFileProcessor for that type. Each processor receives deduplicated
+// BuildFiles of its type and returns them enriched with their related files
+// (e.g. sub-modules, parent POMs). Results from all processors are merged
+// into the returned map.
+//
+// If no processor is registered for a FileType, a no-op processor is used
+// that returns each file with an empty children slice.
 //
 // If filters are provided, only BuildFiles whose FileType matches one of
 // the filters are included.
@@ -88,6 +94,10 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile][]BuildFi
 	for _, f := range filters {
 		filterSet[f] = struct{}{}
 	}
+
+	// Collect build files grouped by FileType, deduplicating across components.
+	grouped := make(map[FileType][]BuildFile)
+	seen := make(map[BuildFile]struct{})
 
 	for _, comp := range *bom.Components {
 		if comp.Evidence == nil || comp.Evidence.Occurrences == nil {
@@ -115,9 +125,21 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile][]BuildFi
 				FileType: ft,
 				FilePath: loc.Block.FileName,
 			}
-			if _, exists := result[bf]; !exists {
-				result[bf] = []BuildFile{}
+			if _, exists := seen[bf]; !exists {
+				seen[bf] = struct{}{}
+				grouped[ft] = append(grouped[ft], bf)
 			}
+		}
+	}
+
+	// Dispatch each group to its registered processor and merge the results.
+	for ft, files := range grouped {
+		p, ok := processors[ft]
+		if !ok {
+			p = noopProcessor{}
+		}
+		for bf, children := range p.Process(files) {
+			result[bf] = children
 		}
 	}
 

--- a/pkg/sbomgen/build_files.go
+++ b/pkg/sbomgen/build_files.go
@@ -51,6 +51,24 @@ func fileTypeFromBasename(basename string) FileType {
 	return FileType(basename)
 }
 
+// addBuildFile adds a build file identified by filePath to the grouped map if it
+// passes the filterSet check and has not been seen before.
+func addBuildFile(filePath string, filterSet map[FileType]struct{}, seen map[BuildFile]struct{}, grouped map[FileType][]BuildFile) {
+	ft := fileTypeFromBasename(filepath.Base(filePath))
+
+	if len(filterSet) > 0 {
+		if _, match := filterSet[ft]; !match {
+			return
+		}
+	}
+
+	bf := BuildFile{FileType: ft, FilePath: filePath}
+	if _, exists := seen[bf]; !exists {
+		seen[bf] = struct{}{}
+		grouped[ft] = append(grouped[ft], bf)
+	}
+}
+
 // occurrenceLocation is the subset of models.PackageLocations we need to parse
 // from the SBOM occurrence location JSON string.
 type occurrenceLocation struct {
@@ -61,21 +79,22 @@ type occurrenceLocation struct {
 }
 
 // GetBuildFileTrees parses a CycloneDX JSON SBOM and returns a map of all
-// manifest build files found in component evidence occurrences.
+// manifest build files found in component evidence occurrences, each enriched
+// with its resolved relationships (parent, children).
 //
 // Build files are grouped by FileType and dispatched to a registered
 // BuildFileProcessor for that type. Each processor receives deduplicated
-// BuildFiles of its type and returns them enriched with their related files
-// (e.g. sub-modules, parent POMs). Results from all processors are merged
-// into the returned map.
+// BuildFiles of its type and a ProcessorContext derived from the SBOM
+// dependencies section, and returns the files enriched with their
+// relationships. Results from all processors are merged into the returned map.
 //
 // If no processor is registered for a FileType, a no-op processor is used
-// that returns each file with an empty children slice.
+// that returns each file with empty relations.
 //
 // If filters are provided, only BuildFiles whose FileType matches one of
 // the filters are included.
-func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile][]BuildFile {
-	result := make(map[BuildFile][]BuildFile)
+func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile]BuildFileRelations {
+	result := make(map[BuildFile]BuildFileRelations)
 
 	if len(sbom) == 0 {
 		return result
@@ -100,6 +119,14 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile][]BuildFi
 	seen := make(map[BuildFile]struct{})
 
 	for _, comp := range *bom.Components {
+		// File-type components (produced by ExtractMavenPomArtifactIds) represent
+		// build/manifest files directly. Their BOMRef is the filename relative to
+		// the repo root. Collect them so parent POMs with no package occurrences
+		// are never missed.
+		if comp.Type == cyclonedx.ComponentTypeFile && comp.BOMRef != "" {
+			addBuildFile(comp.BOMRef, filterSet, seen, grouped)
+		}
+
 		if comp.Evidence == nil || comp.Evidence.Occurrences == nil {
 			continue
 		}
@@ -113,24 +140,12 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile][]BuildFi
 				continue
 			}
 
-			ft := fileTypeFromBasename(filepath.Base(loc.Block.FileName))
-
-			if len(filterSet) > 0 {
-				if _, match := filterSet[ft]; !match {
-					continue
-				}
-			}
-
-			bf := BuildFile{
-				FileType: ft,
-				FilePath: loc.Block.FileName,
-			}
-			if _, exists := seen[bf]; !exists {
-				seen[bf] = struct{}{}
-				grouped[ft] = append(grouped[ft], bf)
-			}
+			addBuildFile(loc.Block.FileName, filterSet, seen, grouped)
 		}
 	}
+
+	// Build the ProcessorContext from the SBOM dependencies section.
+	ctx := buildProcessorContext(&bom)
 
 	// Dispatch each group to its registered processor and merge the results.
 	for ft, files := range grouped {
@@ -138,10 +153,100 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile][]BuildFi
 		if !ok {
 			p = noopProcessor{}
 		}
-		for bf, children := range p.Process(files) {
-			result[bf] = children
+		for bf, rels := range p.Process(files, ctx) {
+			result[bf] = rels
 		}
 	}
 
 	return result
+}
+
+// mavenParentPomProperty is the CycloneDX component property name that records
+// the parent POM path for a Maven file-type component. It mirrors the constant
+// in internal/output/sbom/models.go; kept here to avoid an internal→pkg import
+// cycle.
+const mavenParentPomProperty = "maven:parentPom"
+
+// osvScannerPackageProperty is the CycloneDX component property name that
+// records the package URL for a file-type component. For Maven components the
+// purl format is "pkg:maven/{groupId}/{artifactId}@{version}".
+const osvScannerPackageProperty = "osv-scanner:package"
+
+// buildProcessorContext extracts enrichment data from the SBOM into a
+// ProcessorContext.
+//
+// MavenParents is populated from the "maven:parentPom" property on file-type
+// components — the authoritative signal for Maven <parent> relationships.
+//
+// FileDependencies is populated from bom.Dependencies for processors that need
+// the raw dependency graph (note: for Maven, this section mixes parent edges
+// with ordinary module-dependency edges and must not be used for parent
+// resolution).
+// parseMavenArtifactID extracts "groupId:artifactId" from a Maven purl.
+// For example, "pkg:maven/com.example/my-module@1.0" yields "com.example:my-module".
+// Returns "" if the purl is not a Maven purl or cannot be parsed.
+func parseMavenArtifactID(purl string) string {
+	const prefix = "pkg:maven/"
+	if !strings.HasPrefix(purl, prefix) {
+		return ""
+	}
+	rest := purl[len(prefix):]
+
+	// Split into groupId/artifactId[@version]
+	slash := strings.IndexByte(rest, '/')
+	if slash < 0 {
+		return ""
+	}
+	groupID := rest[:slash]
+	artifactAndVersion := rest[slash+1:]
+
+	// Strip @version if present.
+	artifactID := artifactAndVersion
+	if at := strings.IndexByte(artifactAndVersion, '@'); at >= 0 {
+		artifactID = artifactAndVersion[:at]
+	}
+
+	if groupID == "" || artifactID == "" {
+		return ""
+	}
+
+	return groupID + ":" + artifactID
+}
+
+func buildProcessorContext(bom *cyclonedx.BOM) ProcessorContext {
+	ctx := ProcessorContext{
+		FileDependencies: make(map[string][]string),
+		MavenParents:     make(map[string]string),
+		MavenArtifactIDs: make(map[string]string),
+	}
+
+	for _, comp := range *bom.Components {
+		if comp.Type != cyclonedx.ComponentTypeFile || comp.Properties == nil {
+			continue
+		}
+		for _, prop := range *comp.Properties {
+			if prop.Name == mavenParentPomProperty && prop.Value != "" {
+				ctx.MavenParents[comp.BOMRef] = prop.Value
+			}
+			if prop.Name == osvScannerPackageProperty && prop.Value != "" {
+				if id := parseMavenArtifactID(prop.Value); id != "" {
+					ctx.MavenArtifactIDs[comp.BOMRef] = id
+				}
+			}
+		}
+	}
+
+	if bom.Dependencies == nil {
+		return ctx
+	}
+
+	for _, dep := range *bom.Dependencies {
+		if dep.Dependencies == nil {
+			continue
+		}
+
+		ctx.FileDependencies[dep.Ref] = *dep.Dependencies
+	}
+
+	return ctx
 }

--- a/pkg/sbomgen/build_files.go
+++ b/pkg/sbomgen/build_files.go
@@ -26,22 +26,6 @@ const (
 	FileTypeCsproj          FileType = "*.csproj"
 )
 
-// exactFileTypes maps exact basenames to their FileType.
-// build.gradle.kts is checked before build.gradle to avoid false matches.
-var exactFileTypes = map[string]FileType{
-	"pom.xml":          FileTypePomXML,
-	"Cargo.toml":       FileTypeCargoToml,
-	"package.json":     FileTypePackageJSON,
-	"build.gradle.kts": FileTypeBuildGradleKts,
-	"build.gradle":     FileTypeBuildGradle,
-	"composer.json":    FileTypeComposerJSON,
-	"Gemfile":          FileTypeGemfile,
-	"Package.swift":    FileTypePackageSwift,
-	"pyproject.toml":   FileTypePyprojectToml,
-	"Pipfile":          FileTypePipfile,
-	"requirements.txt": FileTypeRequirementsTxt,
-}
-
 // BuildFile identifies a build/manifest file within a repository.
 type BuildFile struct {
 	FileType FileType
@@ -49,19 +33,22 @@ type BuildFile struct {
 	RepoPath string // absolute filesystem path of the repo root (empty when not available)
 }
 
-// fileTypeFromBasename returns the FileType for the given filename base,
-// or ("", false) if the filename is not a recognized manifest type.
-func fileTypeFromBasename(basename string) (FileType, bool) {
-	// Check exact matches first.
-	if ft, ok := exactFileTypes[basename]; ok {
-		return ft, true
-	}
-	// Wildcard: *.csproj
+// fileTypeFromBasename returns the FileType for the given filename basename.
+// For most files it is derived directly from the name (e.g. "Cargo.toml").
+// Dynamic-name types with a known suffix or prefix pattern are normalised to
+// their corresponding constant so callers can filter by FileType reliably:
+//   - "*.csproj"            → FileTypeCsproj
+//   - "requirements*.txt"   → FileTypeRequirementsTxt
+func fileTypeFromBasename(basename string) FileType {
 	if strings.HasSuffix(basename, ".csproj") {
-		return FileTypeCsproj, true
+		return FileTypeCsproj
 	}
 
-	return "", false
+	if strings.HasPrefix(basename, "requirements") && strings.HasSuffix(basename, ".txt") {
+		return FileTypeRequirementsTxt
+	}
+
+	return FileType(basename)
 }
 
 // occurrenceLocation is the subset of models.PackageLocations we need to parse
@@ -112,15 +99,11 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile][]BuildFi
 				continue
 			}
 
-			if loc.Block.Role == "lockfile" || loc.Block.FileName == "" {
+			if loc.Block.Role != "manifest" || loc.Block.FileName == "" {
 				continue
 			}
 
-			basename := filepath.Base(loc.Block.FileName)
-			ft, ok := fileTypeFromBasename(basename)
-			if !ok {
-				continue
-			}
+			ft := fileTypeFromBasename(filepath.Base(loc.Block.FileName))
 
 			if len(filterSet) > 0 {
 				if _, match := filterSet[ft]; !match {

--- a/pkg/sbomgen/build_files_test.go
+++ b/pkg/sbomgen/build_files_test.go
@@ -349,3 +349,53 @@ func TestGetBuildFileTrees_UnknownManifestIncluded(t *testing.T) {
 		t.Errorf("expected unknown manifest type to be included, got: %v", result)
 	}
 }
+
+// stubbedProcessor is a BuildFileProcessor that records received files and
+// returns them with a fixed sentinel child for easy assertion in tests.
+type stubbedProcessor struct {
+	received []BuildFile
+	child    BuildFile
+}
+
+func (p *stubbedProcessor) Process(files []BuildFile) map[BuildFile][]BuildFile {
+	p.received = append(p.received, files...)
+	result := make(map[BuildFile][]BuildFile, len(files))
+	for _, f := range files {
+		result[f] = []BuildFile{p.child}
+	}
+
+	return result
+}
+
+//nolint:paralleltest // mutates the global processors registry; cannot run in parallel
+func TestGetBuildFileTrees_RegisteredProcessorIsCalled(t *testing.T) {
+	sentinel := BuildFile{FileType: FileType("sentinel"), FilePath: "sentinel"}
+	stub := &stubbedProcessor{child: sentinel}
+
+	const testType FileType = "test-manifest.xyz"
+	RegisterBuildFileProcessor(testType, stub)
+	defer delete(processors, testType)
+
+	comp := componentWithOccurrences("pkg", "1.0.0",
+		makeLocation("test-manifest.xyz", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp})
+
+	result := GetBuildFileTrees(sbom)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+
+	expected := BuildFile{FileType: testType, FilePath: "test-manifest.xyz"}
+	children, ok := result[expected]
+	if !ok {
+		t.Fatalf("expected key %+v not found", expected)
+	}
+	if len(children) != 1 || children[0] != sentinel {
+		t.Errorf("expected sentinel child, got %v", children)
+	}
+	if len(stub.received) != 1 || stub.received[0] != expected {
+		t.Errorf("processor received unexpected files: %v", stub.received)
+	}
+}

--- a/pkg/sbomgen/build_files_test.go
+++ b/pkg/sbomgen/build_files_test.go
@@ -92,15 +92,15 @@ func TestGetBuildFileTrees_ManifestOnly(t *testing.T) {
 		FileType: FileTypeCargoToml,
 		FilePath: "Cargo.toml",
 	}
-	val, ok := result[expected]
+	rel, ok := result[expected]
 	if !ok {
 		t.Fatalf("expected key %+v not found in result: %v", expected, result)
 	}
-	if val == nil {
-		t.Error("expected non-nil empty slice, got nil")
+	if rel.Dependencies == nil {
+		t.Error("expected non-nil Dependencies slice, got nil")
 	}
-	if len(val) != 0 {
-		t.Errorf("expected empty children slice, got %v", val)
+	if len(rel.Dependencies) != 0 {
+		t.Errorf("expected empty Dependencies slice, got %v", rel.Dependencies)
 	}
 }
 
@@ -163,12 +163,12 @@ func TestGetBuildFileTrees_NoFilter(t *testing.T) {
 		{FileType: FileTypeCargoToml, FilePath: "Cargo.toml"},
 		{FileType: FileTypePackageJSON, FilePath: "package.json"},
 	} {
-		val, ok := result[expected]
+		rel, ok := result[expected]
 		if !ok {
 			t.Errorf("expected key %+v not found", expected)
 		}
-		if val == nil {
-			t.Errorf("expected non-nil slice for %+v", expected)
+		if rel.Dependencies == nil {
+			t.Errorf("expected non-nil Dependencies slice for %+v", expected)
 		}
 	}
 }
@@ -350,6 +350,53 @@ func TestGetBuildFileTrees_UnknownManifestIncluded(t *testing.T) {
 	}
 }
 
+// fileTypeComponent creates a CycloneDX component of type "file" with the given
+// BOMRef/Name, as produced by ExtractMavenPomArtifactIds for manifest files.
+func fileTypeComponent(filename string) cyclonedx.Component {
+	return cyclonedx.Component{
+		Type:   cyclonedx.ComponentTypeFile,
+		BOMRef: filename,
+		Name:   filename,
+	}
+}
+
+func TestGetBuildFileTrees_FileTypeComponentCollected(t *testing.T) {
+	t.Parallel()
+
+	// A file-type component with no evidence occurrences (e.g. a parent POM that
+	// declares no dependencies and never appears in package occurrence locations).
+	comp := fileTypeComponent("pom.xml")
+	sbom := makeSBOM([]cyclonedx.Component{comp})
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 build file from file-type component, got %d: %v", len(result), result)
+	}
+	expected := BuildFile{FileType: FileTypePomXML, FilePath: "pom.xml"}
+	if _, ok := result[expected]; !ok {
+		t.Errorf("expected key %+v not found in result: %v", expected, result)
+	}
+}
+
+func TestGetBuildFileTrees_FileTypeComponentDeduplicatedWithOccurrence(t *testing.T) {
+	t.Parallel()
+
+	// When the same file appears both as a file-type component and in an
+	// occurrence of a package component, it must be deduplicated to one entry.
+	fileComp := fileTypeComponent("pom.xml")
+	pkgComp := componentWithOccurrences("com.example:child", "1.0.0",
+		makeLocation("pom.xml", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{fileComp, pkgComp})
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 deduplicated entry, got %d: %v", len(result), result)
+	}
+}
+
 // stubbedProcessor is a BuildFileProcessor that records received files and
 // returns them with a fixed sentinel child for easy assertion in tests.
 type stubbedProcessor struct {
@@ -357,11 +404,11 @@ type stubbedProcessor struct {
 	child    BuildFile
 }
 
-func (p *stubbedProcessor) Process(files []BuildFile) map[BuildFile][]BuildFile {
+func (p *stubbedProcessor) Process(files []BuildFile, _ ProcessorContext) map[BuildFile]BuildFileRelations {
 	p.received = append(p.received, files...)
-	result := make(map[BuildFile][]BuildFile, len(files))
+	result := make(map[BuildFile]BuildFileRelations, len(files))
 	for _, f := range files {
-		result[f] = []BuildFile{p.child}
+		result[f] = BuildFileRelations{Dependencies: []BuildFile{p.child}}
 	}
 
 	return result
@@ -388,12 +435,12 @@ func TestGetBuildFileTrees_RegisteredProcessorIsCalled(t *testing.T) {
 	}
 
 	expected := BuildFile{FileType: testType, FilePath: "test-manifest.xyz"}
-	children, ok := result[expected]
+	rel, ok := result[expected]
 	if !ok {
 		t.Fatalf("expected key %+v not found", expected)
 	}
-	if len(children) != 1 || children[0] != sentinel {
-		t.Errorf("expected sentinel child, got %v", children)
+	if len(rel.Dependencies) != 1 || rel.Dependencies[0] != sentinel {
+		t.Errorf("expected sentinel dependency, got %v", rel.Dependencies)
 	}
 	if len(stub.received) != 1 || stub.received[0] != expected {
 		t.Errorf("processor received unexpected files: %v", stub.received)

--- a/pkg/sbomgen/build_files_test.go
+++ b/pkg/sbomgen/build_files_test.go
@@ -218,40 +218,41 @@ func TestGetBuildFileTrees_EmptySBOM(t *testing.T) {
 	}
 }
 
-func TestDefaultFileTypeFromFilename(t *testing.T) {
+func TestFileTypeFromBasename(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		filename string
 		expected FileType
-		found    bool
 	}{
-		{"Cargo.toml", FileTypeCargoToml, true},
-		{"package.json", FileTypePackageJSON, true},
-		{"pom.xml", FileTypePomXML, true},
-		{"build.gradle", FileTypeBuildGradle, true},
-		{"build.gradle.kts", FileTypeBuildGradleKts, true},
-		{"composer.json", FileTypeComposerJSON, true},
-		{"Gemfile", FileTypeGemfile, true},
-		{"Package.swift", FileTypePackageSwift, true},
-		{"pyproject.toml", FileTypePyprojectToml, true},
-		{"Pipfile", FileTypePipfile, true},
-		{"requirements.txt", FileTypeRequirementsTxt, true},
-		{"myapp.csproj", FileTypeCsproj, true},
-		{"Some.Other.csproj", FileTypeCsproj, true},
-		// Unknown files
-		{"unknown.txt", "", false},
-		{"Cargo.lock", "", false},
-		{"yarn.lock", "", false},
+		// Known exact types: FileType is the basename itself.
+		{"Cargo.toml", FileTypeCargoToml},
+		{"package.json", FileTypePackageJSON},
+		{"pom.xml", FileTypePomXML},
+		{"build.gradle", FileTypeBuildGradle},
+		{"build.gradle.kts", FileTypeBuildGradleKts},
+		{"composer.json", FileTypeComposerJSON},
+		{"Gemfile", FileTypeGemfile},
+		{"Package.swift", FileTypePackageSwift},
+		{"pyproject.toml", FileTypePyprojectToml},
+		{"Pipfile", FileTypePipfile},
+		{"requirements.txt", FileTypeRequirementsTxt},
+		// Dynamic suffix types: normalised to their constant.
+		{"myapp.csproj", FileTypeCsproj},
+		{"Some.Other.csproj", FileTypeCsproj},
+		// requirements variants: normalised to FileTypeRequirementsTxt.
+		{"requirements-dev.txt", FileTypeRequirementsTxt},
+		{"requirements-test.txt", FileTypeRequirementsTxt},
+		{"requirements_prod.txt", FileTypeRequirementsTxt},
+		// Unknown files: returned as-is.
+		{"unknown.txt", FileType("unknown.txt")},
+		{"Cargo.lock", FileType("Cargo.lock")},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.filename, func(t *testing.T) {
 			t.Parallel()
-			ft, ok := fileTypeFromBasename(tt.filename)
-			if ok != tt.found {
-				t.Errorf("fileTypeFromBasename(%q) found=%v, want %v", tt.filename, ok, tt.found)
-			}
+			ft := fileTypeFromBasename(tt.filename)
 			if ft != tt.expected {
 				t.Errorf("fileTypeFromBasename(%q) = %q, want %q", tt.filename, ft, tt.expected)
 			}
@@ -295,9 +296,47 @@ func TestGetBuildFileTrees_CsprojWildcard(t *testing.T) {
 	}
 }
 
-func TestGetBuildFileTrees_UnknownManifestIgnored(t *testing.T) {
+func TestGetBuildFileTrees_RequirementsVariantsNormalized(t *testing.T) {
 	t.Parallel()
 
+	// requirements-dev.txt and requirements-test.txt are valid manifests
+	// produced by RequirementsTxtExtractor; they must be reachable via the
+	// FileTypeRequirementsTxt filter, not silently excluded.
+	comp1 := componentWithOccurrences("requests", "2.31.0",
+		makeLocation("requirements-dev.txt", "manifest"),
+	)
+	comp2 := componentWithOccurrences("pytest", "7.0.0",
+		makeLocation("requirements-test.txt", "manifest"),
+	)
+	comp3 := componentWithOccurrences("flask", "3.0.0",
+		makeLocation("requirements.txt", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp1, comp2, comp3})
+
+	// Unfiltered: all three collapse to FileTypeRequirementsTxt.
+	result := GetBuildFileTrees(sbom)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %v", len(result), result)
+	}
+	for _, path := range []string{"requirements-dev.txt", "requirements-test.txt", "requirements.txt"} {
+		bf := BuildFile{FileType: FileTypeRequirementsTxt, FilePath: path}
+		if _, ok := result[bf]; !ok {
+			t.Errorf("expected key %+v not found in result: %v", bf, result)
+		}
+	}
+
+	// Filtered: all three are returned when filtering by FileTypeRequirementsTxt.
+	filtered := GetBuildFileTrees(sbom, FileTypeRequirementsTxt)
+	if len(filtered) != 3 {
+		t.Fatalf("filtered: expected 3 entries, got %d: %v", len(filtered), filtered)
+	}
+}
+
+func TestGetBuildFileTrees_UnknownManifestIncluded(t *testing.T) {
+	t.Parallel()
+
+	// Any file the SBOM marks as role=manifest is included, even if its type
+	// is not one of the known FileType constants. The FileType is the basename.
 	comp := componentWithOccurrences("something", "1.0.0",
 		makeLocation("unknown-manifest.xyz", "manifest"),
 	)
@@ -305,7 +344,8 @@ func TestGetBuildFileTrees_UnknownManifestIgnored(t *testing.T) {
 
 	result := GetBuildFileTrees(sbom)
 
-	if len(result) != 0 {
-		t.Errorf("expected empty map for unknown manifest type, got %v", result)
+	expected := BuildFile{FileType: FileType("unknown-manifest.xyz"), FilePath: "unknown-manifest.xyz"}
+	if _, ok := result[expected]; !ok {
+		t.Errorf("expected unknown manifest type to be included, got: %v", result)
 	}
 }

--- a/pkg/sbomgen/build_files_test.go
+++ b/pkg/sbomgen/build_files_test.go
@@ -1,0 +1,311 @@
+package sbomgen
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+)
+
+// locationBlock mirrors the JSON shape written by models.PackageLocations.
+type locationBlock struct {
+	FileName    string `json:"file_name"`
+	LineStart   int    `json:"line_start"`
+	LineEnd     int    `json:"line_end"`
+	ColumnStart int    `json:"column_start"`
+	ColumnEnd   int    `json:"column_end"`
+	Role        string `json:"role"`
+}
+
+type locationWrapper struct {
+	Block locationBlock `json:"block"`
+}
+
+// makeLocation builds a CycloneDX occurrence location JSON string
+// matching the format produced by models.PackageLocations.MarshalToJSONString.
+func makeLocation(fileName, role string) string {
+	loc := locationWrapper{
+		Block: locationBlock{
+			FileName:    fileName,
+			LineStart:   1,
+			LineEnd:     1,
+			ColumnStart: 1,
+			ColumnEnd:   1,
+			Role:        role,
+		},
+	}
+	b, err := json.Marshal(loc)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(b)
+}
+
+// makeSBOM builds minimal CycloneDX JSON bytes from a list of components.
+func makeSBOM(components []cyclonedx.Component) []byte {
+	bom := cyclonedx.BOM{
+		BOMFormat:   "CycloneDX",
+		SpecVersion: cyclonedx.SpecVersion1_5,
+		Components:  &components,
+	}
+	b, err := json.Marshal(bom)
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+// componentWithOccurrences creates a component with evidence occurrences.
+func componentWithOccurrences(name, version string, locations ...string) cyclonedx.Component {
+	occs := make([]cyclonedx.EvidenceOccurrence, len(locations))
+	for i, loc := range locations {
+		occs[i] = cyclonedx.EvidenceOccurrence{Location: loc}
+	}
+
+	return cyclonedx.Component{
+		Name:    name,
+		Version: version,
+		Evidence: &cyclonedx.Evidence{
+			Occurrences: &occs,
+		},
+	}
+}
+
+func TestGetBuildFileTrees_ManifestOnly(t *testing.T) {
+	t.Parallel()
+
+	comp := componentWithOccurrences("serde", "1.0.0",
+		makeLocation("Cargo.toml", "manifest"),
+		makeLocation("Cargo.lock", "lockfile"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp})
+
+	result := GetBuildFileTrees(sbom)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 build file, got %d: %v", len(result), result)
+	}
+
+	expected := BuildFile{
+		FileType: FileTypeCargoToml,
+		FilePath: "Cargo.toml",
+	}
+	val, ok := result[expected]
+	if !ok {
+		t.Fatalf("expected key %+v not found in result: %v", expected, result)
+	}
+	if val == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
+	if len(val) != 0 {
+		t.Errorf("expected empty children slice, got %v", val)
+	}
+}
+
+func TestGetBuildFileTrees_OnlyLockfiles(t *testing.T) {
+	t.Parallel()
+
+	comp := componentWithOccurrences("serde", "1.0.0",
+		makeLocation("Cargo.lock", "lockfile"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp})
+
+	result := GetBuildFileTrees(sbom)
+
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %v", result)
+	}
+}
+
+func TestGetBuildFileTrees_FilterByType(t *testing.T) {
+	t.Parallel()
+
+	comp1 := componentWithOccurrences("serde", "1.0.0",
+		makeLocation("Cargo.toml", "manifest"),
+	)
+	comp2 := componentWithOccurrences("lodash", "4.0.0",
+		makeLocation("package.json", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp1, comp2})
+
+	result := GetBuildFileTrees(sbom, FileTypeCargoToml)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 build file after filter, got %d: %v", len(result), result)
+	}
+
+	expected := BuildFile{FileType: FileTypeCargoToml, FilePath: "Cargo.toml"}
+	if _, ok := result[expected]; !ok {
+		t.Errorf("expected Cargo.toml key, got: %v", result)
+	}
+}
+
+func TestGetBuildFileTrees_NoFilter(t *testing.T) {
+	t.Parallel()
+
+	comp1 := componentWithOccurrences("serde", "1.0.0",
+		makeLocation("Cargo.toml", "manifest"),
+	)
+	comp2 := componentWithOccurrences("lodash", "4.0.0",
+		makeLocation("package.json", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp1, comp2})
+
+	result := GetBuildFileTrees(sbom)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 build files, got %d: %v", len(result), result)
+	}
+
+	for _, expected := range []BuildFile{
+		{FileType: FileTypeCargoToml, FilePath: "Cargo.toml"},
+		{FileType: FileTypePackageJSON, FilePath: "package.json"},
+	} {
+		val, ok := result[expected]
+		if !ok {
+			t.Errorf("expected key %+v not found", expected)
+		}
+		if val == nil {
+			t.Errorf("expected non-nil slice for %+v", expected)
+		}
+	}
+}
+
+func TestGetBuildFileTrees_Deduplication(t *testing.T) {
+	t.Parallel()
+
+	// Two different components reference the same Cargo.toml manifest
+	comp1 := componentWithOccurrences("serde", "1.0.0",
+		makeLocation("Cargo.toml", "manifest"),
+	)
+	comp2 := componentWithOccurrences("tokio", "1.0.0",
+		makeLocation("Cargo.toml", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp1, comp2})
+
+	result := GetBuildFileTrees(sbom)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 deduplicated build file, got %d: %v", len(result), result)
+	}
+}
+
+func TestGetBuildFileTrees_EmptySBOM(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{"nil input", nil},
+		{"empty bytes", []byte{}},
+		{"empty JSON object", []byte("{}")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := GetBuildFileTrees(tt.input)
+			if result == nil {
+				t.Error("expected non-nil empty map, got nil")
+			}
+			if len(result) != 0 {
+				t.Errorf("expected empty map, got %v", result)
+			}
+		})
+	}
+}
+
+func TestDefaultFileTypeFromFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		expected FileType
+		found    bool
+	}{
+		{"Cargo.toml", FileTypeCargoToml, true},
+		{"package.json", FileTypePackageJSON, true},
+		{"pom.xml", FileTypePomXML, true},
+		{"build.gradle", FileTypeBuildGradle, true},
+		{"build.gradle.kts", FileTypeBuildGradleKts, true},
+		{"composer.json", FileTypeComposerJSON, true},
+		{"Gemfile", FileTypeGemfile, true},
+		{"Package.swift", FileTypePackageSwift, true},
+		{"pyproject.toml", FileTypePyprojectToml, true},
+		{"Pipfile", FileTypePipfile, true},
+		{"requirements.txt", FileTypeRequirementsTxt, true},
+		{"myapp.csproj", FileTypeCsproj, true},
+		{"Some.Other.csproj", FileTypeCsproj, true},
+		// Unknown files
+		{"unknown.txt", "", false},
+		{"Cargo.lock", "", false},
+		{"yarn.lock", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			t.Parallel()
+			ft, ok := fileTypeFromBasename(tt.filename)
+			if ok != tt.found {
+				t.Errorf("fileTypeFromBasename(%q) found=%v, want %v", tt.filename, ok, tt.found)
+			}
+			if ft != tt.expected {
+				t.Errorf("fileTypeFromBasename(%q) = %q, want %q", tt.filename, ft, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetBuildFileTrees_SubdirectoryPaths(t *testing.T) {
+	t.Parallel()
+
+	comp := componentWithOccurrences("serde", "1.0.0",
+		makeLocation("backend/Cargo.toml", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp})
+
+	result := GetBuildFileTrees(sbom)
+
+	expected := BuildFile{FileType: FileTypeCargoToml, FilePath: "backend/Cargo.toml"}
+	if _, ok := result[expected]; !ok {
+		t.Errorf("expected key with subdirectory path, got: %v", result)
+	}
+}
+
+func TestGetBuildFileTrees_CsprojWildcard(t *testing.T) {
+	t.Parallel()
+
+	comp := componentWithOccurrences("Newtonsoft.Json", "13.0.0",
+		makeLocation("src/MyApp.csproj", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp})
+
+	result := GetBuildFileTrees(sbom, FileTypeCsproj)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 csproj build file, got %d: %v", len(result), result)
+	}
+
+	expected := BuildFile{FileType: FileTypeCsproj, FilePath: "src/MyApp.csproj"}
+	if _, ok := result[expected]; !ok {
+		t.Errorf("expected csproj key, got: %v", result)
+	}
+}
+
+func TestGetBuildFileTrees_UnknownManifestIgnored(t *testing.T) {
+	t.Parallel()
+
+	comp := componentWithOccurrences("something", "1.0.0",
+		makeLocation("unknown-manifest.xyz", "manifest"),
+	)
+	sbom := makeSBOM([]cyclonedx.Component{comp})
+
+	result := GetBuildFileTrees(sbom)
+
+	if len(result) != 0 {
+		t.Errorf("expected empty map for unknown manifest type, got %v", result)
+	}
+}

--- a/pkg/sbomgen/gradle_processor.go
+++ b/pkg/sbomgen/gradle_processor.go
@@ -1,0 +1,27 @@
+package sbomgen
+
+// GradleProcessor populates the ID field for build.gradle and build.gradle.kts
+// BuildFiles from the osv-scanner:package property emitted by GetArtifact.
+// Dependencies is always empty (no inter-project hierarchy for Gradle).
+type GradleProcessor struct{}
+
+// Process returns each file with its ID from the ProcessorContext and empty
+// Dependencies. Gradle projects do not have a parent-child hierarchy like Maven
+// modules, so the dependency slice is always empty.
+func (p *GradleProcessor) Process(files []BuildFile, ctx ProcessorContext) map[BuildFile]BuildFileRelations {
+	result := make(map[BuildFile]BuildFileRelations, len(files))
+	for _, f := range files {
+		result[f] = BuildFileRelations{
+			ID:           ctx.MavenArtifactIDs[f.FilePath],
+			Dependencies: []BuildFile{},
+		}
+	}
+
+	return result
+}
+
+//nolint:gochecknoinits
+func init() {
+	RegisterBuildFileProcessor(FileTypeBuildGradle, &GradleProcessor{})
+	RegisterBuildFileProcessor(FileTypeBuildGradleKts, &GradleProcessor{})
+}

--- a/pkg/sbomgen/gradle_processor_test.go
+++ b/pkg/sbomgen/gradle_processor_test.go
@@ -1,0 +1,174 @@
+package sbomgen
+
+import (
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+)
+
+// gradleFileComponent creates a file-type CycloneDX component representing a
+// build.gradle or build.gradle.kts, as produced by GetArtifact on the Gradle
+// extractor. The osv-scanner:package property encodes the group:artifact as a
+// Maven purl so that buildProcessorContext populates MavenArtifactIDs.
+func gradleFileComponent(buildFilePath, groupArtifact string) cyclonedx.Component {
+	props := []cyclonedx.Property{
+		{Name: osvScannerPackageProperty, Value: "pkg:maven/" + groupArtifact + "@1.0"},
+	}
+
+	return cyclonedx.Component{
+		Type:       cyclonedx.ComponentTypeFile,
+		BOMRef:     buildFilePath,
+		Name:       buildFilePath,
+		Properties: &props,
+	}
+}
+
+// gradleComponent builds a CycloneDX component with a manifest occurrence for
+// the given build.gradle path, as the SBOM generator would emit it.
+func gradleComponent(name, buildFilePath string) cyclonedx.Component {
+	return componentWithOccurrences(name, "1.0.0", makeLocation(buildFilePath, "manifest"))
+}
+
+// gradleFile is a shorthand for a build.gradle BuildFile with no RepoPath.
+func gradleFile(path string) BuildFile {
+	return BuildFile{FileType: FileTypeBuildGradle, FilePath: path}
+}
+
+// gradleKtsFile is a shorthand for a build.gradle.kts BuildFile with no RepoPath.
+func gradleKtsFile(path string) BuildFile {
+	return BuildFile{FileType: FileTypeBuildGradleKts, FilePath: path}
+}
+
+// TestGradleProcessor_BuildGradle_IDPopulated verifies that a build.gradle
+// with a group property gets its ID populated from the osv-scanner:package purl.
+func TestGradleProcessor_BuildGradle_IDPopulated(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOM([]cyclonedx.Component{
+		gradleFileComponent("build.gradle", "com.example/myproject"),
+		gradleComponent("org.springframework:spring-core", "build.gradle"),
+	})
+
+	result := GetBuildFileTrees(sbom, FileTypeBuildGradle)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+
+	rel := result[gradleFile("build.gradle")]
+	if rel.ID != "com.example:myproject" {
+		t.Errorf("expected ID=com.example:myproject, got %q", rel.ID)
+	}
+	if len(rel.Dependencies) != 0 {
+		t.Errorf("expected no Dependencies, got %v", rel.Dependencies)
+	}
+}
+
+// TestGradleProcessor_BuildGradleKts_IDPopulated verifies that a
+// build.gradle.kts with a group property gets its ID populated.
+func TestGradleProcessor_BuildGradleKts_IDPopulated(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOM([]cyclonedx.Component{
+		gradleFileComponent("build.gradle.kts", "com.example/myproject"),
+		gradleComponent("org.springframework:spring-core", "build.gradle.kts"),
+	})
+
+	result := GetBuildFileTrees(sbom, FileTypeBuildGradleKts)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+
+	rel := result[gradleKtsFile("build.gradle.kts")]
+	if rel.ID != "com.example:myproject" {
+		t.Errorf("expected ID=com.example:myproject, got %q", rel.ID)
+	}
+	if len(rel.Dependencies) != 0 {
+		t.Errorf("expected no Dependencies, got %v", rel.Dependencies)
+	}
+}
+
+// TestGradleProcessor_NoID_EmptyString verifies that a file-type component
+// without osv-scanner:package results in an empty ID.
+func TestGradleProcessor_NoID_EmptyString(t *testing.T) {
+	t.Parallel()
+
+	// File component with no properties at all
+	comp := cyclonedx.Component{
+		Type:   cyclonedx.ComponentTypeFile,
+		BOMRef: "build.gradle",
+		Name:   "build.gradle",
+	}
+	sbom := makeSBOM([]cyclonedx.Component{comp})
+
+	result := GetBuildFileTrees(sbom, FileTypeBuildGradle)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+
+	rel := result[gradleFile("build.gradle")]
+	if rel.ID != "" {
+		t.Errorf("expected empty ID, got %q", rel.ID)
+	}
+}
+
+// TestGradleProcessor_Dependencies_AlwaysEmpty verifies that Gradle processor
+// always returns empty Dependencies (no inter-project hierarchy).
+func TestGradleProcessor_Dependencies_AlwaysEmpty(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOM([]cyclonedx.Component{
+		gradleFileComponent("build.gradle", "com.example/root"),
+		gradleFileComponent("module-a/build.gradle", "com.example/module-a"),
+		gradleComponent("com.example:root", "build.gradle"),
+		gradleComponent("com.example:module-a", "module-a/build.gradle"),
+	})
+
+	result := GetBuildFileTrees(sbom, FileTypeBuildGradle)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(result), result)
+	}
+
+	for bf, rel := range result {
+		if len(rel.Dependencies) != 0 {
+			t.Errorf("%s: expected empty Dependencies, got %v", bf.FilePath, rel.Dependencies)
+		}
+	}
+}
+
+// TestGradleProcessor_BothFileTypesRegistered verifies that GetBuildFileTrees
+// returns entries for both build.gradle and build.gradle.kts when present.
+func TestGradleProcessor_BothFileTypesRegistered(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOM([]cyclonedx.Component{
+		gradleFileComponent("app/build.gradle", "com.example/app"),
+		gradleFileComponent("lib/build.gradle.kts", "com.example/lib"),
+		gradleComponent("com.example:dep-a", "app/build.gradle"),
+		gradleComponent("com.example:dep-b", "lib/build.gradle.kts"),
+	})
+
+	result := GetBuildFileTrees(sbom)
+
+	expectedGradle := BuildFile{FileType: FileTypeBuildGradle, FilePath: "app/build.gradle"}
+	expectedKts := BuildFile{FileType: FileTypeBuildGradleKts, FilePath: "lib/build.gradle.kts"}
+
+	if _, ok := result[expectedGradle]; !ok {
+		t.Errorf("expected build.gradle entry, got: %v", result)
+	}
+	if _, ok := result[expectedKts]; !ok {
+		t.Errorf("expected build.gradle.kts entry, got: %v", result)
+	}
+
+	relGradle := result[expectedGradle]
+	if relGradle.ID != "com.example:app" {
+		t.Errorf("build.gradle: expected ID=com.example:app, got %q", relGradle.ID)
+	}
+	relKts := result[expectedKts]
+	if relKts.ID != "com.example:lib" {
+		t.Errorf("build.gradle.kts: expected ID=com.example:lib, got %q", relKts.ID)
+	}
+}

--- a/pkg/sbomgen/maven_processor.go
+++ b/pkg/sbomgen/maven_processor.go
@@ -1,0 +1,71 @@
+package sbomgen
+
+import "sort"
+
+// MavenProcessor enriches pom.xml BuildFiles with transitive dependencies and
+// ecosystem-specific IDs derived from the SBOM.
+//
+// ProcessorContext.FileDependencies contains all direct dependency edges for
+// each POM — both <parent> relationships (from addFileDependencies) and
+// local-module <dependency> relationships (from createFileComponents). The
+// processor computes the full transitive closure via BFS over this graph,
+// restricted to build files present in the SBOM.
+//
+// The ID field is populated with "groupId:artifactId" from the
+// "osv-scanner:package" purl property via ProcessorContext.MavenArtifactIDs.
+type MavenProcessor struct{}
+
+// Process resolves transitive dependencies and IDs for a set of pom.xml BuildFiles.
+func (p *MavenProcessor) Process(files []BuildFile, ctx ProcessorContext) map[BuildFile]BuildFileRelations {
+	// Index files by path for O(1) lookup.
+	filesByPath := make(map[string]BuildFile, len(files))
+	for _, f := range files {
+		filesByPath[f.FilePath] = f
+	}
+
+	// Build the result map with full transitive closure via BFS for each file.
+	// FileDependencies contains both parent edges and local-module dependency
+	// edges, so BFS captures all reachable local build files in one pass.
+	result := make(map[BuildFile]BuildFileRelations, len(files))
+	for _, f := range files {
+		var deps []BuildFile
+		visited := map[string]struct{}{f.FilePath: {}} // cycle protection
+		queue := []string{f.FilePath}
+
+		for len(queue) > 0 {
+			current := queue[0]
+			queue = queue[1:]
+			for _, depPath := range ctx.FileDependencies[current] {
+				if _, seen := visited[depPath]; seen {
+					continue
+				}
+				visited[depPath] = struct{}{}
+				if dep, known := filesByPath[depPath]; known {
+					deps = append(deps, dep)
+					queue = append(queue, depPath)
+				}
+			}
+		}
+
+		// Sort dependencies by FilePath for deterministic output.
+		sort.Slice(deps, func(i, j int) bool {
+			return deps[i].FilePath < deps[j].FilePath
+		})
+
+		if deps == nil {
+			deps = []BuildFile{}
+		}
+
+		result[f] = BuildFileRelations{
+			ID:           ctx.MavenArtifactIDs[f.FilePath],
+			Dependencies: deps,
+		}
+	}
+
+	return result
+}
+
+//nolint:gochecknoinits
+func init() {
+	RegisterBuildFileProcessor(FileTypePomXML, &MavenProcessor{})
+}

--- a/pkg/sbomgen/maven_processor_test.go
+++ b/pkg/sbomgen/maven_processor_test.go
@@ -1,0 +1,383 @@
+package sbomgen
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+)
+
+// mavenFileComponent creates a file-type CycloneDX component representing a
+// pom.xml, as produced by ExtractMavenPomArtifactIds. If parentPath is
+// non-empty it sets the maven:parentPom property, encoding the <parent>
+// relationship unambiguously.
+func mavenFileComponent(pomPath, parentPath string) cyclonedx.Component {
+	props := []cyclonedx.Property{
+		{Name: "osv-scanner:package", Value: "pkg:maven/com.example/" + pomPath + "@1.0"},
+	}
+	if parentPath != "" {
+		props = append(props, cyclonedx.Property{
+			Name:  mavenParentPomProperty,
+			Value: parentPath,
+		})
+	}
+
+	return cyclonedx.Component{
+		Type:       cyclonedx.ComponentTypeFile,
+		BOMRef:     pomPath,
+		Name:       pomPath,
+		Properties: &props,
+	}
+}
+
+// mavenComponent builds a CycloneDX component with a manifest occurrence for
+// the given pom.xml path, as the SBOM generator would emit it.
+func mavenComponent(name, pomPath string) cyclonedx.Component {
+	return componentWithOccurrences(name, "1.0.0", makeLocation(pomPath, "manifest"))
+}
+
+// mavenDep builds a CycloneDX Dependency entry for a POM pointing to one or
+// more direct dependencies (parent and/or local module POMs).
+func mavenDep(ref string, dependsOn ...string) cyclonedx.Dependency {
+	return cyclonedx.Dependency{Ref: ref, Dependencies: &dependsOn}
+}
+
+// makeSBOMWithDeps builds CycloneDX JSON bytes from components and explicit
+// dependency entries. Use instead of makeSBOM when bom.Dependencies must be
+// populated so that ProcessorContext.FileDependencies is non-empty.
+func makeSBOMWithDeps(components []cyclonedx.Component, deps []cyclonedx.Dependency) []byte {
+	bom := cyclonedx.BOM{
+		BOMFormat:    "CycloneDX",
+		SpecVersion:  cyclonedx.SpecVersion1_5,
+		Components:   &components,
+		Dependencies: &deps,
+	}
+	b, err := json.Marshal(bom)
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+// pomFile is a shorthand for a pom.xml BuildFile with no RepoPath.
+func pomFile(path string) BuildFile {
+	return BuildFile{FileType: FileTypePomXML, FilePath: path}
+}
+
+// --- Tests ---
+
+// TestMavenProcessor_SingleRootPom verifies that a standalone pom.xml
+// (no parent, no modules) gets empty dependencies and an ID from the purl.
+func TestMavenProcessor_SingleRootPom(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOM([]cyclonedx.Component{
+		mavenFileComponent("pom.xml", ""),
+		mavenComponent("com.example:app", "pom.xml"),
+	})
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+	rel := result[pomFile("pom.xml")]
+	if rel.ID != "com.example:pom.xml" {
+		t.Errorf("expected ID=com.example:pom.xml, got %q", rel.ID)
+	}
+	if len(rel.Dependencies) != 0 {
+		t.Errorf("expected no Dependencies, got %v", rel.Dependencies)
+	}
+}
+
+// TestMavenProcessor_ParentChild verifies a simple two-level hierarchy:
+//
+//	pom.xml
+//	└── child/pom.xml
+//
+// child depends on pom.xml (its parent). root has no dependencies.
+func TestMavenProcessor_ParentChild(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			mavenFileComponent("pom.xml", ""),
+			mavenFileComponent("child/pom.xml", "pom.xml"),
+			mavenComponent("com.example:parent", "pom.xml"),
+			mavenComponent("com.example:child", "child/pom.xml"),
+		},
+		[]cyclonedx.Dependency{
+			mavenDep("child/pom.xml", "pom.xml"),
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(result), result)
+	}
+
+	root := result[pomFile("pom.xml")]
+	if root.ID != "com.example:pom.xml" {
+		t.Errorf("root: expected ID=com.example:pom.xml, got %q", root.ID)
+	}
+	if len(root.Dependencies) != 0 {
+		t.Errorf("root: expected no Dependencies, got %v", root.Dependencies)
+	}
+
+	child := result[pomFile("child/pom.xml")]
+	if child.ID != "com.example:child/pom.xml" {
+		t.Errorf("child: expected ID=com.example:child/pom.xml, got %q", child.ID)
+	}
+	if len(child.Dependencies) != 1 || child.Dependencies[0] != pomFile("pom.xml") {
+		t.Errorf("child: expected Dependencies=[pom.xml], got %v", child.Dependencies)
+	}
+}
+
+// TestMavenProcessor_MultiModule verifies a flat multi-module layout:
+//
+//	pom.xml (aggregator)
+//	├── core/pom.xml
+//	├── web/pom.xml
+//	└── integration-tests/pom.xml
+//
+// Each child depends on pom.xml (its parent). Root has no dependencies.
+func TestMavenProcessor_MultiModule(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			mavenFileComponent("pom.xml", ""),
+			mavenFileComponent("core/pom.xml", "pom.xml"),
+			mavenFileComponent("web/pom.xml", "pom.xml"),
+			mavenFileComponent("integration-tests/pom.xml", "pom.xml"),
+			mavenComponent("com.example:parent", "pom.xml"),
+			mavenComponent("com.example:core", "core/pom.xml"),
+			mavenComponent("com.example:web", "web/pom.xml"),
+			mavenComponent("com.example:integration-tests", "integration-tests/pom.xml"),
+		},
+		[]cyclonedx.Dependency{
+			mavenDep("core/pom.xml", "pom.xml"),
+			mavenDep("web/pom.xml", "pom.xml"),
+			mavenDep("integration-tests/pom.xml", "pom.xml"),
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	if len(result) != 4 {
+		t.Fatalf("expected 4 entries, got %d: %v", len(result), result)
+	}
+
+	root := result[pomFile("pom.xml")]
+	if root.ID != "com.example:pom.xml" {
+		t.Errorf("root: expected ID=com.example:pom.xml, got %q", root.ID)
+	}
+	if len(root.Dependencies) != 0 {
+		t.Errorf("root: expected no Dependencies, got %v", root.Dependencies)
+	}
+
+	for _, childPath := range []string{"core/pom.xml", "integration-tests/pom.xml", "web/pom.xml"} {
+		rel := result[pomFile(childPath)]
+		expectedID := "com.example:" + childPath
+		if rel.ID != expectedID {
+			t.Errorf("%s: expected ID=%s, got %q", childPath, expectedID, rel.ID)
+		}
+		if len(rel.Dependencies) != 1 || rel.Dependencies[0] != pomFile("pom.xml") {
+			t.Errorf("%s: expected Dependencies=[pom.xml], got %v", childPath, rel.Dependencies)
+		}
+	}
+}
+
+// TestMavenProcessor_DeepHierarchy verifies a three-level chain:
+//
+//	pom.xml
+//	└── module/pom.xml
+//	    └── module/sub/pom.xml
+//
+// Transitive closure: root.Dependencies=[], mid.Dependencies=[pom.xml],
+// leaf.Dependencies=[module/pom.xml, pom.xml] (sorted by FilePath).
+func TestMavenProcessor_DeepHierarchy(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			mavenFileComponent("pom.xml", ""),
+			mavenFileComponent("module/pom.xml", "pom.xml"),
+			mavenFileComponent("module/sub/pom.xml", "module/pom.xml"),
+			mavenComponent("com.example:root", "pom.xml"),
+			mavenComponent("com.example:module", "module/pom.xml"),
+			mavenComponent("com.example:sub", "module/sub/pom.xml"),
+		},
+		[]cyclonedx.Dependency{
+			mavenDep("module/pom.xml", "pom.xml"),
+			mavenDep("module/sub/pom.xml", "module/pom.xml"),
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	root := result[pomFile("pom.xml")]
+	if root.ID != "com.example:pom.xml" {
+		t.Errorf("root: expected ID=com.example:pom.xml, got %q", root.ID)
+	}
+	if len(root.Dependencies) != 0 {
+		t.Errorf("root: expected no Dependencies, got %v", root.Dependencies)
+	}
+
+	mid := result[pomFile("module/pom.xml")]
+	if mid.ID != "com.example:module/pom.xml" {
+		t.Errorf("module: expected ID=com.example:module/pom.xml, got %q", mid.ID)
+	}
+	if len(mid.Dependencies) != 1 || mid.Dependencies[0] != pomFile("pom.xml") {
+		t.Errorf("module: expected Dependencies=[pom.xml], got %v", mid.Dependencies)
+	}
+
+	leaf := result[pomFile("module/sub/pom.xml")]
+	if leaf.ID != "com.example:module/sub/pom.xml" {
+		t.Errorf("sub: expected ID=com.example:module/sub/pom.xml, got %q", leaf.ID)
+	}
+	// Transitive: leaf depends on module/pom.xml AND pom.xml, sorted by FilePath.
+	if len(leaf.Dependencies) != 2 {
+		t.Fatalf("sub: expected 2 Dependencies, got %v", leaf.Dependencies)
+	}
+	if leaf.Dependencies[0] != pomFile("module/pom.xml") {
+		t.Errorf("sub: expected Dependencies[0]=module/pom.xml, got %v", leaf.Dependencies[0])
+	}
+	if leaf.Dependencies[1] != pomFile("pom.xml") {
+		t.Errorf("sub: expected Dependencies[1]=pom.xml, got %v", leaf.Dependencies[1])
+	}
+}
+
+// TestMavenProcessor_ExternalParentIgnored verifies that a dependency edge
+// pointing to a POM path not present in the SBOM (e.g. a parent from Maven
+// Central) is silently ignored — the file has no dependencies.
+func TestMavenProcessor_ExternalParentIgnored(t *testing.T) {
+	t.Parallel()
+
+	const externalParent = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-parent/3.0.0/spring-boot-starter-parent-3.0.0.pom"
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			mavenFileComponent("pom.xml", externalParent),
+			mavenComponent("com.example:child", "pom.xml"),
+		},
+		[]cyclonedx.Dependency{
+			mavenDep("pom.xml", externalParent),
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	rel := result[pomFile("pom.xml")]
+	if rel.ID != "com.example:pom.xml" {
+		t.Errorf("expected ID=com.example:pom.xml, got %q", rel.ID)
+	}
+	if len(rel.Dependencies) != 0 {
+		t.Errorf("expected no Dependencies for external parent, got %v", rel.Dependencies)
+	}
+}
+
+// TestMavenProcessor_SiblingModuleIncludedAsDependency verifies that when a
+// module depends on a sibling module (ordinary Maven <dependency>) in addition
+// to a <parent>, BOTH the parent and the sibling appear in Dependencies.
+// bom.Dependencies carries both edge types (parent from addFileDependencies,
+// module dep from createFileComponents), so BFS over FileDependencies picks up
+// all of them.
+//
+// Layout:
+//
+//	pom.xml (root aggregator)
+//	├── module-a/pom.xml  (parent=pom.xml, <dependency> on module-b)
+//	└── module-b/pom.xml  (parent=pom.xml)
+func TestMavenProcessor_SiblingModuleIncludedAsDependency(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			mavenFileComponent("pom.xml", ""),
+			mavenFileComponent("module-a/pom.xml", "pom.xml"),
+			mavenFileComponent("module-b/pom.xml", "pom.xml"),
+			mavenComponent("com.example:root", "pom.xml"),
+			mavenComponent("com.example:module-a", "module-a/pom.xml"),
+			mavenComponent("com.example:module-b", "module-b/pom.xml"),
+		},
+		[]cyclonedx.Dependency{
+			// module-a: parent edge (from addFileDependencies) + sibling edge
+			// (from createFileComponents) — sorted alphabetically as the real SBOM does.
+			mavenDep("module-a/pom.xml", "module-b/pom.xml", "pom.xml"),
+			mavenDep("module-b/pom.xml", "pom.xml"),
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %v", len(result), result)
+	}
+
+	root := result[pomFile("pom.xml")]
+	if len(root.Dependencies) != 0 {
+		t.Errorf("root: expected no Dependencies, got %v", root.Dependencies)
+	}
+
+	// module-a depends on both its parent (pom.xml) and the sibling library
+	// (module-b/pom.xml), plus module-b's own transitive dep (pom.xml, already
+	// counted). Sorted by FilePath: [module-b/pom.xml, pom.xml].
+	modA := result[pomFile("module-a/pom.xml")]
+	if len(modA.Dependencies) != 2 {
+		t.Fatalf("module-a: expected 2 Dependencies, got %v", modA.Dependencies)
+	}
+	if modA.Dependencies[0] != pomFile("module-b/pom.xml") {
+		t.Errorf("module-a: expected Dependencies[0]=module-b/pom.xml, got %v", modA.Dependencies[0])
+	}
+	if modA.Dependencies[1] != pomFile("pom.xml") {
+		t.Errorf("module-a: expected Dependencies[1]=pom.xml, got %v", modA.Dependencies[1])
+	}
+
+	modB := result[pomFile("module-b/pom.xml")]
+	if len(modB.Dependencies) != 1 || modB.Dependencies[0] != pomFile("pom.xml") {
+		t.Errorf("module-b: expected Dependencies=[pom.xml], got %v", modB.Dependencies)
+	}
+}
+
+// TestMavenProcessor_ParentPomViaFileComponent verifies that a parent POM which
+// has no package occurrences of its own is still discovered via the file-type
+// component emitted by ExtractMavenPomArtifactIds, and appears in the child's
+// Dependencies.
+//
+// Layout:
+//
+//	pom.xml        ← file-type component only (no package occurrences)
+//	└── child/pom.xml  ← normal package occurrence
+func TestMavenProcessor_ParentPomViaFileComponent(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			mavenFileComponent("pom.xml", ""),
+			mavenFileComponent("child/pom.xml", "pom.xml"),
+			mavenComponent("com.example:child", "child/pom.xml"),
+		},
+		[]cyclonedx.Dependency{
+			mavenDep("child/pom.xml", "pom.xml"),
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypePomXML)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries (parent + child), got %d: %v", len(result), result)
+	}
+
+	root := result[pomFile("pom.xml")]
+	if len(root.Dependencies) != 0 {
+		t.Errorf("root: expected no Dependencies, got %v", root.Dependencies)
+	}
+
+	child := result[pomFile("child/pom.xml")]
+	if len(child.Dependencies) != 1 || child.Dependencies[0] != pomFile("pom.xml") {
+		t.Errorf("child: expected Dependencies=[pom.xml], got %v", child.Dependencies)
+	}
+}

--- a/pkg/sbomgen/sbomgen.go
+++ b/pkg/sbomgen/sbomgen.go
@@ -30,14 +30,20 @@ type Options struct {
 
 	// ExcludePaths is a list of glob patterns to exclude from scanning.
 	ExcludePaths []string
+
+	// ExtractMavenPomArtifactIds controls whether Maven pom.xml artifact IDs
+	// and parent dependency relationships are extracted and included in the SBOM.
+	// Defaults to true in DefaultOptions.
+	ExtractMavenPomArtifactIds bool
 }
 
 // DefaultOptions returns Options with sensible defaults:
-// recursive scanning enabled and no exclusions.
+// recursive scanning enabled, no exclusions, and artifact extraction enabled.
 func DefaultOptions() Options {
 	return Options{
-		Recursive:    true,
-		ExcludePaths: []string{},
+		Recursive:                  true,
+		ExcludePaths:               []string{},
+		ExtractMavenPomArtifactIds: true,
 	}
 }
 
@@ -51,9 +57,10 @@ func GenerateSBOM(dirs []string, opts Options) ([]byte, error) {
 	}
 
 	actions := scanner.ScannerActions{
-		DirectoryPaths: dirs,
-		ExcludePaths:   opts.ExcludePaths,
-		Recursive:      opts.Recursive,
+		DirectoryPaths:             dirs,
+		ExcludePaths:               opts.ExcludePaths,
+		Recursive:                  opts.Recursive,
+		ExtractMavenPomArtifactIds: opts.ExtractMavenPomArtifactIds,
 	}
 
 	r := reporter.NewCycloneDXReporter(&bytes.Buffer{}, &bytes.Buffer{}, reporter.WarnLevel)

--- a/pkg/sbomgen/testdata/Cargo.toml
+++ b/pkg/sbomgen/testdata/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0.0"

--- a/pkg/scanner/datadog_sbom_generator.go
+++ b/pkg/scanner/datadog_sbom_generator.go
@@ -48,6 +48,10 @@ type ScannerActions struct {
 	ManifestParsers     bool
 	DDEnvVars           DDEnvVars
 	ExitOnConfigFailure bool
+	// ExtractMavenPomArtifactIds controls whether Maven pom.xml artifact IDs
+	// and parent dependency relationships are extracted and included in the SBOM.
+	// When false, ScannedArtifact entries are never produced.
+	ExtractMavenPomArtifactIds bool
 }
 
 type DDEnvVars struct {
@@ -78,7 +82,7 @@ var ErrAPIFailed = models.ErrAPIFailed
 // scanDir walks through the given directory to try to find any relevant files
 // These include:
 //   - Any lockfiles with scanLockfile
-func scanDir(r reporter.Reporter, dir string, repoRoot string, recursive bool, useGitIgnore bool, enabledParsers map[string]bool, cliExcludePaths []string, configExcludePaths []string) ([]extractor.PackageDetails, []models.ScannedArtifact, error) {
+func scanDir(r reporter.Reporter, dir string, repoRoot string, recursive bool, useGitIgnore bool, enabledParsers map[string]bool, cliExcludePaths []string, configExcludePaths []string, extractMavenPomArtifactIds bool) ([]extractor.PackageDetails, []models.ScannedArtifact, error) {
 	scanRoot := dir
 	// Normalize the scan root once before exclusion matching.
 	if absPath, err := filepath.Abs(dir); err == nil {
@@ -150,7 +154,7 @@ func scanDir(r reporter.Reporter, dir string, repoRoot string, recursive bool, u
 					return nil
 				}
 
-				context := extractor.ScanContext{EnabledParsers: enabledParsers, RootDir: dir, Reporter: r}
+				context := extractor.ScanContext{EnabledParsers: enabledParsers, RootDir: dir, Reporter: r, ExtractMavenPomArtifactIds: extractMavenPomArtifactIds}
 				pkgs, artifact, err := scanLockfile(path, context)
 				if err != nil {
 					r.Warnf("Attempted to scan lockfile but failed: %s (%v)\n", path, err.Error())
@@ -299,7 +303,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 			absolutePath = absPath
 		}
 		r.Infof("Scanning directory '%s', resolved absolute path '%s'\n", dir, absolutePath)
-		pkgs, artifacts, err := scanDir(r, dir, repoRoot, actions.Recursive, !actions.NoIgnore, enabledParsers, actions.ExcludePaths, configExcludePaths)
+		pkgs, artifacts, err := scanDir(r, dir, repoRoot, actions.Recursive, !actions.NoIgnore, enabledParsers, actions.ExcludePaths, configExcludePaths, actions.ExtractMavenPomArtifactIds)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}

--- a/pkg/scanner/datadog_sbom_generator_test.go
+++ b/pkg/scanner/datadog_sbom_generator_test.go
@@ -62,7 +62,7 @@ func Test_scanDir(t *testing.T) {
 	var excludedGlobs []string
 	var configExcludedGlobs []string
 	enabledParsers := initializeEnabledParsers([]string{}, mockReporter)
-	packages, artifacts, err := scanDir(mockReporter, tempDir, tempDir, true, false, enabledParsers, excludedGlobs, configExcludedGlobs)
+	packages, artifacts, err := scanDir(mockReporter, tempDir, tempDir, true, false, enabledParsers, excludedGlobs, configExcludedGlobs, false)
 
 	// Validate results
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func Test_scanDir(t *testing.T) {
 
 	// Exclude all files in the subdir
 	excludedGlobs = []string{filepath.Join("subdir", "*")}
-	packages, artifacts, err = scanDir(mockReporter, tempDir, tempDir, true, false, enabledParsers, excludedGlobs, configExcludedGlobs)
+	packages, artifacts, err = scanDir(mockReporter, tempDir, tempDir, true, false, enabledParsers, excludedGlobs, configExcludedGlobs, false)
 
 	require.NoError(t, err)
 	assert.Len(t, packages, 2) // Only package-lock.json and yarn.lock should be scanned (subdir/package-lock.json is excluded)
@@ -79,7 +79,7 @@ func Test_scanDir(t *testing.T) {
 
 	// Exclude all files in the subdir and yarn.lock (precisely one file)
 	excludedGlobs = []string{filepath.Join("subdir", "*"), "yarn.lock"}
-	packages, artifacts, err = scanDir(mockReporter, tempDir, tempDir, true, false, enabledParsers, excludedGlobs, configExcludedGlobs)
+	packages, artifacts, err = scanDir(mockReporter, tempDir, tempDir, true, false, enabledParsers, excludedGlobs, configExcludedGlobs, false)
 
 	require.NoError(t, err)
 	assert.Len(t, packages, 1) // Only package-lock.json should be scanned (yarn.lock and subdir/package-lock.json is excluded)
@@ -107,7 +107,7 @@ func Test_scanDir_ConfigExclusionsUseRepositoryRoot(t *testing.T) {
 	mockReporter.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
 
 	enabledParsers := initializeEnabledParsers([]string{}, mockReporter)
-	packages, artifacts, err := scanDir(mockReporter, scanDirPath, repoRoot, true, false, enabledParsers, nil, []string{"subdir/*"})
+	packages, artifacts, err := scanDir(mockReporter, scanDirPath, repoRoot, true, false, enabledParsers, nil, []string{"subdir/*"}, false)
 
 	require.NoError(t, err)
 	assert.Empty(t, packages)
@@ -146,6 +146,7 @@ func Test_scanDir_ConfigExclusionsSupportPrefixAndDoublestarMatching(t *testing.
 		enabledParsers,
 		nil,
 		[]string{"subdir/dist", "subdir/**/*.lock"},
+		false,
 	)
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Add `GetArtifact` to `GradleLockExtractor` that extracts `group:projectName` from `build.gradle` / `build.gradle.kts` project-level group assignments
- Add `GradleProcessor` that populates the ID field for Gradle build files in `GetBuildFileTrees`, registered for both `FileTypeBuildGradle` and `FileTypeBuildGradleKts`
- Dependencies are always empty (Gradle projects lack Maven-style parent-child hierarchy)

## Test plan

- [x] 5 subtests for `GetArtifact`: groovy with group, kotlin with group, no group, missing build file, group in dependency kwarg only
- [x] 5 tests for `GradleProcessor`: ID populated (groovy), ID populated (kotlin), no ID, dependencies always empty, both file types registered
- [x] Full test suite passes (`./scripts/run_tests.sh`)
- [x] Linter clean (`./scripts/run_lints.sh`)
- [x] Formatter clean (`./scripts/run_formatters.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)