### PR TITLE
feat(sbomgen): add HopCount to BuildFileRelations.Dependencies

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -66,7 +66,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "    id: %s\n", rels.ID)
 		}
 		for _, dep := range rels.Dependencies {
-			fmt.Fprintf(os.Stderr, "    dep: %s\n", dep.FilePath)
+			fmt.Fprintf(os.Stderr, "    dep (hop=%d): %s\n", dep.HopCount, dep.FilePath)
 		}
 	}
 }

--- a/pkg/sbomgen/build_file_processor.go
+++ b/pkg/sbomgen/build_file_processor.go
@@ -1,5 +1,13 @@
 package sbomgen
 
+// BuildFileWithHopCount wraps a BuildFile with its hop distance from the
+// source file. HopCount is 1 for direct dependencies, 2 for
+// dependencies-of-dependencies, and so on.
+type BuildFileWithHopCount struct {
+	BuildFile
+	HopCount int
+}
+
 // BuildFileRelations holds the resolved relationships of a build file.
 //
 // ID is an ecosystem-specific identifier (e.g. Maven "groupId:artifactId").
@@ -12,8 +20,8 @@ type BuildFileRelations struct {
 	// For Maven this is "groupId:artifactId"; for other ecosystems it is empty.
 	ID string
 	// Dependencies lists all transitively reachable build files, sorted by
-	// FilePath.
-	Dependencies []BuildFile
+	// FilePath, each annotated with its hop distance from this file.
+	Dependencies []BuildFileWithHopCount
 }
 
 // ProcessorContext carries SBOM-derived data that processors can use for
@@ -57,7 +65,7 @@ type noopProcessor struct{}
 func (noopProcessor) Process(files []BuildFile, _ ProcessorContext) map[BuildFile]BuildFileRelations {
 	result := make(map[BuildFile]BuildFileRelations, len(files))
 	for _, f := range files {
-		result[f] = BuildFileRelations{Dependencies: []BuildFile{}}
+		result[f] = BuildFileRelations{Dependencies: []BuildFileWithHopCount{}}
 	}
 
 	return result

--- a/pkg/sbomgen/build_files_test.go
+++ b/pkg/sbomgen/build_files_test.go
@@ -408,7 +408,7 @@ func (p *stubbedProcessor) Process(files []BuildFile, _ ProcessorContext) map[Bu
 	p.received = append(p.received, files...)
 	result := make(map[BuildFile]BuildFileRelations, len(files))
 	for _, f := range files {
-		result[f] = BuildFileRelations{Dependencies: []BuildFile{p.child}}
+		result[f] = BuildFileRelations{Dependencies: []BuildFileWithHopCount{{BuildFile: p.child, HopCount: 1}}}
 	}
 
 	return result
@@ -439,7 +439,7 @@ func TestGetBuildFileTrees_RegisteredProcessorIsCalled(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected key %+v not found", expected)
 	}
-	if len(rel.Dependencies) != 1 || rel.Dependencies[0] != sentinel {
+	if len(rel.Dependencies) != 1 || rel.Dependencies[0].BuildFile != sentinel {
 		t.Errorf("expected sentinel dependency, got %v", rel.Dependencies)
 	}
 	if len(stub.received) != 1 || stub.received[0] != expected {

--- a/pkg/sbomgen/simple_processor.go
+++ b/pkg/sbomgen/simple_processor.go
@@ -13,6 +13,13 @@ import "sort"
 // optional artifact ID" pattern. Register it for each such FileType in init().
 type SimpleProcessor struct{}
 
+// bfsNode is an entry in the BFS queue carrying both the path and the hop
+// depth at which it was reached from the source file.
+type bfsNode struct {
+	path  string
+	depth int
+}
+
 // Process resolves transitive dependencies and IDs for a set of BuildFiles.
 func (p *SimpleProcessor) Process(files []BuildFile, ctx ProcessorContext) map[BuildFile]BuildFileRelations {
 	// Index files by path for O(1) lookup.
@@ -24,21 +31,21 @@ func (p *SimpleProcessor) Process(files []BuildFile, ctx ProcessorContext) map[B
 	// Build the result map with full transitive closure via BFS for each file.
 	result := make(map[BuildFile]BuildFileRelations, len(files))
 	for _, f := range files {
-		var deps []BuildFile
+		var deps []BuildFileWithHopCount
 		visited := map[string]struct{}{f.FilePath: {}} // cycle protection
-		queue := []string{f.FilePath}
+		queue := []bfsNode{{path: f.FilePath, depth: 0}}
 
 		for len(queue) > 0 {
-			current := queue[0]
+			node := queue[0]
 			queue = queue[1:]
-			for _, depPath := range ctx.FileDependencies[current] {
+			for _, depPath := range ctx.FileDependencies[node.path] {
 				if _, seen := visited[depPath]; seen {
 					continue
 				}
 				visited[depPath] = struct{}{}
 				if dep, known := filesByPath[depPath]; known {
-					deps = append(deps, dep)
-					queue = append(queue, depPath)
+					deps = append(deps, BuildFileWithHopCount{BuildFile: dep, HopCount: node.depth + 1})
+					queue = append(queue, bfsNode{path: depPath, depth: node.depth + 1})
 				}
 			}
 		}
@@ -49,7 +56,7 @@ func (p *SimpleProcessor) Process(files []BuildFile, ctx ProcessorContext) map[B
 		})
 
 		if deps == nil {
-			deps = []BuildFile{}
+			deps = []BuildFileWithHopCount{}
 		}
 
 		result[f] = BuildFileRelations{

--- a/pkg/sbomgen/simple_processor_test.go
+++ b/pkg/sbomgen/simple_processor_test.go
@@ -71,6 +71,11 @@ func pomFile(path string) BuildFile {
 	return BuildFile{FileType: FileTypePomXML, FilePath: path}
 }
 
+// pomFileWithHop is a shorthand for a pom.xml BuildFileWithHopCount.
+func pomFileWithHop(path string, hop int) BuildFileWithHopCount {
+	return BuildFileWithHopCount{BuildFile: pomFile(path), HopCount: hop}
+}
+
 // --- Tests ---
 
 // TestSimpleProcessor_Maven_SingleRootPom verifies that a standalone pom.xml
@@ -136,8 +141,8 @@ func TestSimpleProcessor_Maven_ParentChild(t *testing.T) {
 	if child.ID != "com.example:child" {
 		t.Errorf("child: expected ID=com.example:child, got %q", child.ID)
 	}
-	if len(child.Dependencies) != 1 || child.Dependencies[0] != pomFile("pom.xml") {
-		t.Errorf("child: expected Dependencies=[pom.xml], got %v", child.Dependencies)
+	if len(child.Dependencies) != 1 || child.Dependencies[0] != pomFileWithHop("pom.xml", 1) {
+		t.Errorf("child: expected Dependencies=[pom.xml hop=1], got %v", child.Dependencies)
 	}
 }
 
@@ -195,8 +200,8 @@ func TestSimpleProcessor_Maven_MultiModule(t *testing.T) {
 		if rel.ID != expectedID {
 			t.Errorf("%s: expected ID=%s, got %q", childPath, expectedID, rel.ID)
 		}
-		if len(rel.Dependencies) != 1 || rel.Dependencies[0] != pomFile("pom.xml") {
-			t.Errorf("%s: expected Dependencies=[pom.xml], got %v", childPath, rel.Dependencies)
+		if len(rel.Dependencies) != 1 || rel.Dependencies[0] != pomFileWithHop("pom.xml", 1) {
+			t.Errorf("%s: expected Dependencies=[pom.xml hop=1], got %v", childPath, rel.Dependencies)
 		}
 	}
 }
@@ -241,23 +246,23 @@ func TestSimpleProcessor_Maven_DeepHierarchy(t *testing.T) {
 	if mid.ID != "com.example:module" {
 		t.Errorf("module: expected ID=com.example:module, got %q", mid.ID)
 	}
-	if len(mid.Dependencies) != 1 || mid.Dependencies[0] != pomFile("pom.xml") {
-		t.Errorf("module: expected Dependencies=[pom.xml], got %v", mid.Dependencies)
+	if len(mid.Dependencies) != 1 || mid.Dependencies[0] != pomFileWithHop("pom.xml", 1) {
+		t.Errorf("module: expected Dependencies=[pom.xml hop=1], got %v", mid.Dependencies)
 	}
 
 	leaf := result[pomFile("module/sub/pom.xml")]
 	if leaf.ID != "com.example:sub" {
 		t.Errorf("sub: expected ID=com.example:sub, got %q", leaf.ID)
 	}
-	// Transitive: leaf depends on module/pom.xml AND pom.xml, sorted by FilePath.
+	// Transitive: leaf depends on module/pom.xml (hop=1) AND pom.xml (hop=2), sorted by FilePath.
 	if len(leaf.Dependencies) != 2 {
 		t.Fatalf("sub: expected 2 Dependencies, got %v", leaf.Dependencies)
 	}
-	if leaf.Dependencies[0] != pomFile("module/pom.xml") {
-		t.Errorf("sub: expected Dependencies[0]=module/pom.xml, got %v", leaf.Dependencies[0])
+	if leaf.Dependencies[0] != pomFileWithHop("module/pom.xml", 1) {
+		t.Errorf("sub: expected Dependencies[0]=module/pom.xml hop=1, got %v", leaf.Dependencies[0])
 	}
-	if leaf.Dependencies[1] != pomFile("pom.xml") {
-		t.Errorf("sub: expected Dependencies[1]=pom.xml, got %v", leaf.Dependencies[1])
+	if leaf.Dependencies[1] != pomFileWithHop("pom.xml", 2) {
+		t.Errorf("sub: expected Dependencies[1]=pom.xml hop=2, got %v", leaf.Dependencies[1])
 	}
 }
 
@@ -340,16 +345,16 @@ func TestSimpleProcessor_Maven_SiblingModuleDependency(t *testing.T) {
 	if len(modA.Dependencies) != 2 {
 		t.Fatalf("module-a: expected 2 Dependencies, got %v", modA.Dependencies)
 	}
-	if modA.Dependencies[0] != pomFile("module-b/pom.xml") {
-		t.Errorf("module-a: expected Dependencies[0]=module-b/pom.xml, got %v", modA.Dependencies[0])
+	if modA.Dependencies[0] != pomFileWithHop("module-b/pom.xml", 1) {
+		t.Errorf("module-a: expected Dependencies[0]=module-b/pom.xml hop=1, got %v", modA.Dependencies[0])
 	}
-	if modA.Dependencies[1] != pomFile("pom.xml") {
-		t.Errorf("module-a: expected Dependencies[1]=pom.xml, got %v", modA.Dependencies[1])
+	if modA.Dependencies[1] != pomFileWithHop("pom.xml", 1) {
+		t.Errorf("module-a: expected Dependencies[1]=pom.xml hop=1, got %v", modA.Dependencies[1])
 	}
 
 	modB := result[pomFile("module-b/pom.xml")]
-	if len(modB.Dependencies) != 1 || modB.Dependencies[0] != pomFile("pom.xml") {
-		t.Errorf("module-b: expected Dependencies=[pom.xml], got %v", modB.Dependencies)
+	if len(modB.Dependencies) != 1 || modB.Dependencies[0] != pomFileWithHop("pom.xml", 1) {
+		t.Errorf("module-b: expected Dependencies=[pom.xml hop=1], got %v", modB.Dependencies)
 	}
 }
 
@@ -513,7 +518,7 @@ func TestSimpleProcessor_Maven_ParentPomViaFileComponent(t *testing.T) {
 	}
 
 	child := result[pomFile("child/pom.xml")]
-	if len(child.Dependencies) != 1 || child.Dependencies[0] != pomFile("pom.xml") {
-		t.Errorf("child: expected Dependencies=[pom.xml], got %v", child.Dependencies)
+	if len(child.Dependencies) != 1 || child.Dependencies[0] != pomFileWithHop("pom.xml", 1) {
+		t.Errorf("child: expected Dependencies=[pom.xml hop=1], got %v", child.Dependencies)
 	}
 }


### PR DESCRIPTION
## Summary

- Introduces `BuildFileWithHopCount` struct that embeds `BuildFile` and adds a `HopCount int` field
- Changes `BuildFileRelations.Dependencies` from `[]BuildFile` to `[]BuildFileWithHopCount`
- Refactors the BFS in `SimpleProcessor.Process()` to track depth per node, assigning `HopCount = 1` for direct dependencies, `2` for transitive-of-direct, etc.

**Breaking change:** callers iterating `Dependencies` must access fields through the embedded `BuildFile` (e.g. `dep.FilePath` still works) or compare against `BuildFileWithHopCount` values.

## Test plan

- [x] All existing tests updated and passing (`go test ./pkg/sbomgen/...`)
- [x] HopCount values explicitly asserted in `TestSimpleProcessor_Maven_DeepHierarchy` (hop=1 and hop=2)
- [x] Lints pass (`./scripts/run_lints.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)