### PR TITLE
[codex] Guard against legacy SBOM property prefixes

### DIFF
--- a/cmd/datadog-sbom-generator/main_test.go
+++ b/cmd/datadog-sbom-generator/main_test.go
@@ -390,6 +390,25 @@ func TestRun_WithCycloneDX15(t *testing.T) {
 	})
 }
 
+func TestRun_CycloneDX15DoesNotEmitLegacyPropertyPrefixes(t *testing.T) {
+	t.Parallel()
+	args := []string{
+		"",
+		"--format=cyclonedx-1-5",
+		"--pretty",
+		"./fixtures/integration-test-locks",
+	}
+
+	stdout, _ := runCli(t, cliTestCase{
+		name: "CycloneDX15DoesNotEmitLegacyPropertyPrefixes",
+		args: args,
+		exit: 0,
+	})
+
+	assert.NotContains(t, stdout, "osv-scanner:")
+	assert.NotContains(t, stdout, "datadog-sbom-generator:")
+}
+
 func TestRun_WithEmptyCycloneDX15(t *testing.T) {
 	t.Parallel()
 	args := []string{


### PR DESCRIPTION
## What problem are you trying to solve?

The SCA SBOM pipeline is standardizing on canonical `datadog:*` property names and removing old `osv-scanner:` / `datadog-sbom-generator:` output.

- [K9CODESEC-1789](https://datadoghq.atlassian.net/browse/K9CODESEC-1789)

## What is your solution?

Add a generator regression test that exercises CycloneDX output and fails if either legacy property prefix appears in generated SBOM data. Current `main` already emits the canonical `datadog:maven-package` property for Maven file components, so this keeps that behavior covered without removing the canonical metadata.

## Alternatives considered

Relying on the current code shape would leave this producer-side guarantee implicit and easy to regress while downstream cleanup removes legacy support.

## What the reviewer should know

RFC: N/A. No RFC was linked from the Jira ticket.

Validation: `GOCACHE=/private/tmp/codex-go-cache-datadog-sbom-generator go test ./internal/output/sbom ./cmd/datadog-sbom-generator`

Jira transition: attempted to move K9CODESEC-1789 to Under Review, but Jira returned `No allowed transitions found for given status`.