### PR TITLE
Python build file tree support for Code Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,11 @@ Returns sensible defaults: recursive scanning enabled, no path exclusions.
 
 #### `Options`
 
-| Field                        | Type       | Description                                                                                                                                |
-| ---------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Recursive`                  | `bool`     | Scan subdirectories recursively (default: `true`)                                                                                          |
-| `ExcludePaths`               | `[]string` | Glob patterns to exclude from scanning                                                                                                     |
-| `ExtractMavenPomArtifactIds` | `bool`     | Emit file-type components and dependency edges for Maven POMs, enabling `GetBuildFileTrees` dependency and ID resolution (default: `true`) |
+| Field                | Type       | Description                                                                                                                                 |
+| -------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Recursive`          | `bool`     | Scan subdirectories recursively (default: `true`)                                                                                           |
+| `ExcludePaths`       | `[]string` | Glob patterns to exclude from scanning                                                                                                      |
+| `ExtractArtifactIds` | `bool`     | Emit file-type components and dependency edges for build files, enabling `GetBuildFileTrees` dependency and ID resolution (default: `true`) |
 
 ## Contributing
 

--- a/internal/output/__snapshots__/cyclonedx_test.snap
+++ b/internal/output/__snapshots__/cyclonedx_test.snap
@@ -63,6 +63,16 @@
   },
   "components": [
     {
+      "bom-ref": "lib1/pom.xml",
+      "type": "file",
+      "name": "lib1/pom.xml"
+    },
+    {
+      "bom-ref": "lib2/pom.xml",
+      "type": "file",
+      "name": "lib2/pom.xml"
+    },
+    {
       "bom-ref": "pkg:maven/dev.foo/lib1@1.0-SNAPSHOT",
       "type": "library",
       "name": "dev.foo:lib1",
@@ -75,6 +85,11 @@
       "name": "dev.foo:lib2",
       "version": "1.0-SNAPSHOT",
       "purl": "pkg:maven/dev.foo/lib2@1.0-SNAPSHOT"
+    },
+    {
+      "bom-ref": "pom.xml",
+      "type": "file",
+      "name": "pom.xml"
     }
   ],
   "dependencies": [
@@ -137,6 +152,11 @@
       "name": "com.nobody:mine1",
       "version": "1.2.3",
       "purl": "pkg:maven/com.nobody/mine1@1.2.3"
+    },
+    {
+      "bom-ref": "pom.xml",
+      "type": "file",
+      "name": "pom.xml"
     }
   ]
 }
@@ -163,11 +183,35 @@
   },
   "components": [
     {
+      "bom-ref": "parent/pom.xml",
+      "type": "file",
+      "name": "parent/pom.xml"
+    },
+    {
       "bom-ref": "pkg:maven/com.nobody/mine1@1.2.3",
       "type": "library",
       "name": "com.nobody:mine1",
       "version": "1.2.3",
       "purl": "pkg:maven/com.nobody/mine1@1.2.3"
+    },
+    {
+      "bom-ref": "pom.xml",
+      "type": "file",
+      "name": "pom.xml",
+      "properties": [
+        {
+          "name": "datadog:maven-parent-pom",
+          "value": "parent/pom.xml"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pom.xml",
+      "dependsOn": [
+        "parent/pom.xml"
+      ]
     }
   ]
 }

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -162,7 +162,7 @@ func buildDatadogProperty(metadataKey string, value string) cyclonedx.Property {
 
 func findArtifact(name string, version string, artifacts []models.ScannedArtifact) *models.ScannedArtifact {
 	for _, artifact := range artifacts {
-		if artifact.Name == name && (version == "" || artifact.Version == version) {
+		if artifact.Name == name && (version == "" || artifact.Version == "" || artifact.Version == version) {
 			return &artifact
 		}
 	}

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -274,21 +274,24 @@ func addFileDependencies(artifacts []models.ScannedArtifact) (map[string]cyclone
 	dependsOn := make(map[string]cyclonedx.Dependency)
 
 	for _, artifact := range artifacts {
-		artifactPURL, err := purl.From(models.PackageInfo{
-			Name:      artifact.Name,
-			Version:   artifact.Version,
-			Ecosystem: string(artifact.Ecosystem),
-		})
-		if err != nil {
-			continue
-		}
-
 		component := cyclonedx.Component{}
 		component.Name = artifact.Filename
 		component.BOMRef = artifact.Filename
 		component.Type = fileComponentType
-		properties := []cyclonedx.Property{
-			{Name: mavenPackageProperty, Value: artifactPURL.String()},
+
+		var properties []cyclonedx.Property
+		if artifact.Name != "" {
+			artifactPURL, err := purl.From(models.PackageInfo{
+				Name:      artifact.Name,
+				Version:   artifact.Version,
+				Ecosystem: string(artifact.Ecosystem),
+			})
+			if err == nil {
+				properties = append(properties, cyclonedx.Property{
+					Name:  mavenPackageProperty,
+					Value: artifactPURL.String(),
+				})
+			}
 		}
 		// Computing parent dependency
 		if artifact.DependsOn != nil {
@@ -316,7 +319,9 @@ func addFileDependencies(artifacts []models.ScannedArtifact) (map[string]cyclone
 			}
 		}
 
-		component.Properties = &properties
+		if len(properties) > 0 {
+			component.Properties = &properties
+		}
 		components[component.BOMRef] = component
 	}
 

--- a/pkg/extractor/extract.go
+++ b/pkg/extractor/extract.go
@@ -149,10 +149,10 @@ var ErrExtractorNotFound = errors.New("could not determine extractor")
 // ScanContext is used to pass context to extractors
 // It is passed to extractors to allow them to access the root directory of the scan as well as the reporter
 type ScanContext struct {
-	EnabledParsers             map[string]bool
-	RootDir                    string
-	Reporter                   reporter.Reporter
-	ExtractMavenPomArtifactIds bool
+	EnabledParsers     map[string]bool
+	RootDir            string
+	Reporter           reporter.Reporter
+	ExtractArtifactIds bool
 }
 
 func ExtractDeps(f DepFile, context ScanContext) (Lockfile, error) {
@@ -201,7 +201,7 @@ func ExtractDeps(f DepFile, context ScanContext) (Lockfile, error) {
 		return parsedLockfile, err
 	}
 	defer depFile.Close()
-	if context.ExtractMavenPomArtifactIds {
+	if context.ExtractArtifactIds {
 		if e, ok := extractor.(ArtifactExtractor); ok {
 			artifact, err := e.GetArtifact(depFile, context)
 			if err == nil {

--- a/pkg/extractor/extract.go
+++ b/pkg/extractor/extract.go
@@ -208,6 +208,14 @@ func ExtractDeps(f DepFile, context ScanContext) (Lockfile, error) {
 				parsedLockfile.Artifact = artifact
 			}
 		}
+		// Even if GetArtifact is not implemented or returned nil, emit a bare
+		// file-type component so every scanned build file appears in GetBuildFileTrees,
+		// regardless of whether it has an artifact identity or any packages.
+		if parsedLockfile.Artifact == nil {
+			parsedLockfile.Artifact = &models.ScannedArtifact{
+				ArtifactDetail: models.ArtifactDetail{Filename: f.Path()},
+			}
+		}
 	}
 
 	return parsedLockfile, err

--- a/pkg/extractor/extract.go
+++ b/pkg/extractor/extract.go
@@ -207,13 +207,14 @@ func ExtractDeps(f DepFile, context ScanContext) (Lockfile, error) {
 			if err == nil {
 				parsedLockfile.Artifact = artifact
 			}
-		}
-		// Even if GetArtifact is not implemented or returned nil, emit a bare
-		// file-type component so every scanned build file appears in GetBuildFileTrees,
-		// regardless of whether it has an artifact identity or any packages.
-		if parsedLockfile.Artifact == nil {
-			parsedLockfile.Artifact = &models.ScannedArtifact{
-				ArtifactDetail: models.ArtifactDetail{Filename: f.Path()},
+			// Even if GetArtifact returned nil, emit a bare file-type component
+			// so every build file that opts in (by implementing ArtifactExtractor)
+			// appears in GetBuildFileTrees. Lockfile-only extractors that do not
+			// implement ArtifactExtractor are intentionally excluded.
+			if parsedLockfile.Artifact == nil {
+				parsedLockfile.Artifact = &models.ScannedArtifact{
+					ArtifactDetail: models.ArtifactDetail{Filename: f.Path()},
+				}
 			}
 		}
 	}

--- a/pkg/extractor/python/match-pyproject-toml.go
+++ b/pkg/extractor/python/match-pyproject-toml.go
@@ -1,6 +1,8 @@
 package python
 
-import "github.com/DataDog/datadog-sbom-generator/pkg/extractor"
+import (
+	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
+)
 
 func (m PyprojectTOMLMatcher) GetSourceFile(depFile extractor.DepFile) (extractor.DepFile, error) {
 	return depFile.Open("pyproject.toml")

--- a/pkg/extractor/python/parse-pyproject-toml-artifact_test.go
+++ b/pkg/extractor/python/parse-pyproject-toml-artifact_test.go
@@ -31,7 +31,7 @@ version = "1.0.0"
 	}
 	defer f.Close()
 
-	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifacts: true})
+	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifactIds: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -69,7 +69,7 @@ version = "1.0.0"
 	}
 	defer f.Close()
 
-	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifacts: true})
+	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifactIds: true})
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -78,7 +78,7 @@ version = "1.0.0"
 	}
 }
 
-func TestPyProjectTOMLExtractor_GetArtifact_ExtractArtifactsDisabled(t *testing.T) {
+func TestPyProjectTOMLExtractor_GetArtifact_ExtractArtifactIdsDisabled(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -97,13 +97,13 @@ name = "my-lib"
 	}
 	defer f.Close()
 
-	// ExtractArtifacts is false — should return nil
-	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifacts: false})
+	// ExtractArtifactIds is false — should return nil
+	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifactIds: false})
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 	if artifact != nil {
-		t.Errorf("expected nil artifact when ExtractArtifacts is false, got %+v", artifact)
+		t.Errorf("expected nil artifact when ExtractArtifactIds is false, got %+v", artifact)
 	}
 }
 
@@ -155,7 +155,7 @@ func TestPyProjectTOMLExtractor_GetArtifact_NormalizesName(t *testing.T) {
 			}
 			defer f.Close()
 
-			artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifacts: true})
+			artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifactIds: true})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/extractor/python/parse-pyproject-toml-artifact_test.go
+++ b/pkg/extractor/python/parse-pyproject-toml-artifact_test.go
@@ -49,6 +49,39 @@ version = "1.0.0"
 	}
 }
 
+func TestPyProjectTOMLExtractor_GetArtifact_PoetryName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Poetry layout: name is under [tool.poetry], not [project]
+	pyprojectPath := filepath.Join(dir, "pyproject.toml")
+	err := os.WriteFile(pyprojectPath, []byte(`[tool.poetry]
+name = "my-poetry-lib"
+version = "2.0.0"
+`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := extractor.OpenLocalDepFile(pyprojectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifactIds: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if artifact == nil {
+		t.Fatal("expected artifact from [tool.poetry].name, got nil")
+	}
+	if artifact.Name != "my-poetry-lib" {
+		t.Errorf("expected name 'my-poetry-lib', got %q", artifact.Name)
+	}
+}
+
 func TestPyProjectTOMLExtractor_GetArtifact_NoName(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/extractor/python/parse-pyproject-toml-artifact_test.go
+++ b/pkg/extractor/python/parse-pyproject-toml-artifact_test.go
@@ -1,0 +1,170 @@
+package python_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
+	"github.com/DataDog/datadog-sbom-generator/pkg/extractor/python"
+	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+)
+
+func TestPyProjectTOMLExtractor_GetArtifact(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Create a pyproject.toml with a project name
+	pyprojectPath := filepath.Join(dir, "pyproject.toml")
+	err := os.WriteFile(pyprojectPath, []byte(`[project]
+name = "my-awesome-lib"
+version = "1.0.0"
+`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := extractor.OpenLocalDepFile(pyprojectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifacts: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if artifact == nil {
+		t.Fatal("expected artifact, got nil")
+	}
+	if artifact.Name != "my-awesome-lib" {
+		t.Errorf("expected name 'my-awesome-lib', got %q", artifact.Name)
+	}
+	if artifact.Filename != pyprojectPath {
+		t.Errorf("expected filename %q, got %q", pyprojectPath, artifact.Filename)
+	}
+	if artifact.Ecosystem != models.EcosystemPyPI {
+		t.Errorf("expected ecosystem %q, got %q", models.EcosystemPyPI, artifact.Ecosystem)
+	}
+}
+
+func TestPyProjectTOMLExtractor_GetArtifact_NoName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Create a pyproject.toml without a project name
+	pyprojectPath := filepath.Join(dir, "pyproject.toml")
+	err := os.WriteFile(pyprojectPath, []byte(`[project]
+version = "1.0.0"
+`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := extractor.OpenLocalDepFile(pyprojectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifacts: true})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if artifact != nil {
+		t.Errorf("expected nil artifact, got %+v", artifact)
+	}
+}
+
+func TestPyProjectTOMLExtractor_GetArtifact_ExtractArtifactsDisabled(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	pyprojectPath := filepath.Join(dir, "pyproject.toml")
+	err := os.WriteFile(pyprojectPath, []byte(`[project]
+name = "my-lib"
+`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := extractor.OpenLocalDepFile(pyprojectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// ExtractArtifacts is false — should return nil
+	artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifacts: false})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if artifact != nil {
+		t.Errorf("expected nil artifact when ExtractArtifacts is false, got %+v", artifact)
+	}
+}
+
+func TestPyProjectTOMLExtractor_GetArtifact_NormalizesName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tomlName string
+		expected string
+	}{
+		{
+			name:     "underscores to hyphens",
+			tomlName: "my_package",
+			expected: "my-package",
+		},
+		{
+			name:     "dots to hyphens",
+			tomlName: "my.package",
+			expected: "my-package",
+		},
+		{
+			name:     "uppercase to lowercase",
+			tomlName: "My-Package",
+			expected: "my-package",
+		},
+		{
+			name:     "mixed separators and case",
+			tomlName: "My_Cool.Package",
+			expected: "my-cool-package",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			pyprojectPath := filepath.Join(dir, "pyproject.toml")
+			err := os.WriteFile(pyprojectPath, []byte("[project]\nname = \""+tt.tomlName+"\"\n"), 0600)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			f, err := extractor.OpenLocalDepFile(pyprojectPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			artifact, err := python.PyProjectExtractor.GetArtifact(f, extractor.ScanContext{ExtractArtifacts: true})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if artifact == nil {
+				t.Fatal("expected artifact, got nil")
+			}
+			if artifact.Name != tt.expected {
+				t.Errorf("expected name %q, got %q", tt.expected, artifact.Name)
+			}
+		})
+	}
+}

--- a/pkg/extractor/python/parse-pyproject-toml.go
+++ b/pkg/extractor/python/parse-pyproject-toml.go
@@ -357,7 +357,7 @@ func isConcreteVersion(version string) bool {
 // own path as Filename so that findArtifact can match packages from sibling
 // lockfiles (e.g. requirements.txt) against this module.
 func (e PyProjectTOMLExtractor) GetArtifact(f extractor.DepFile, ctx extractor.ScanContext) (*models.ScannedArtifact, error) {
-	if !ctx.ExtractArtifacts {
+	if !ctx.ExtractArtifactIds {
 		return nil, nil
 	}
 

--- a/pkg/extractor/python/parse-pyproject-toml.go
+++ b/pkg/extractor/python/parse-pyproject-toml.go
@@ -372,6 +372,9 @@ func (e PyProjectTOMLExtractor) GetArtifact(f extractor.DepFile, ctx extractor.S
 	}
 
 	name := normalizedRequirementName(pyproject.Project.Name)
+	if name == "" && pyproject.Tool.Poetry != nil {
+		name = normalizedRequirementName(pyproject.Tool.Poetry.Name)
+	}
 	if name == "" {
 		return nil, nil
 	}

--- a/pkg/extractor/python/parse-pyproject-toml.go
+++ b/pkg/extractor/python/parse-pyproject-toml.go
@@ -352,6 +352,39 @@ func isConcreteVersion(version string) bool {
 	return version != "" && !strings.Contains(version, "*") && !strings.ContainsAny(version, " \t")
 }
 
+// GetArtifact extracts the Python package identity from a pyproject.toml file.
+// It returns the [project].name field as the artifact name, using the file's
+// own path as Filename so that findArtifact can match packages from sibling
+// lockfiles (e.g. requirements.txt) against this module.
+func (e PyProjectTOMLExtractor) GetArtifact(f extractor.DepFile, ctx extractor.ScanContext) (*models.ScannedArtifact, error) {
+	if !ctx.ExtractArtifacts {
+		return nil, nil
+	}
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var pyproject PyProjectTOML
+	if err := toml.Unmarshal(content, &pyproject); err != nil {
+		return nil, err
+	}
+
+	name := normalizedRequirementName(pyproject.Project.Name)
+	if name == "" {
+		return nil, nil
+	}
+
+	return &models.ScannedArtifact{
+		ArtifactDetail: models.ArtifactDetail{
+			Name:      name,
+			Filename:  f.Path(),
+			Ecosystem: models.EcosystemPyPI,
+		},
+	}, nil
+}
+
 var PyProjectExtractor = PyProjectTOMLExtractor{}
 
 func ParsePyProjectTOML(pathToLockfile string) ([]extractor.PackageDetails, error) {
@@ -360,6 +393,7 @@ func ParsePyProjectTOML(pathToLockfile string) ([]extractor.PackageDetails, erro
 
 var _ extractor.Extractor = PyProjectExtractor
 var _ extractor.ManifestExtractor = PyProjectExtractor
+var _ extractor.ArtifactExtractor = PyProjectExtractor
 
 //nolint:gochecknoinits
 func init() {

--- a/pkg/extractor/python/parse-requirements-txt.go
+++ b/pkg/extractor/python/parse-requirements-txt.go
@@ -431,7 +431,18 @@ var RequirementsExtractor = RequirementsTxtExtractor{
 	extractor.WithMatcher{Matchers: []extractor.Matcher{&RequirementsInMatcher{}}},
 }
 
+// GetArtifact implements extractor.ArtifactExtractor.
+// Requirements files do not carry module-identity metadata themselves,
+// so this always returns nil. The implementation exists so that
+// requirements.txt files are emitted as bare file-type SBOM components
+// when ExtractArtifactIds is enabled, allowing them to appear in
+// GetBuildFileTrees even when they contain no identifiable packages.
+func (e RequirementsTxtExtractor) GetArtifact(_ extractor.DepFile, _ extractor.ScanContext) (*models.ScannedArtifact, error) {
+	return nil, nil
+}
+
 var _ extractor.Extractor = RequirementsExtractor
+var _ extractor.ArtifactExtractor = RequirementsExtractor
 
 //nolint:gochecknoinits
 func init() {

--- a/pkg/extractor/python/types.go
+++ b/pkg/extractor/python/types.go
@@ -187,6 +187,7 @@ type PyProjectBuildSystem struct {
 }
 
 type PyProjectProject struct {
+	Name                 string              `toml:"name"`
 	Dependencies         []string            `toml:"dependencies"`
 	OptionalDependencies map[string][]string `toml:"optional-dependencies"`
 }

--- a/pkg/extractor/python/types.go
+++ b/pkg/extractor/python/types.go
@@ -199,6 +199,7 @@ type PyProjectToolSections struct {
 }
 
 type PyProjectPoetry struct {
+	Name            string                          `toml:"name"`
 	Dependencies    map[string]any                  `toml:"dependencies"`
 	DevDependencies map[string]any                  `toml:"dev-dependencies"`
 	Group           map[string]PyProjectPoetryGroup `toml:"group"`

--- a/pkg/sbomgen/build_file_processor.go
+++ b/pkg/sbomgen/build_file_processor.go
@@ -23,10 +23,11 @@ type ProcessorContext struct {
 	// on, as declared in the SBOM dependencies section.
 	FileDependencies map[string][]string
 
-	// MavenArtifactIDs maps each Maven file path to its "groupId:artifactId"
-	// string, extracted from the "datadog:maven-package" purl property on
-	// file-type components.
-	MavenArtifactIDs map[string]string
+	// ArtifactIDs maps each file path to its ecosystem-specific artifact
+	// identifier, extracted from the "datadog:maven-package" purl property on
+	// file-type components. For Maven this is "groupId:artifactId"; for PyPI
+	// it is the normalized package name.
+	ArtifactIDs map[string]string
 }
 
 // BuildFileProcessor enriches a group of build files of the same FileType.

--- a/pkg/sbomgen/build_files.go
+++ b/pkg/sbomgen/build_files.go
@@ -153,18 +153,21 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile]BuildFile
 	// Build the ProcessorContext from the SBOM dependencies section.
 	ctx := buildProcessorContext(&bom)
 
-	// Second pass: resolve cross-type dependency targets.
+	// Second pass: resolve cross-type dependency targets to a fixed point.
 	//
 	// A file-type component may have a different basename than the lockfile
-	// that depends on it (e.g. setup.py is a dependency target of
-	// requirements.txt). When a filter is active, such targets are missed by
-	// the first pass because their FileType doesn't match the filter.
+	// that depends on it (e.g. pyproject.toml is a dependency target of
+	// requirements.txt). Such targets are missed by the first pass because
+	// their FileType doesn't match the requesting file's FileType.
 	//
-	// We fix this by scanning dependency edges of already-collected files:
-	// if a dependency target is a known file-type component that wasn't
-	// collected, we add it to the same FileType group as its dependent so
-	// the processor can resolve it during BFS.
-	if len(filterSet) > 0 {
+	// We fix this by repeatedly scanning dependency edges of already-collected
+	// files: if a dependency target is a known file-type component that hasn't
+	// been added to a group yet, we add it under the same FileType as its
+	// dependent so the processor can resolve it during BFS. We loop until no
+	// new files are added (fixed point), resolving chains like:
+	//   requirements.txt → libs/a/pyproject.toml → libs/b/pyproject.toml
+	for {
+		added := false
 		for ft, files := range grouped {
 			for _, f := range files {
 				for _, depPath := range ctx.FileDependencies[f.FilePath] {
@@ -175,9 +178,13 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile]BuildFile
 					if _, exists := seen[bf]; !exists {
 						seen[bf] = struct{}{}
 						grouped[ft] = append(grouped[ft], bf)
+						added = true
 					}
 				}
 			}
+		}
+		if !added {
+			break
 		}
 	}
 

--- a/pkg/sbomgen/build_files.go
+++ b/pkg/sbomgen/build_files.go
@@ -232,7 +232,7 @@ func parseArtifactID(purl string) string {
 func buildProcessorContext(bom *cyclonedx.BOM) ProcessorContext {
 	ctx := ProcessorContext{
 		FileDependencies: make(map[string][]string),
-		ArtifactIDs: make(map[string]string),
+		ArtifactIDs:      make(map[string]string),
 	}
 
 	for _, comp := range *bom.Components {

--- a/pkg/sbomgen/build_files.go
+++ b/pkg/sbomgen/build_files.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/CycloneDX/cyclonedx-go"
+	packageurl "github.com/package-url/packageurl-go"
 )
 
 // FileType represents a recognized build/manifest file type.
@@ -173,35 +174,21 @@ const mavenParentPomProperty = "datadog:maven-parent-pom"
 // cycle.
 const mavenPackageProperty = "datadog:maven-package"
 
-// parseMavenArtifactID extracts "groupId:artifactId" from a Maven purl.
-// For example, "pkg:maven/com.example/my-module@1.0" yields "com.example:my-module".
-// Returns "" if the purl is not a Maven purl or cannot be parsed.
-func parseMavenArtifactID(purl string) string {
-	const prefix = "pkg:maven/"
-	if !strings.HasPrefix(purl, prefix) {
-		return ""
-	}
-	rest := purl[len(prefix):]
-
-	// Split into groupId/artifactId[@version]
-	slash := strings.IndexByte(rest, '/')
-	if slash < 0 {
-		return ""
-	}
-	groupID := rest[:slash]
-	artifactAndVersion := rest[slash+1:]
-
-	// Strip @version if present.
-	artifactID := artifactAndVersion
-	if at := strings.IndexByte(artifactAndVersion, '@'); at >= 0 {
-		artifactID = artifactAndVersion[:at]
-	}
-
-	if groupID == "" || artifactID == "" {
+// parseArtifactID extracts an ecosystem-specific artifact identifier from a
+// purl string. For purls with a namespace (e.g. Maven, npm) it returns
+// "namespace:name"; for purls without a namespace (e.g. PyPI) it returns the
+// name alone. Returns "" if the purl cannot be parsed.
+func parseArtifactID(purl string) string {
+	parsed, err := packageurl.FromString(purl)
+	if err != nil || parsed.Name == "" {
 		return ""
 	}
 
-	return groupID + ":" + artifactID
+	if parsed.Namespace != "" {
+		return parsed.Namespace + ":" + parsed.Name
+	}
+
+	return parsed.Name
 }
 
 // buildProcessorContext extracts enrichment data from the SBOM into a
@@ -212,7 +199,7 @@ func parseMavenArtifactID(purl string) string {
 func buildProcessorContext(bom *cyclonedx.BOM) ProcessorContext {
 	ctx := ProcessorContext{
 		FileDependencies: make(map[string][]string),
-		MavenArtifactIDs: make(map[string]string),
+		ArtifactIDs: make(map[string]string),
 	}
 
 	for _, comp := range *bom.Components {
@@ -221,8 +208,8 @@ func buildProcessorContext(bom *cyclonedx.BOM) ProcessorContext {
 		}
 		for _, prop := range *comp.Properties {
 			if prop.Name == mavenPackageProperty && prop.Value != "" {
-				if id := parseMavenArtifactID(prop.Value); id != "" {
-					ctx.MavenArtifactIDs[comp.BOMRef] = id
+				if id := parseArtifactID(prop.Value); id != "" {
+					ctx.ArtifactIDs[comp.BOMRef] = id
 				}
 			}
 		}

--- a/pkg/sbomgen/build_files.go
+++ b/pkg/sbomgen/build_files.go
@@ -119,12 +119,17 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile]BuildFile
 	grouped := make(map[FileType][]BuildFile)
 	seen := make(map[BuildFile]struct{})
 
+	// Track all file-type component paths so we can resolve cross-type
+	// dependency targets in the second pass below.
+	fileComponentPaths := make(map[string]struct{})
+
 	for _, comp := range *bom.Components {
-		// File-type components (produced by ExtractMavenPomArtifactIds) represent
+		// File-type components (produced by ExtractArtifactIds) represent
 		// build/manifest files directly. Their BOMRef is the filename relative to
 		// the repo root. Collect them so parent POMs with no package occurrences
 		// are never missed.
 		if comp.Type == cyclonedx.ComponentTypeFile && comp.BOMRef != "" {
+			fileComponentPaths[comp.BOMRef] = struct{}{}
 			addBuildFile(comp.BOMRef, filterSet, seen, grouped)
 		}
 
@@ -147,6 +152,34 @@ func GetBuildFileTrees(sbom []byte, filters ...FileType) map[BuildFile]BuildFile
 
 	// Build the ProcessorContext from the SBOM dependencies section.
 	ctx := buildProcessorContext(&bom)
+
+	// Second pass: resolve cross-type dependency targets.
+	//
+	// A file-type component may have a different basename than the lockfile
+	// that depends on it (e.g. setup.py is a dependency target of
+	// requirements.txt). When a filter is active, such targets are missed by
+	// the first pass because their FileType doesn't match the filter.
+	//
+	// We fix this by scanning dependency edges of already-collected files:
+	// if a dependency target is a known file-type component that wasn't
+	// collected, we add it to the same FileType group as its dependent so
+	// the processor can resolve it during BFS.
+	if len(filterSet) > 0 {
+		for ft, files := range grouped {
+			for _, f := range files {
+				for _, depPath := range ctx.FileDependencies[f.FilePath] {
+					if _, isFileComponent := fileComponentPaths[depPath]; !isFileComponent {
+						continue
+					}
+					bf := BuildFile{FileType: ft, FilePath: depPath}
+					if _, exists := seen[bf]; !exists {
+						seen[bf] = struct{}{}
+						grouped[ft] = append(grouped[ft], bf)
+					}
+				}
+			}
+		}
+	}
 
 	// Dispatch each group to its registered processor and merge the results.
 	for ft, files := range grouped {

--- a/pkg/sbomgen/build_files_test.go
+++ b/pkg/sbomgen/build_files_test.go
@@ -446,3 +446,64 @@ func TestGetBuildFileTrees_RegisteredProcessorIsCalled(t *testing.T) {
 		t.Errorf("processor received unexpected files: %v", stub.received)
 	}
 }
+
+func TestParseArtifactID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		purl     string
+		expected string
+	}{
+		{
+			name:     "Maven purl returns namespace:name",
+			purl:     "pkg:maven/com.example/my-module@1.0",
+			expected: "com.example:my-module",
+		},
+		{
+			name:     "Maven purl without version",
+			purl:     "pkg:maven/com.example/my-module",
+			expected: "com.example:my-module",
+		},
+		{
+			name:     "PyPI purl returns name only",
+			purl:     "pkg:pypi/mylib@1.0",
+			expected: "mylib",
+		},
+		{
+			name:     "PyPI purl without version",
+			purl:     "pkg:pypi/mylib",
+			expected: "mylib",
+		},
+		{
+			name:     "npm purl with namespace returns namespace:name",
+			purl:     "pkg:npm/%40angular/core@12.0.0",
+			expected: "@angular:core",
+		},
+		{
+			name:     "npm purl without namespace returns name only",
+			purl:     "pkg:npm/lodash@4.17.21",
+			expected: "lodash",
+		},
+		{
+			name:     "invalid purl returns empty",
+			purl:     "not-a-purl",
+			expected: "",
+		},
+		{
+			name:     "empty string returns empty",
+			purl:     "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseArtifactID(tt.purl)
+			if got != tt.expected {
+				t.Errorf("parseArtifactID(%q) = %q, want %q", tt.purl, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/sbomgen/build_files_test.go
+++ b/pkg/sbomgen/build_files_test.go
@@ -351,7 +351,7 @@ func TestGetBuildFileTrees_UnknownManifestIncluded(t *testing.T) {
 }
 
 // fileTypeComponent creates a CycloneDX component of type "file" with the given
-// BOMRef/Name, as produced by ExtractMavenPomArtifactIds for manifest files.
+// BOMRef/Name, as produced by ExtractArtifactIds for manifest files.
 func fileTypeComponent(filename string) cyclonedx.Component {
 	return cyclonedx.Component{
 		Type:   cyclonedx.ComponentTypeFile,

--- a/pkg/sbomgen/sbomgen.go
+++ b/pkg/sbomgen/sbomgen.go
@@ -31,10 +31,17 @@ type Options struct {
 	// ExcludePaths is a list of glob patterns to exclude from scanning.
 	ExcludePaths []string
 
+	// ManifestParsers enables extractors that read manifest files (e.g.
+	// pyproject.toml, package.json) as package sources when no lockfile is
+	// present. Additive to the default lockfile extractor set.
+	ManifestParsers bool
+
 	// ExtractArtifactIds controls whether build file artifact IDs and dependency
 	// relationships are extracted and included in the SBOM. When true, extractors
 	// that implement ArtifactExtractor produce file-type components and dependency
 	// edges, enabling GetBuildFileTrees dependency and ID resolution.
+	// Enabling this also activates manifest parsers internally, because manifest
+	// extractors (e.g. PyProjectTOMLExtractor) are needed to call GetArtifact.
 	// Defaults to true in DefaultOptions.
 	ExtractArtifactIds bool
 }
@@ -62,7 +69,7 @@ func GenerateSBOM(dirs []string, opts Options) ([]byte, error) {
 		DirectoryPaths:     dirs,
 		ExcludePaths:       opts.ExcludePaths,
 		Recursive:          opts.Recursive,
-		ManifestParsers:    opts.ExtractArtifactIds,
+		ManifestParsers:    opts.ManifestParsers || opts.ExtractArtifactIds,
 		ExtractArtifactIds: opts.ExtractArtifactIds,
 	}
 

--- a/pkg/sbomgen/sbomgen.go
+++ b/pkg/sbomgen/sbomgen.go
@@ -62,6 +62,7 @@ func GenerateSBOM(dirs []string, opts Options) ([]byte, error) {
 		DirectoryPaths:     dirs,
 		ExcludePaths:       opts.ExcludePaths,
 		Recursive:          opts.Recursive,
+		ManifestParsers:    opts.ExtractArtifactIds,
 		ExtractArtifactIds: opts.ExtractArtifactIds,
 	}
 

--- a/pkg/sbomgen/sbomgen.go
+++ b/pkg/sbomgen/sbomgen.go
@@ -31,19 +31,21 @@ type Options struct {
 	// ExcludePaths is a list of glob patterns to exclude from scanning.
 	ExcludePaths []string
 
-	// ExtractMavenPomArtifactIds controls whether Maven pom.xml artifact IDs
-	// and parent dependency relationships are extracted and included in the SBOM.
+	// ExtractArtifactIds controls whether build file artifact IDs and dependency
+	// relationships are extracted and included in the SBOM. When true, extractors
+	// that implement ArtifactExtractor produce file-type components and dependency
+	// edges, enabling GetBuildFileTrees dependency and ID resolution.
 	// Defaults to true in DefaultOptions.
-	ExtractMavenPomArtifactIds bool
+	ExtractArtifactIds bool
 }
 
 // DefaultOptions returns Options with sensible defaults:
 // recursive scanning enabled, no exclusions, and artifact extraction enabled.
 func DefaultOptions() Options {
 	return Options{
-		Recursive:                  true,
-		ExcludePaths:               []string{},
-		ExtractMavenPomArtifactIds: true,
+		Recursive:          true,
+		ExcludePaths:       []string{},
+		ExtractArtifactIds: true,
 	}
 }
 
@@ -57,10 +59,10 @@ func GenerateSBOM(dirs []string, opts Options) ([]byte, error) {
 	}
 
 	actions := scanner.ScannerActions{
-		DirectoryPaths:             dirs,
-		ExcludePaths:               opts.ExcludePaths,
-		Recursive:                  opts.Recursive,
-		ExtractMavenPomArtifactIds: opts.ExtractMavenPomArtifactIds,
+		DirectoryPaths:     dirs,
+		ExcludePaths:       opts.ExcludePaths,
+		Recursive:          opts.Recursive,
+		ExtractArtifactIds: opts.ExtractArtifactIds,
 	}
 
 	r := reporter.NewCycloneDXReporter(&bytes.Buffer{}, &bytes.Buffer{}, reporter.WarnLevel)

--- a/pkg/sbomgen/simple_processor.go
+++ b/pkg/sbomgen/simple_processor.go
@@ -65,4 +65,5 @@ func (p *SimpleProcessor) Process(files []BuildFile, ctx ProcessorContext) map[B
 func init() {
 	RegisterBuildFileProcessor(FileTypePomXML, &SimpleProcessor{})
 	RegisterBuildFileProcessor(FileTypeRequirementsTxt, &SimpleProcessor{})
+	RegisterBuildFileProcessor(FileTypePyprojectToml, &SimpleProcessor{})
 }

--- a/pkg/sbomgen/simple_processor.go
+++ b/pkg/sbomgen/simple_processor.go
@@ -64,4 +64,5 @@ func (p *SimpleProcessor) Process(files []BuildFile, ctx ProcessorContext) map[B
 //nolint:gochecknoinits
 func init() {
 	RegisterBuildFileProcessor(FileTypePomXML, &SimpleProcessor{})
+	RegisterBuildFileProcessor(FileTypeRequirementsTxt, &SimpleProcessor{})
 }

--- a/pkg/sbomgen/simple_processor.go
+++ b/pkg/sbomgen/simple_processor.go
@@ -2,21 +2,19 @@ package sbomgen
 
 import "sort"
 
-// MavenProcessor enriches pom.xml BuildFiles with transitive dependencies and
-// ecosystem-specific IDs derived from the SBOM.
-//
-// ProcessorContext.FileDependencies contains all direct dependency edges for
-// each POM — both <parent> relationships (from addFileDependencies) and
-// local-module <dependency> relationships (from createFileComponents). The
-// processor computes the full transitive closure via BFS over this graph,
+// SimpleProcessor enriches BuildFiles with transitive dependencies and
+// ecosystem-specific IDs derived from the SBOM. It uses BFS over
+// ProcessorContext.FileDependencies to compute the full transitive closure,
 // restricted to build files present in the SBOM.
 //
-// The ID field is populated with "groupId:artifactId" from the
-// "datadog:maven-package" purl property via ProcessorContext.MavenArtifactIDs.
-type MavenProcessor struct{}
+// The ID field is populated from ProcessorContext.ArtifactIDs.
+//
+// SimpleProcessor is suitable for any file type that follows the "BFS +
+// optional artifact ID" pattern. Register it for each such FileType in init().
+type SimpleProcessor struct{}
 
-// Process resolves transitive dependencies and IDs for a set of pom.xml BuildFiles.
-func (p *MavenProcessor) Process(files []BuildFile, ctx ProcessorContext) map[BuildFile]BuildFileRelations {
+// Process resolves transitive dependencies and IDs for a set of BuildFiles.
+func (p *SimpleProcessor) Process(files []BuildFile, ctx ProcessorContext) map[BuildFile]BuildFileRelations {
 	// Index files by path for O(1) lookup.
 	filesByPath := make(map[string]BuildFile, len(files))
 	for _, f := range files {
@@ -24,8 +22,6 @@ func (p *MavenProcessor) Process(files []BuildFile, ctx ProcessorContext) map[Bu
 	}
 
 	// Build the result map with full transitive closure via BFS for each file.
-	// FileDependencies contains both parent edges and local-module dependency
-	// edges, so BFS captures all reachable local build files in one pass.
 	result := make(map[BuildFile]BuildFileRelations, len(files))
 	for _, f := range files {
 		var deps []BuildFile
@@ -57,7 +53,7 @@ func (p *MavenProcessor) Process(files []BuildFile, ctx ProcessorContext) map[Bu
 		}
 
 		result[f] = BuildFileRelations{
-			ID:           ctx.MavenArtifactIDs[f.FilePath],
+			ID:           ctx.ArtifactIDs[f.FilePath],
 			Dependencies: deps,
 		}
 	}
@@ -67,5 +63,5 @@ func (p *MavenProcessor) Process(files []BuildFile, ctx ProcessorContext) map[Bu
 
 //nolint:gochecknoinits
 func init() {
-	RegisterBuildFileProcessor(FileTypePomXML, &MavenProcessor{})
+	RegisterBuildFileProcessor(FileTypePomXML, &SimpleProcessor{})
 }

--- a/pkg/sbomgen/simple_processor_test.go
+++ b/pkg/sbomgen/simple_processor_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // mavenFileComponent creates a file-type CycloneDX component representing a
-// pom.xml, as produced by ExtractArtifacts. artifactID is the Maven
+// pom.xml, as produced by ExtractArtifactIds. artifactID is the Maven
 // "groupId:artifactId" (e.g. "com.example:child"). If parentPath is non-empty
 // it sets the datadog:maven-parent-pom property, encoding the <parent>
 // relationship unambiguously.
@@ -353,9 +353,134 @@ func TestSimpleProcessor_Maven_SiblingModuleDependency(t *testing.T) {
 	}
 }
 
+// --- Python requirements.txt tests ---
+
+// pythonFileComponent creates a file-type CycloneDX component representing a
+// Python source file (setup.py or pyproject.toml), as produced by
+// ExtractArtifactIds. packageName is the normalized Python package name.
+func pythonFileComponent(sourcePath, packageName string) cyclonedx.Component {
+	purl := "pkg:pypi/" + packageName + "@1.0"
+
+	props := []cyclonedx.Property{
+		{Name: mavenPackageProperty, Value: purl},
+	}
+
+	return cyclonedx.Component{
+		Type:       cyclonedx.ComponentTypeFile,
+		BOMRef:     sourcePath,
+		Name:       sourcePath,
+		Properties: &props,
+	}
+}
+
+// pythonComponent builds a CycloneDX component with a manifest occurrence for
+// the given requirements.txt path, as the SBOM generator would emit it.
+func pythonComponent(name, requirementsPath string) cyclonedx.Component {
+	return componentWithOccurrences(name, "1.0", makeLocation(requirementsPath, "manifest"))
+}
+
+// reqFile is a shorthand for a requirements.txt BuildFile.
+func reqFile(path string) BuildFile {
+	return BuildFile{FileType: FileTypeRequirementsTxt, FilePath: path}
+}
+
+// TestSimpleProcessor_RequirementsTxt_InterModuleDependency verifies the
+// end-to-end inter-module flow:
+//
+//	app/requirements.txt  →  depends on mylib (resolved via libs/mylib/setup.py)
+//	libs/mylib/setup.py   →  file-type component with pkg:pypi/mylib@1.0
+//
+// GetBuildFileTrees should return app/requirements.txt with a dependency on
+// libs/mylib/setup.py, and the setup.py entry with ID="mylib".
+func TestSimpleProcessor_RequirementsTxt_InterModuleDependency(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			pythonFileComponent("libs/mylib/setup.py", "mylib"),
+			pythonComponent("mylib", "app/requirements.txt"),
+		},
+		[]cyclonedx.Dependency{
+			{Ref: "app/requirements.txt", Dependencies: &[]string{"libs/mylib/setup.py"}},
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypeRequirementsTxt)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries (requirements.txt + setup.py), got %d: %v", len(result), result)
+	}
+
+	// app/requirements.txt should depend on libs/mylib/setup.py.
+	req := result[reqFile("app/requirements.txt")]
+	if len(req.Dependencies) != 1 {
+		t.Fatalf("app/requirements.txt: expected 1 dependency, got %v", req.Dependencies)
+	}
+	if req.Dependencies[0].FilePath != "libs/mylib/setup.py" {
+		t.Errorf("app/requirements.txt: expected dep on libs/mylib/setup.py, got %v", req.Dependencies[0])
+	}
+
+	// libs/mylib/setup.py should have ID="mylib" and no dependencies.
+	setupPy := result[reqFile("libs/mylib/setup.py")]
+	if setupPy.ID != "mylib" {
+		t.Errorf("libs/mylib/setup.py: expected ID=mylib, got %q", setupPy.ID)
+	}
+	if len(setupPy.Dependencies) != 0 {
+		t.Errorf("libs/mylib/setup.py: expected no Dependencies, got %v", setupPy.Dependencies)
+	}
+}
+
+// TestSimpleProcessor_RequirementsTxt_NoInterModuleDeps verifies that a
+// standalone requirements.txt with no file-type components or dependency edges
+// gets empty dependencies.
+func TestSimpleProcessor_RequirementsTxt_NoInterModuleDeps(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOM([]cyclonedx.Component{
+		pythonComponent("requests", "requirements.txt"),
+	})
+
+	result := GetBuildFileTrees(sbom, FileTypeRequirementsTxt)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+
+	rel := result[reqFile("requirements.txt")]
+	if len(rel.Dependencies) != 0 {
+		t.Errorf("expected no Dependencies, got %v", rel.Dependencies)
+	}
+	if rel.ID != "" {
+		t.Errorf("expected empty ID, got %q", rel.ID)
+	}
+}
+
+// TestSimpleProcessor_RequirementsTxt_ArtifactID verifies that ArtifactIDs
+// are correctly populated from a pkg:pypi purl on a file-type component.
+func TestSimpleProcessor_RequirementsTxt_ArtifactID(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			pythonFileComponent("libs/mylib/setup.py", "mylib"),
+			pythonComponent("mylib", "app/requirements.txt"),
+		},
+		[]cyclonedx.Dependency{
+			{Ref: "app/requirements.txt", Dependencies: &[]string{"libs/mylib/setup.py"}},
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypeRequirementsTxt)
+
+	setupPy := result[reqFile("libs/mylib/setup.py")]
+	if setupPy.ID != "mylib" {
+		t.Errorf("expected ID=mylib, got %q", setupPy.ID)
+	}
+}
+
 // TestSimpleProcessor_Maven_ParentPomViaFileComponent verifies that a parent POM which
 // has no package occurrences of its own is still discovered via the file-type
-// component emitted by ExtractMavenPomArtifactIds, and appears in the child's
+// component emitted by ExtractArtifactIds, and appears in the child's
 // Dependencies.
 //
 // Layout:

--- a/pkg/sbomgen/simple_processor_test.go
+++ b/pkg/sbomgen/simple_processor_test.go
@@ -2,18 +2,24 @@ package sbomgen
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
 )
 
 // mavenFileComponent creates a file-type CycloneDX component representing a
-// pom.xml, as produced by ExtractMavenPomArtifactIds. If parentPath is
-// non-empty it sets the datadog:maven-parent-pom property, encoding the <parent>
+// pom.xml, as produced by ExtractArtifacts. artifactID is the Maven
+// "groupId:artifactId" (e.g. "com.example:child"). If parentPath is non-empty
+// it sets the datadog:maven-parent-pom property, encoding the <parent>
 // relationship unambiguously.
-func mavenFileComponent(pomPath, parentPath string) cyclonedx.Component {
+func mavenFileComponent(pomPath, artifactID, parentPath string) cyclonedx.Component {
+	// Build a realistic Maven purl from the artifactID: "group:name" -> "pkg:maven/group/name@1.0"
+	parts := strings.SplitN(artifactID, ":", 2)
+	purl := "pkg:maven/" + parts[0] + "/" + parts[1] + "@1.0"
+
 	props := []cyclonedx.Property{
-		{Name: mavenPackageProperty, Value: "pkg:maven/com.example/" + pomPath + "@1.0"},
+		{Name: mavenPackageProperty, Value: purl},
 	}
 	if parentPath != "" {
 		props = append(props, cyclonedx.Property{
@@ -67,13 +73,13 @@ func pomFile(path string) BuildFile {
 
 // --- Tests ---
 
-// TestMavenProcessor_SingleRootPom verifies that a standalone pom.xml
+// TestSimpleProcessor_Maven_SingleRootPom verifies that a standalone pom.xml
 // (no parent, no modules) gets empty dependencies and an ID from the purl.
-func TestMavenProcessor_SingleRootPom(t *testing.T) {
+func TestSimpleProcessor_Maven_SingleRootPom(t *testing.T) {
 	t.Parallel()
 
 	sbom := makeSBOM([]cyclonedx.Component{
-		mavenFileComponent("pom.xml", ""),
+		mavenFileComponent("pom.xml", "com.example:app", ""),
 		mavenComponent("com.example:app", "pom.xml"),
 	})
 
@@ -83,27 +89,27 @@ func TestMavenProcessor_SingleRootPom(t *testing.T) {
 		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
 	}
 	rel := result[pomFile("pom.xml")]
-	if rel.ID != "com.example:pom.xml" {
-		t.Errorf("expected ID=com.example:pom.xml, got %q", rel.ID)
+	if rel.ID != "com.example:app" {
+		t.Errorf("expected ID=com.example:app, got %q", rel.ID)
 	}
 	if len(rel.Dependencies) != 0 {
 		t.Errorf("expected no Dependencies, got %v", rel.Dependencies)
 	}
 }
 
-// TestMavenProcessor_ParentChild verifies a simple two-level hierarchy:
+// TestSimpleProcessor_Maven_ParentChild verifies a simple two-level hierarchy:
 //
 //	pom.xml
 //	└── child/pom.xml
 //
 // child depends on pom.xml (its parent). root has no dependencies.
-func TestMavenProcessor_ParentChild(t *testing.T) {
+func TestSimpleProcessor_Maven_ParentChild(t *testing.T) {
 	t.Parallel()
 
 	sbom := makeSBOMWithDeps(
 		[]cyclonedx.Component{
-			mavenFileComponent("pom.xml", ""),
-			mavenFileComponent("child/pom.xml", "pom.xml"),
+			mavenFileComponent("pom.xml", "com.example:parent", ""),
+			mavenFileComponent("child/pom.xml", "com.example:child", "pom.xml"),
 			mavenComponent("com.example:parent", "pom.xml"),
 			mavenComponent("com.example:child", "child/pom.xml"),
 		},
@@ -119,23 +125,23 @@ func TestMavenProcessor_ParentChild(t *testing.T) {
 	}
 
 	root := result[pomFile("pom.xml")]
-	if root.ID != "com.example:pom.xml" {
-		t.Errorf("root: expected ID=com.example:pom.xml, got %q", root.ID)
+	if root.ID != "com.example:parent" {
+		t.Errorf("root: expected ID=com.example:parent, got %q", root.ID)
 	}
 	if len(root.Dependencies) != 0 {
 		t.Errorf("root: expected no Dependencies, got %v", root.Dependencies)
 	}
 
 	child := result[pomFile("child/pom.xml")]
-	if child.ID != "com.example:child/pom.xml" {
-		t.Errorf("child: expected ID=com.example:child/pom.xml, got %q", child.ID)
+	if child.ID != "com.example:child" {
+		t.Errorf("child: expected ID=com.example:child, got %q", child.ID)
 	}
 	if len(child.Dependencies) != 1 || child.Dependencies[0] != pomFile("pom.xml") {
 		t.Errorf("child: expected Dependencies=[pom.xml], got %v", child.Dependencies)
 	}
 }
 
-// TestMavenProcessor_MultiModule verifies a flat multi-module layout:
+// TestSimpleProcessor_Maven_MultiModule verifies a flat multi-module layout:
 //
 //	pom.xml (aggregator)
 //	├── core/pom.xml
@@ -143,15 +149,15 @@ func TestMavenProcessor_ParentChild(t *testing.T) {
 //	└── integration-tests/pom.xml
 //
 // Each child depends on pom.xml (its parent). Root has no dependencies.
-func TestMavenProcessor_MultiModule(t *testing.T) {
+func TestSimpleProcessor_Maven_MultiModule(t *testing.T) {
 	t.Parallel()
 
 	sbom := makeSBOMWithDeps(
 		[]cyclonedx.Component{
-			mavenFileComponent("pom.xml", ""),
-			mavenFileComponent("core/pom.xml", "pom.xml"),
-			mavenFileComponent("web/pom.xml", "pom.xml"),
-			mavenFileComponent("integration-tests/pom.xml", "pom.xml"),
+			mavenFileComponent("pom.xml", "com.example:parent", ""),
+			mavenFileComponent("core/pom.xml", "com.example:core", "pom.xml"),
+			mavenFileComponent("web/pom.xml", "com.example:web", "pom.xml"),
+			mavenFileComponent("integration-tests/pom.xml", "com.example:integration-tests", "pom.xml"),
 			mavenComponent("com.example:parent", "pom.xml"),
 			mavenComponent("com.example:core", "core/pom.xml"),
 			mavenComponent("com.example:web", "web/pom.xml"),
@@ -171,16 +177,21 @@ func TestMavenProcessor_MultiModule(t *testing.T) {
 	}
 
 	root := result[pomFile("pom.xml")]
-	if root.ID != "com.example:pom.xml" {
-		t.Errorf("root: expected ID=com.example:pom.xml, got %q", root.ID)
+	if root.ID != "com.example:parent" {
+		t.Errorf("root: expected ID=com.example:parent, got %q", root.ID)
 	}
 	if len(root.Dependencies) != 0 {
 		t.Errorf("root: expected no Dependencies, got %v", root.Dependencies)
 	}
 
+	expectedIDs := map[string]string{
+		"core/pom.xml":              "com.example:core",
+		"integration-tests/pom.xml": "com.example:integration-tests",
+		"web/pom.xml":               "com.example:web",
+	}
 	for _, childPath := range []string{"core/pom.xml", "integration-tests/pom.xml", "web/pom.xml"} {
 		rel := result[pomFile(childPath)]
-		expectedID := "com.example:" + childPath
+		expectedID := expectedIDs[childPath]
 		if rel.ID != expectedID {
 			t.Errorf("%s: expected ID=%s, got %q", childPath, expectedID, rel.ID)
 		}
@@ -190,7 +201,7 @@ func TestMavenProcessor_MultiModule(t *testing.T) {
 	}
 }
 
-// TestMavenProcessor_DeepHierarchy verifies a three-level chain:
+// TestSimpleProcessor_Maven_DeepHierarchy verifies a three-level chain:
 //
 //	pom.xml
 //	└── module/pom.xml
@@ -198,14 +209,14 @@ func TestMavenProcessor_MultiModule(t *testing.T) {
 //
 // Transitive closure: root.Dependencies=[], mid.Dependencies=[pom.xml],
 // leaf.Dependencies=[module/pom.xml, pom.xml] (sorted by FilePath).
-func TestMavenProcessor_DeepHierarchy(t *testing.T) {
+func TestSimpleProcessor_Maven_DeepHierarchy(t *testing.T) {
 	t.Parallel()
 
 	sbom := makeSBOMWithDeps(
 		[]cyclonedx.Component{
-			mavenFileComponent("pom.xml", ""),
-			mavenFileComponent("module/pom.xml", "pom.xml"),
-			mavenFileComponent("module/sub/pom.xml", "module/pom.xml"),
+			mavenFileComponent("pom.xml", "com.example:root", ""),
+			mavenFileComponent("module/pom.xml", "com.example:module", "pom.xml"),
+			mavenFileComponent("module/sub/pom.xml", "com.example:sub", "module/pom.xml"),
 			mavenComponent("com.example:root", "pom.xml"),
 			mavenComponent("com.example:module", "module/pom.xml"),
 			mavenComponent("com.example:sub", "module/sub/pom.xml"),
@@ -219,24 +230,24 @@ func TestMavenProcessor_DeepHierarchy(t *testing.T) {
 	result := GetBuildFileTrees(sbom, FileTypePomXML)
 
 	root := result[pomFile("pom.xml")]
-	if root.ID != "com.example:pom.xml" {
-		t.Errorf("root: expected ID=com.example:pom.xml, got %q", root.ID)
+	if root.ID != "com.example:root" {
+		t.Errorf("root: expected ID=com.example:root, got %q", root.ID)
 	}
 	if len(root.Dependencies) != 0 {
 		t.Errorf("root: expected no Dependencies, got %v", root.Dependencies)
 	}
 
 	mid := result[pomFile("module/pom.xml")]
-	if mid.ID != "com.example:module/pom.xml" {
-		t.Errorf("module: expected ID=com.example:module/pom.xml, got %q", mid.ID)
+	if mid.ID != "com.example:module" {
+		t.Errorf("module: expected ID=com.example:module, got %q", mid.ID)
 	}
 	if len(mid.Dependencies) != 1 || mid.Dependencies[0] != pomFile("pom.xml") {
 		t.Errorf("module: expected Dependencies=[pom.xml], got %v", mid.Dependencies)
 	}
 
 	leaf := result[pomFile("module/sub/pom.xml")]
-	if leaf.ID != "com.example:module/sub/pom.xml" {
-		t.Errorf("sub: expected ID=com.example:module/sub/pom.xml, got %q", leaf.ID)
+	if leaf.ID != "com.example:sub" {
+		t.Errorf("sub: expected ID=com.example:sub, got %q", leaf.ID)
 	}
 	// Transitive: leaf depends on module/pom.xml AND pom.xml, sorted by FilePath.
 	if len(leaf.Dependencies) != 2 {
@@ -250,17 +261,17 @@ func TestMavenProcessor_DeepHierarchy(t *testing.T) {
 	}
 }
 
-// TestMavenProcessor_ExternalParentIgnored verifies that a dependency edge
+// TestSimpleProcessor_Maven_ExternalParentIgnored verifies that a dependency edge
 // pointing to a POM path not present in the SBOM (e.g. a parent from Maven
 // Central) is silently ignored — the file has no dependencies.
-func TestMavenProcessor_ExternalParentIgnored(t *testing.T) {
+func TestSimpleProcessor_Maven_ExternalParentIgnored(t *testing.T) {
 	t.Parallel()
 
 	const externalParent = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-parent/3.0.0/spring-boot-starter-parent-3.0.0.pom"
 
 	sbom := makeSBOMWithDeps(
 		[]cyclonedx.Component{
-			mavenFileComponent("pom.xml", externalParent),
+			mavenFileComponent("pom.xml", "com.example:child", externalParent),
 			mavenComponent("com.example:child", "pom.xml"),
 		},
 		[]cyclonedx.Dependency{
@@ -271,15 +282,15 @@ func TestMavenProcessor_ExternalParentIgnored(t *testing.T) {
 	result := GetBuildFileTrees(sbom, FileTypePomXML)
 
 	rel := result[pomFile("pom.xml")]
-	if rel.ID != "com.example:pom.xml" {
-		t.Errorf("expected ID=com.example:pom.xml, got %q", rel.ID)
+	if rel.ID != "com.example:child" {
+		t.Errorf("expected ID=com.example:child, got %q", rel.ID)
 	}
 	if len(rel.Dependencies) != 0 {
 		t.Errorf("expected no Dependencies for external parent, got %v", rel.Dependencies)
 	}
 }
 
-// TestMavenProcessor_SiblingModuleIncludedAsDependency verifies that when a
+// TestSimpleProcessor_Maven_SiblingModuleDependency verifies that when a
 // module depends on a sibling module (ordinary Maven <dependency>) in addition
 // to a <parent>, BOTH the parent and the sibling appear in Dependencies.
 // bom.Dependencies carries both edge types (parent from addFileDependencies,
@@ -291,14 +302,14 @@ func TestMavenProcessor_ExternalParentIgnored(t *testing.T) {
 //	pom.xml (root aggregator)
 //	├── module-a/pom.xml  (parent=pom.xml, <dependency> on module-b)
 //	└── module-b/pom.xml  (parent=pom.xml)
-func TestMavenProcessor_SiblingModuleIncludedAsDependency(t *testing.T) {
+func TestSimpleProcessor_Maven_SiblingModuleDependency(t *testing.T) {
 	t.Parallel()
 
 	sbom := makeSBOMWithDeps(
 		[]cyclonedx.Component{
-			mavenFileComponent("pom.xml", ""),
-			mavenFileComponent("module-a/pom.xml", "pom.xml"),
-			mavenFileComponent("module-b/pom.xml", "pom.xml"),
+			mavenFileComponent("pom.xml", "com.example:root", ""),
+			mavenFileComponent("module-a/pom.xml", "com.example:module-a", "pom.xml"),
+			mavenFileComponent("module-b/pom.xml", "com.example:module-b", "pom.xml"),
 			mavenComponent("com.example:root", "pom.xml"),
 			mavenComponent("com.example:module-a", "module-a/pom.xml"),
 			mavenComponent("com.example:module-b", "module-b/pom.xml"),
@@ -342,7 +353,7 @@ func TestMavenProcessor_SiblingModuleIncludedAsDependency(t *testing.T) {
 	}
 }
 
-// TestMavenProcessor_ParentPomViaFileComponent verifies that a parent POM which
+// TestSimpleProcessor_Maven_ParentPomViaFileComponent verifies that a parent POM which
 // has no package occurrences of its own is still discovered via the file-type
 // component emitted by ExtractMavenPomArtifactIds, and appears in the child's
 // Dependencies.
@@ -351,13 +362,13 @@ func TestMavenProcessor_SiblingModuleIncludedAsDependency(t *testing.T) {
 //
 //	pom.xml        ← file-type component only (no package occurrences)
 //	└── child/pom.xml  ← normal package occurrence
-func TestMavenProcessor_ParentPomViaFileComponent(t *testing.T) {
+func TestSimpleProcessor_Maven_ParentPomViaFileComponent(t *testing.T) {
 	t.Parallel()
 
 	sbom := makeSBOMWithDeps(
 		[]cyclonedx.Component{
-			mavenFileComponent("pom.xml", ""),
-			mavenFileComponent("child/pom.xml", "pom.xml"),
+			mavenFileComponent("pom.xml", "com.example:parent", ""),
+			mavenFileComponent("child/pom.xml", "com.example:child", "pom.xml"),
 			mavenComponent("com.example:child", "child/pom.xml"),
 		},
 		[]cyclonedx.Dependency{

--- a/pkg/scanner/datadog_sbom_generator.go
+++ b/pkg/scanner/datadog_sbom_generator.go
@@ -48,10 +48,11 @@ type ScannerActions struct {
 	ManifestParsers     bool
 	DDEnvVars           DDEnvVars
 	ExitOnConfigFailure bool
-	// ExtractMavenPomArtifactIds controls whether Maven pom.xml artifact IDs
-	// and parent dependency relationships are extracted and included in the SBOM.
+	// ExtractArtifactIds controls whether build file artifact IDs and dependency
+	// relationships are extracted and included in the SBOM. When true, extractors
+	// that implement ArtifactExtractor produce ScannedArtifact entries.
 	// When false, ScannedArtifact entries are never produced.
-	ExtractMavenPomArtifactIds bool
+	ExtractArtifactIds bool
 }
 
 type DDEnvVars struct {
@@ -82,7 +83,7 @@ var ErrAPIFailed = models.ErrAPIFailed
 // scanDir walks through the given directory to try to find any relevant files
 // These include:
 //   - Any lockfiles with scanLockfile
-func scanDir(r reporter.Reporter, dir string, repoRoot string, recursive bool, useGitIgnore bool, enabledParsers map[string]bool, cliExcludePaths []string, configExcludePaths []string, extractMavenPomArtifactIds bool) ([]extractor.PackageDetails, []models.ScannedArtifact, error) {
+func scanDir(r reporter.Reporter, dir string, repoRoot string, recursive bool, useGitIgnore bool, enabledParsers map[string]bool, cliExcludePaths []string, configExcludePaths []string, extractArtifacts bool) ([]extractor.PackageDetails, []models.ScannedArtifact, error) {
 	scanRoot := dir
 	// Normalize the scan root once before exclusion matching.
 	if absPath, err := filepath.Abs(dir); err == nil {
@@ -154,7 +155,7 @@ func scanDir(r reporter.Reporter, dir string, repoRoot string, recursive bool, u
 					return nil
 				}
 
-				context := extractor.ScanContext{EnabledParsers: enabledParsers, RootDir: dir, Reporter: r, ExtractMavenPomArtifactIds: extractMavenPomArtifactIds}
+				context := extractor.ScanContext{EnabledParsers: enabledParsers, RootDir: dir, Reporter: r, ExtractArtifactIds: extractArtifacts}
 				pkgs, artifact, err := scanLockfile(path, context)
 				if err != nil {
 					r.Warnf("Attempted to scan lockfile but failed: %s (%v)\n", path, err.Error())
@@ -303,7 +304,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 			absolutePath = absPath
 		}
 		r.Infof("Scanning directory '%s', resolved absolute path '%s'\n", dir, absolutePath)
-		pkgs, artifacts, err := scanDir(r, dir, repoRoot, actions.Recursive, !actions.NoIgnore, enabledParsers, actions.ExcludePaths, configExcludePaths, actions.ExtractMavenPomArtifactIds)
+		pkgs, artifacts, err := scanDir(r, dir, repoRoot, actions.Recursive, !actions.NoIgnore, enabledParsers, actions.ExcludePaths, configExcludePaths, actions.ExtractArtifactIds)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}


### PR DESCRIPTION
## Summary

- **Replaces `MavenProcessor` with a generic `SimpleProcessor`** that handles build file tree generation for any file type via BFS over `FileDependencies`. Adding support for a new file type now requires only a registration call — no new processor code needed.
- **Adds `GetArtifact` to `PyProjectTOMLExtractor`** so `pyproject.toml` files report their module identity (reading `[project].name` or `[tool.poetry].name`) — enabling Python inter-module relationships in `GetBuildFileTrees`.
- **Registers `SimpleProcessor` for `requirements.txt` and `pyproject.toml`** so both file types participate in build file tree traversal.
- **Renames flag to `ExtractArtifactIds`** (previously `ExtractArtifacts`) for clarity.
- **Exposes `ManifestParsers` as an independent field in `sbomgen.Options`**, decoupled from `ExtractArtifactIds`. Manifest parsing (pyproject.toml as package source when no lockfile exists) and artifact ID extraction are orthogonal capabilities. Internally, `ExtractArtifactIds=true` still activates manifest parsers as a side-effect (required for `GetArtifact` to run on manifest extractors).
- **Emits a bare `type:file` SBOM component for every build file that opts in** (by implementing `ArtifactExtractor`) when `ExtractArtifactIds=true`, even if `GetArtifact` returns no identity. Lockfile-only parsers (Cargo.lock, yarn.lock, etc.) that do not implement `ArtifactExtractor` are unaffected. `RequirementsTxtExtractor` implements `ArtifactExtractor` with a trivial `GetArtifact` returning `nil`, so `requirements.txt` files appear in `GetBuildFileTrees` even when they contain only local editable deps.
- **Fixes `findArtifact` version matching** to also match when the artifact has no declared version — handles local modules that omit the version field.
- **Generalizes `parseArtifactID`** from Maven-only to any purl type.

## Changes

| File | What changed |
|------|-------------|
| `pkg/sbomgen/simple_processor.go` | New `SimpleProcessor` (replaces `MavenProcessor`); registered for `pom.xml`, `requirements.txt`, and `pyproject.toml` |
| `pkg/sbomgen/build_files.go` | Generic `parseArtifactID`; fixed-point cross-type expansion |
| `pkg/sbomgen/sbomgen.go` | `ManifestParsers` exposed as independent `Options` field; `ExtractArtifactIds` renamed |
| `pkg/extractor/python/parse-pyproject-toml.go` | `GetArtifact`: reads `[project].name` then `[tool.poetry].name` |
| `pkg/extractor/python/parse-requirements-txt.go` | Trivial `GetArtifact` so requirements.txt opts in to file-type component emission |
| `pkg/extractor/python/types.go` | Added `Name` field to `PyProjectPoetry` struct |
| `pkg/extractor/extract.go` | Bare `ScannedArtifact` fallback scoped to `ArtifactExtractor` implementors only |
| `internal/output/sbom/cyclonedx.go` | `addFileDependencies` handles name-less artifacts; `findArtifact` allows empty artifact version |
| `pkg/scanner/datadog_sbom_generator.go` | Updated flag name reference |

## Test plan

- [x] Unit tests for `SimpleProcessor` (BFS traversal, artifact ID lookup, multi-type registration)
- [x] Unit tests for `PyProjectTOMLExtractor.GetArtifact` (PEP project name, poetry name fallback, missing name, parse error)
- [x] `build_files_test.go`: cross-type expansion, empty-name artifacts, fixed-point loop
- [x] Snapshot tests updated for `addFileDependencies` bare artifact change
- [x] All existing Maven tests pass with `SimpleProcessor`
- [x] `go test ./...` passes
- [x] `golangci-lint` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)