### PR TITLE
feat(sbomgen): add Gradle build file tree support

### DIFF
--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -319,6 +319,25 @@ func addFileDependencies(artifacts []models.ScannedArtifact) (map[string]cyclone
 			}
 		}
 
+		// Direct project-level build file dependencies (e.g. Gradle project(':...') refs).
+		// These produce build-file → build-file edges that GetBuildFileTrees can traverse.
+		for _, dep := range artifact.ProjectDeps {
+			if dep.Filename == "" {
+				continue
+			}
+			if dependency, ok := dependsOn[artifact.Filename]; ok {
+				dependencies := append(*dependency.Dependencies, dep.Filename)
+				slices.Sort(dependencies)
+				dependency.Dependencies = &dependencies
+				dependsOn[artifact.Filename] = dependency
+			} else {
+				dependsOn[artifact.Filename] = cyclonedx.Dependency{
+					Ref:          artifact.Filename,
+					Dependencies: &[]string{dep.Filename},
+				}
+			}
+		}
+
 		if len(properties) > 0 {
 			component.Properties = &properties
 		}

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -322,8 +322,15 @@ func addFileDependencies(artifacts []models.ScannedArtifact) (map[string]cyclone
 		// Direct project-level build file dependencies (e.g. Gradle project(':...') refs).
 		// These produce build-file → build-file edges that GetBuildFileTrees can traverse.
 		for _, dep := range artifact.ProjectDeps {
-			if dep.Filename == "" {
-				continue
+			// Ensure the target build file has a file component so GetBuildFileTrees
+			// can traverse the edge. A subproject with no lockfile of its own won't
+			// appear in artifacts, so we create a stub component here.
+			if _, exists := components[dep.Filename]; !exists {
+				components[dep.Filename] = cyclonedx.Component{
+					Name:   dep.Filename,
+					BOMRef: dep.Filename,
+					Type:   fileComponentType,
+				}
 			}
 			if dependency, ok := dependsOn[artifact.Filename]; ok {
 				dependencies := append(*dependency.Dependencies, dep.Filename)

--- a/pkg/extractor/java/parse-gradle-lock.go
+++ b/pkg/extractor/java/parse-gradle-lock.go
@@ -3,9 +3,12 @@ package java
 import (
 	"bufio"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-sbom-generator/internal/cachedregexp"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
@@ -93,6 +96,100 @@ func (e GradleLockExtractor) Extract(f extractor.DepFile, context extractor.Scan
 
 	return pkgs, nil
 }
+
+// GetArtifact implements extractor.ArtifactExtractor.
+// It looks for a build.gradle or build.gradle.kts file in the same directory
+// as the lockfile, reads it to extract:
+//   - the top-level group assignment (group:projectDir → artifact Name for findArtifact matching)
+//   - project(':...') references → ProjectDeps for cross-subproject dependency edges
+//
+// If no build file is found, nil is returned.
+func (e GradleLockExtractor) GetArtifact(f extractor.DepFile, ctx extractor.ScanContext) (*models.ScannedArtifact, error) {
+	for _, name := range []string{buildGradleFilename, buildGradleKtsFilename} {
+		buildFile, err := f.Open(name)
+		if err != nil {
+			continue
+		}
+
+		content, err := io.ReadAll(buildFile)
+		buildFilePath := buildFile.Path()
+		_ = buildFile.Close()
+		if err != nil {
+			return &models.ScannedArtifact{ArtifactDetail: models.ArtifactDetail{Filename: buildFilePath}}, err
+		}
+
+		artifact := &models.ScannedArtifact{
+			ArtifactDetail: models.ArtifactDetail{
+				Filename:  buildFilePath,
+				Ecosystem: models.EcosystemMaven,
+			},
+		}
+
+		// Set artifact.Name = "group:projectDir" so findArtifact can match this
+		// subproject when it appears as a dependency in another module's lockfile.
+		if group := extractTopLevelGroup(content); group != "" {
+			projectName := filepath.Base(filepath.Dir(f.Path()))
+			artifact.Name = group + ":" + projectName
+		}
+
+		// Extract project(':submodule') references to build inter-module dep edges.
+		if ctx.RootDir != "" {
+			artifact.ProjectDeps = extractGradleProjectDeps(content, ctx.RootDir)
+		}
+
+		return artifact, nil
+	}
+
+	return nil, nil
+}
+
+// extractTopLevelGroup extracts the value of a top-level `group = "..."` or
+// `group = '...'` assignment from Gradle build file content.
+// It ignores dependency kwargs like `group: 'x'` or method calls like `group("x")`.
+func extractTopLevelGroup(content []byte) string {
+	groupRegex := cachedregexp.MustCompile(`(?m)^[\t ]*group\s*=\s*['"]([^'"]+)['"]`)
+	if m := groupRegex.FindSubmatch(content); m != nil {
+		return string(m[1])
+	}
+
+	return ""
+}
+
+// extractGradleProjectDeps parses project(':submodule') and project(':sub:module')
+// references from Gradle build file content and returns ArtifactDetail entries
+// whose Filename points to the corresponding build.gradle (or build.gradle.kts)
+// under rootDir. Refs that cannot be resolved to an existing file are skipped.
+func extractGradleProjectDeps(content []byte, rootDir string) []models.ArtifactDetail {
+	projectRegex := cachedregexp.MustCompile(`project\(['"]([^'"]+)['"]\)`)
+	matches := projectRegex.FindAllSubmatch(content, -1)
+
+	var deps []models.ArtifactDetail
+	seen := make(map[string]struct{})
+
+	for _, m := range matches {
+		ref := string(m[1]) // e.g. ":communication" or ":dd-java-agent:agent-tooling"
+		// Convert Gradle project path to filesystem path: strip leading ':', replace ':' with '/'.
+		subPath := strings.ReplaceAll(strings.TrimPrefix(ref, ":"), ":", string(filepath.Separator))
+
+		for _, buildFileName := range []string{buildGradleFilename, buildGradleKtsFilename} {
+			depPath := filepath.Join(rootDir, subPath, buildFileName)
+			if _, err := os.Stat(depPath); err != nil {
+				continue
+			}
+			if _, dup := seen[depPath]; dup {
+				break
+			}
+			seen[depPath] = struct{}{}
+			deps = append(deps, models.ArtifactDetail{Filename: depPath})
+
+			break
+		}
+	}
+
+	return deps
+}
+
+var _ extractor.ArtifactExtractor = GradleLockExtractor{}
 
 var GradleExtractor = GradleLockExtractor{
 	extractor.WithMatcher{Matchers: []extractor.Matcher{&BuildGradleMatcher{}}},

--- a/pkg/extractor/java/parse-gradle-lock_test.go
+++ b/pkg/extractor/java/parse-gradle-lock_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGradleLockExtractor_ShouldExtract(t *testing.T) {
@@ -308,4 +309,144 @@ func TestParseGradleLock_WithInvalidLines(t *testing.T) {
 			Ecosystem:      models.EcosystemMaven,
 		},
 	})
+}
+
+// Compile-time check: GradleLockExtractor must satisfy ArtifactExtractor.
+var _ extractor.ArtifactExtractor = java.GradleLockExtractor{}
+
+func TestGradleLockExtractor_GetArtifact_ReturnsBuildGradleKts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, "gradle.lockfile")
+	buildFilePath := filepath.Join(dir, "build.gradle.kts")
+
+	require.NoError(t, os.WriteFile(lockfilePath, []byte("empty=0\n"), 0600))
+	require.NoError(t, os.WriteFile(buildFilePath, []byte(""), 0600))
+
+	f, err := extractor.OpenLocalDepFile(lockfilePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	artifact, err := java.GradleLockExtractor{}.GetArtifact(f, extractor.ScanContext{})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	assert.Equal(t, buildFilePath, artifact.Filename)
+}
+
+func TestGradleLockExtractor_GetArtifact_ReturnsBuildGradle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, "gradle.lockfile")
+	buildFilePath := filepath.Join(dir, "build.gradle")
+
+	require.NoError(t, os.WriteFile(lockfilePath, []byte("empty=0\n"), 0600))
+	require.NoError(t, os.WriteFile(buildFilePath, []byte(""), 0600))
+
+	f, err := extractor.OpenLocalDepFile(lockfilePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	artifact, err := java.GradleLockExtractor{}.GetArtifact(f, extractor.ScanContext{})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	assert.Equal(t, buildFilePath, artifact.Filename)
+}
+
+func TestGradleLockExtractor_GetArtifact_ReturnsNilWhenNoBuildFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, "gradle.lockfile")
+	require.NoError(t, os.WriteFile(lockfilePath, []byte("empty=0\n"), 0600))
+
+	f, err := extractor.OpenLocalDepFile(lockfilePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	artifact, err := java.GradleLockExtractor{}.GetArtifact(f, extractor.ScanContext{})
+
+	require.NoError(t, err)
+	assert.Nil(t, artifact)
+}
+
+func TestGradleLockExtractor_GetArtifact_SetsGroupArtifactName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, "gradle.lockfile")
+	buildFilePath := filepath.Join(dir, "build.gradle")
+
+	require.NoError(t, os.WriteFile(lockfilePath, []byte("empty=0\n"), 0600))
+	require.NoError(t, os.WriteFile(buildFilePath, []byte("group = 'com.example'\n"), 0600))
+
+	f, err := extractor.OpenLocalDepFile(lockfilePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	artifact, err := java.GradleLockExtractor{}.GetArtifact(f, extractor.ScanContext{})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	// Name = "group:projectDirName" where projectDirName = basename of the lockfile's parent dir.
+	assert.Equal(t, "com.example:"+filepath.Base(dir), artifact.Name)
+	assert.Equal(t, buildFilePath, artifact.Filename)
+}
+
+func TestGradleLockExtractor_GetArtifact_ExtractsProjectDeps(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "app")
+	require.NoError(t, os.Mkdir(moduleDir, 0700))
+
+	libDir := filepath.Join(root, "lib")
+	require.NoError(t, os.Mkdir(libDir, 0700))
+
+	lockfilePath := filepath.Join(moduleDir, "gradle.lockfile")
+	buildFilePath := filepath.Join(moduleDir, "build.gradle")
+	libBuildFile := filepath.Join(libDir, "build.gradle")
+
+	require.NoError(t, os.WriteFile(lockfilePath, []byte("empty=0\n"), 0600))
+	require.NoError(t, os.WriteFile(buildFilePath, []byte("implementation project(':lib')\n"), 0600))
+	require.NoError(t, os.WriteFile(libBuildFile, []byte(""), 0600))
+
+	f, err := extractor.OpenLocalDepFile(lockfilePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	artifact, err := java.GradleLockExtractor{}.GetArtifact(f, extractor.ScanContext{RootDir: root})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	require.Len(t, artifact.ProjectDeps, 1)
+	assert.Equal(t, libBuildFile, artifact.ProjectDeps[0].Filename)
+}
+
+func TestGradleLockExtractor_GetArtifact_SkipsNonExistentProjectDeps(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "app")
+	require.NoError(t, os.Mkdir(moduleDir, 0700))
+
+	lockfilePath := filepath.Join(moduleDir, "gradle.lockfile")
+	buildFilePath := filepath.Join(moduleDir, "build.gradle")
+
+	require.NoError(t, os.WriteFile(lockfilePath, []byte("empty=0\n"), 0600))
+	// references :nonexistent which has no build.gradle
+	require.NoError(t, os.WriteFile(buildFilePath, []byte("implementation project(':nonexistent')\n"), 0600))
+
+	f, err := extractor.OpenLocalDepFile(lockfilePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	artifact, err := java.GradleLockExtractor{}.GetArtifact(f, extractor.ScanContext{RootDir: root})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	assert.Empty(t, artifact.ProjectDeps)
 }

--- a/pkg/extractor/java/parse-gradle-verification-metadata.go
+++ b/pkg/extractor/java/parse-gradle-verification-metadata.go
@@ -122,6 +122,50 @@ func (e GradleVerificationMetadataExtractor) Extract(f extractor.DepFile, contex
 	return pkgs, nil
 }
 
+// GetArtifact implements extractor.ArtifactExtractor.
+// verification-metadata.xml lives at <root>/gradle/verification-metadata.xml,
+// so the build file is one level up (../build.gradle or ../build.gradle.kts).
+// The build file is read to extract group and project deps, mirroring
+// GradleLockExtractor.GetArtifact. If no build file is found, nil is returned.
+func (e GradleVerificationMetadataExtractor) GetArtifact(f extractor.DepFile, ctx extractor.ScanContext) (*models.ScannedArtifact, error) {
+	for _, name := range []string{"../" + buildGradleFilename, "../" + buildGradleKtsFilename} {
+		buildFile, err := f.Open(name)
+		if err != nil {
+			continue
+		}
+
+		content, err := io.ReadAll(buildFile)
+		buildFilePath := buildFile.Path()
+		_ = buildFile.Close()
+		if err != nil {
+			return &models.ScannedArtifact{ArtifactDetail: models.ArtifactDetail{Filename: buildFilePath}}, err
+		}
+
+		artifact := &models.ScannedArtifact{
+			ArtifactDetail: models.ArtifactDetail{
+				Filename:  buildFilePath,
+				Ecosystem: models.EcosystemMaven,
+			},
+		}
+
+		// verification-metadata.xml is at <root>/gradle/; project dir is two levels up.
+		if group := extractTopLevelGroup(content); group != "" {
+			projectName := filepath.Base(filepath.Dir(filepath.Dir(f.Path())))
+			artifact.Name = group + ":" + projectName
+		}
+
+		if ctx.RootDir != "" {
+			artifact.ProjectDeps = extractGradleProjectDeps(content, ctx.RootDir)
+		}
+
+		return artifact, nil
+	}
+
+	return nil, nil
+}
+
+var _ extractor.ArtifactExtractor = GradleVerificationMetadataExtractor{}
+
 var GradleVerificationExtractor = GradleVerificationMetadataExtractor{
 	extractor.WithMatcher{Matchers: []extractor.Matcher{&BuildGradleMatcher{}}},
 }

--- a/pkg/extractor/java/parse-gradle-verification-metadata_test.go
+++ b/pkg/extractor/java/parse-gradle-verification-metadata_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGradleVerificationMetadataExtractor_ShouldExtract(t *testing.T) {
@@ -776,4 +777,53 @@ func TestParseGradleVerificationMetadata_TwoPackages_BlockLocation(t *testing.T)
 	assert.Equal(t, absoluteLockfilePath, javaparserPkg.BlockLocation.Filename)
 	assert.Equal(t, 18, javaparserPkg.BlockLocation.Line.Start)
 	assert.Equal(t, 22, javaparserPkg.BlockLocation.Line.End)
+}
+
+// Compile-time check: GradleVerificationMetadataExtractor must satisfy ArtifactExtractor.
+var _ extractor.ArtifactExtractor = java.GradleVerificationMetadataExtractor{}
+
+func TestGradleVerificationMetadataExtractor_GetArtifact_ReturnsBuildGradle(t *testing.T) {
+	t.Parallel()
+
+	// verification-metadata.xml lives at <root>/gradle/verification-metadata.xml
+	// so the build file is at <root>/build.gradle.kts (one level up).
+	rootDir := t.TempDir()
+	gradleDir := filepath.Join(rootDir, "gradle")
+	require.NoError(t, os.Mkdir(gradleDir, 0700))
+
+	metadataPath := filepath.Join(gradleDir, "verification-metadata.xml")
+	buildFilePath := filepath.Join(rootDir, "build.gradle.kts")
+
+	require.NoError(t, os.WriteFile(metadataPath, []byte("<verification-metadata/>"), 0600))
+	require.NoError(t, os.WriteFile(buildFilePath, []byte(""), 0600))
+
+	f, err := extractor.OpenLocalDepFile(metadataPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	artifact, err := java.GradleVerificationMetadataExtractor{}.GetArtifact(f, extractor.ScanContext{})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	assert.Equal(t, buildFilePath, artifact.Filename)
+}
+
+func TestGradleVerificationMetadataExtractor_GetArtifact_ReturnsNilWhenNoBuildFile(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	gradleDir := filepath.Join(rootDir, "gradle")
+	require.NoError(t, os.Mkdir(gradleDir, 0700))
+
+	metadataPath := filepath.Join(gradleDir, "verification-metadata.xml")
+	require.NoError(t, os.WriteFile(metadataPath, []byte("<verification-metadata/>"), 0600))
+
+	f, err := extractor.OpenLocalDepFile(metadataPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	artifact, err := java.GradleVerificationMetadataExtractor{}.GetArtifact(f, extractor.ScanContext{})
+
+	require.NoError(t, err)
+	assert.Nil(t, artifact)
 }

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -15,7 +15,8 @@ type ArtifactDetail struct {
 
 type ScannedArtifact struct {
 	ArtifactDetail
-	DependsOn *ArtifactDetail
+	DependsOn   *ArtifactDetail
+	ProjectDeps []ArtifactDetail // direct project-level build file dependencies (e.g. Gradle subproject refs)
 }
 
 type SourceInfo struct {

--- a/pkg/sbomgen/simple_processor.go
+++ b/pkg/sbomgen/simple_processor.go
@@ -73,4 +73,6 @@ func init() {
 	RegisterBuildFileProcessor(FileTypePomXML, &SimpleProcessor{})
 	RegisterBuildFileProcessor(FileTypeRequirementsTxt, &SimpleProcessor{})
 	RegisterBuildFileProcessor(FileTypePyprojectToml, &SimpleProcessor{})
+	RegisterBuildFileProcessor(FileTypeBuildGradle, &SimpleProcessor{})
+	RegisterBuildFileProcessor(FileTypeBuildGradleKts, &SimpleProcessor{})
 }

--- a/pkg/sbomgen/simple_processor_test.go
+++ b/pkg/sbomgen/simple_processor_test.go
@@ -596,6 +596,52 @@ func TestSimpleProcessor_Gradle_SingleBuildFile(t *testing.T) {
 	}
 }
 
+// TestSimpleProcessor_Gradle_ProjectDepWithNoLockfile verifies that a Gradle
+// subproject that declares a project(':lib') dependency — but where lib/ has no
+// lockfile of its own — still appears in GetBuildFileTrees after the fix that
+// emits a stub file component for the ProjectDep target.
+//
+// Layout:
+//
+//	app/build.gradle  →  project(':lib')
+//	lib/build.gradle  ← stub file component (no lockfile, no package occurrences)
+func TestSimpleProcessor_Gradle_ProjectDepWithNoLockfile(t *testing.T) {
+	t.Parallel()
+
+	// app/build.gradle has package occurrences (its lockfile was parsed).
+	// lib/build.gradle is a stub file component only — no lockfile, no packages.
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			gradleComponent("com.example:app", "app/build.gradle"),
+			// lib/build.gradle: stub file component produced by the cyclonedx fix.
+			{
+				Type:   cyclonedx.ComponentTypeFile,
+				BOMRef: "lib/build.gradle",
+				Name:   "lib/build.gradle",
+			},
+		},
+		[]cyclonedx.Dependency{
+			{Ref: "app/build.gradle", Dependencies: &[]string{"lib/build.gradle"}},
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypeBuildGradle)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries (app + lib), got %d: %v", len(result), result)
+	}
+
+	app := result[gradleFile("app/build.gradle")]
+	if len(app.Dependencies) != 1 || app.Dependencies[0].BuildFile != gradleFile("lib/build.gradle") {
+		t.Errorf("app: expected Dependencies=[lib/build.gradle hop=1], got %v", app.Dependencies)
+	}
+
+	lib := result[gradleFile("lib/build.gradle")]
+	if len(lib.Dependencies) != 0 {
+		t.Errorf("lib: expected no Dependencies, got %v", lib.Dependencies)
+	}
+}
+
 // TestSimpleProcessor_GradleKts_SingleBuildFile verifies that a standalone
 // build.gradle.kts with no file-type components or dependency edges gets empty
 // dependencies and empty ID.

--- a/pkg/sbomgen/simple_processor_test.go
+++ b/pkg/sbomgen/simple_processor_test.go
@@ -522,3 +522,101 @@ func TestSimpleProcessor_Maven_ParentPomViaFileComponent(t *testing.T) {
 		t.Errorf("child: expected Dependencies=[pom.xml hop=1], got %v", child.Dependencies)
 	}
 }
+
+// --- Gradle build.gradle tests ---
+
+// gradleComponent builds a CycloneDX component with a manifest occurrence for
+// the given build.gradle path, as the SBOM generator would emit it.
+func gradleComponent(name, buildGradlePath string) cyclonedx.Component {
+	return componentWithOccurrences(name, "1.0.0", makeLocation(buildGradlePath, "manifest"))
+}
+
+// gradleFile is a shorthand for a build.gradle BuildFile.
+func gradleFile(path string) BuildFile {
+	return BuildFile{FileType: FileTypeBuildGradle, FilePath: path}
+}
+
+// gradleKtsFile is a shorthand for a build.gradle.kts BuildFile.
+func gradleKtsFile(path string) BuildFile {
+	return BuildFile{FileType: FileTypeBuildGradleKts, FilePath: path}
+}
+
+// TestSimpleProcessor_Gradle_ProcessorRegistered verifies that SimpleProcessor
+// (not noopProcessor) is registered for build.gradle. We distinguish them by
+// providing a dependency edge: SimpleProcessor resolves it via BFS, while
+// noopProcessor would ignore it.
+func TestSimpleProcessor_Gradle_ProcessorRegistered(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOMWithDeps(
+		[]cyclonedx.Component{
+			gradleComponent("com.example:app", "app/build.gradle"),
+			gradleComponent("com.example:lib", "lib/build.gradle"),
+		},
+		[]cyclonedx.Dependency{
+			{Ref: "app/build.gradle", Dependencies: &[]string{"lib/build.gradle"}},
+		},
+	)
+
+	result := GetBuildFileTrees(sbom, FileTypeBuildGradle)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(result), result)
+	}
+
+	app := result[gradleFile("app/build.gradle")]
+	// SimpleProcessor resolves the dependency edge; noopProcessor would return empty.
+	if len(app.Dependencies) != 1 || app.Dependencies[0].BuildFile != gradleFile("lib/build.gradle") {
+		t.Errorf("app: expected Dependencies=[lib/build.gradle], got %v", app.Dependencies)
+	}
+}
+
+// TestSimpleProcessor_Gradle_SingleBuildFile verifies that a standalone
+// build.gradle with no file-type components or dependency edges gets empty
+// dependencies and empty ID.
+func TestSimpleProcessor_Gradle_SingleBuildFile(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOM([]cyclonedx.Component{
+		gradleComponent("com.example:app", "build.gradle"),
+	})
+
+	result := GetBuildFileTrees(sbom, FileTypeBuildGradle)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+
+	rel := result[gradleFile("build.gradle")]
+	if rel.ID != "" {
+		t.Errorf("expected empty ID, got %q", rel.ID)
+	}
+	if len(rel.Dependencies) != 0 {
+		t.Errorf("expected no Dependencies, got %v", rel.Dependencies)
+	}
+}
+
+// TestSimpleProcessor_GradleKts_SingleBuildFile verifies that a standalone
+// build.gradle.kts with no file-type components or dependency edges gets empty
+// dependencies and empty ID.
+func TestSimpleProcessor_GradleKts_SingleBuildFile(t *testing.T) {
+	t.Parallel()
+
+	sbom := makeSBOM([]cyclonedx.Component{
+		componentWithOccurrences("com.example:app", "1.0.0", makeLocation("build.gradle.kts", "manifest")),
+	})
+
+	result := GetBuildFileTrees(sbom, FileTypeBuildGradleKts)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+
+	rel := result[gradleKtsFile("build.gradle.kts")]
+	if rel.ID != "" {
+		t.Errorf("expected empty ID, got %q", rel.ID)
+	}
+	if len(rel.Dependencies) != 0 {
+		t.Errorf("expected no Dependencies, got %v", rel.Dependencies)
+	}
+}

--- a/pkg/scanner/datadog_sbom_generator.go
+++ b/pkg/scanner/datadog_sbom_generator.go
@@ -327,6 +327,9 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 			if artifact.DependsOn != nil {
 				artifacts[index].DependsOn.Filename = fileposition.ToRelativePath(dir, artifact.DependsOn.Filename)
 			}
+			for i, dep := range artifact.ProjectDeps {
+				artifacts[index].ProjectDeps[i].Filename = fileposition.ToRelativePath(dir, dep.Filename)
+			}
 		}
 		scannedPackages = append(scannedPackages, pkgs...)
 		scannedArtifacts = append(scannedArtifacts, artifacts...)


### PR DESCRIPTION
## Summary

- Implements `ArtifactExtractor` on both Gradle lockfile extractors (`GradleLockExtractor`, `GradleVerificationMetadataExtractor`) — reads the adjacent `build.gradle`/`build.gradle.kts` to extract:
  - `group:projectDir` as the artifact name (for cross-subproject matching)
  - `project(':...')` references → `ProjectDeps` for build-file dependency edges
- Registers `SimpleProcessor` for `FileTypeBuildGradle` and `FileTypeBuildGradleKts` so `GetBuildFileTrees` returns Gradle build files with BFS-resolved transitive dependencies (same approach as Maven and Python)
- Emits stub file components for `project(':...')` targets with no lockfile of their own, so `GetBuildFileTrees` can traverse cross-subproject edges even when a subproject has no lockfile

## Validation

Validated against a multi-project Gradle repo with `gradle.lockfile` files:

```
--- Build Files (3 found) ---
  [build.gradle] app/build.gradle
  ...
```

`build.gradle` files now appear in `GetBuildFileTrees` output when `ExtractArtifactIds` is enabled (default).

## Known limitations (documented TODOs for follow-up PRs)

- **Artifact ID uses directory name**: `artifact.Name` is set to `group:directoryName` (e.g. `com.example:app`). The canonical name comes from `settings.gradle` (`rootProject.name`, `include ':submodule'`), which is not parsed yet — left for a follow-up PR.
- **No inter-module dependency edges via settings.gradle**: `project(':lib')` refs are extracted directly from `build.gradle`, but subproject names are resolved from directory names, not from `settings.gradle` includes. Full accuracy requires parsing `settings.gradle`.

## Test plan

- [x] Unit tests for `GetArtifact` on both extractors (nil when no build file, correct path when found, group extraction, project deps extraction)
- [x] Unit test for `SimpleProcessor` registration (Gradle build files returned by `GetBuildFileTrees`)
- [x] Unit test for stub file component (subproject with no lockfile appears in tree)
- [x] All tests pass (`./scripts/run_tests.sh`)
- [x] Lints pass (`./scripts/run_lints.sh`)

Generated with [Claude Code](https://claude.com/claude-code)