### PR TITLE
[K9CODESEC-1789] Remove SBOM file package property

### DIFF
--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/CycloneDX/cyclonedx-go"
-	"github.com/DataDog/datadog-sbom-generator/internal/utility/purl"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
@@ -280,19 +279,6 @@ func addFileDependencies(artifacts []models.ScannedArtifact) (map[string]cyclone
 		component.Type = fileComponentType
 
 		var properties []cyclonedx.Property
-		if artifact.Name != "" {
-			artifactPURL, err := purl.From(models.PackageInfo{
-				Name:      artifact.Name,
-				Version:   artifact.Version,
-				Ecosystem: string(artifact.Ecosystem),
-			})
-			if err == nil {
-				properties = append(properties, cyclonedx.Property{
-					Name:  mavenPackageProperty,
-					Value: artifactPURL.String(),
-				})
-			}
-		}
 		// Computing parent dependency
 		if artifact.DependsOn != nil {
 			// Record the parent POM as an explicit property so consumers can

--- a/internal/output/sbom/models.go
+++ b/internal/output/sbom/models.go
@@ -25,10 +25,6 @@ const (
 	// identifies the <parent> relationship, as opposed to ordinary module
 	// dependencies that also appear in the bom.Dependencies section.
 	mavenParentPomProperty = "datadog:maven-parent-pom"
-
-	// mavenPackageProperty is a CycloneDX component property that records the
-	// package URL for a Maven file-type component.
-	mavenPackageProperty = "datadog:maven-package"
 )
 
 var SeverityMapper = map[models.SeverityType]cyclonedx.ScoringMethod{


### PR DESCRIPTION
## What problem are you trying to solve?

SCA no longer forwards the file package property from generated SBOMs, so the generator should stop emitting that dead metadata.

## What is your solution?

Remove the `datadog:maven-package` property from CycloneDX file components. Parent-POM metadata and dependency edges remain unchanged.

## What the reviewer should know

- This is the existing property that renamed from `osv-scanner:package` [here](https://github.com/DataDog/datadog-sbom-generator/pull/157#discussion_r3348664853)
- We no longer process it downstream after https://github.com/DataDog/dd-source/pull/465781, so the generator should stop writing it.


[K9CODESEC-1789]: https://datadoghq.atlassian.net/browse/K9CODESEC-1789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ