### PR TITLE
refactor: replace log.Printf calls with Reporter interface

### DIFF
--- a/pkg/extractor/javascript/match-package-json.go
+++ b/pkg/extractor/javascript/match-package-json.go
@@ -26,9 +26,7 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 	var parsed map[string]interface{}
 	unmarshallErr := json.Unmarshal(data, &parsed)
 	if unmarshallErr != nil {
-		if depMap.reporter != nil {
-			depMap.reporter.Warnf("could not unmarshal %s, received error of %s", packageJSONContent, unmarshallErr)
-		}
+		depMap.reporter.Warnf("could not unmarshal %s, received error of %s", packageJSONContent, unmarshallErr)
 	}
 
 	dependencyNames := make(map[string]bool)
@@ -244,6 +242,7 @@ func (m PackageJSONMatcher) matchPackagesWithoutKnownLocation(sourcefile extract
 }
 
 func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, contentStr string, r reporter.Reporter) packageJSONFile {
+	effectiveReporter := reporter.Effective(r)
 	return packageJSONFile{
 		Dependencies: packageJSONDependencyMap{
 			MatcherDependencyMap: extractor.MatcherDependencyMap{
@@ -251,7 +250,7 @@ func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, conten
 				FilePath:   file.Path(),
 				LineOffset: jsonUtils.GetSectionOffset("dependencies", contentStr),
 			},
-			reporter: r,
+			reporter: effectiveReporter,
 		},
 		DevDependencies: packageJSONDependencyMap{
 			MatcherDependencyMap: extractor.MatcherDependencyMap{
@@ -259,7 +258,7 @@ func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, conten
 				FilePath:   file.Path(),
 				LineOffset: jsonUtils.GetSectionOffset("devDependencies", contentStr),
 			},
-			reporter: r,
+			reporter: effectiveReporter,
 		},
 		OptionalDependencies: packageJSONDependencyMap{
 			MatcherDependencyMap: extractor.MatcherDependencyMap{
@@ -267,7 +266,7 @@ func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, conten
 				FilePath:   file.Path(),
 				LineOffset: jsonUtils.GetSectionOffset("optionalDependencies", contentStr),
 			},
-			reporter: r,
+			reporter: effectiveReporter,
 		},
 	}
 }

--- a/pkg/extractor/javascript/match-package-json.go
+++ b/pkg/extractor/javascript/match-package-json.go
@@ -3,7 +3,6 @@ package javascript
 import (
 	"encoding/json"
 	"io"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 	jsonUtils "github.com/DataDog/datadog-sbom-generator/internal/json"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 	"github.com/bmatcuk/doublestar/v4"
 )
 
@@ -26,7 +26,9 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 	var parsed map[string]interface{}
 	unmarshallErr := json.Unmarshal(data, &parsed)
 	if unmarshallErr != nil {
-		log.Printf("could not unmarshal %s, received error of %s", packageJSONContent, unmarshallErr)
+		if depMap.reporter != nil {
+			depMap.reporter.Errorf("could not unmarshal %s, received error of %s", packageJSONContent, unmarshallErr)
+		}
 	}
 
 	dependencyNames := make(map[string]bool)
@@ -139,7 +141,7 @@ func (m PackageJSONMatcher) Match(sourceFile extractor.DepFile, packages []extra
 
 	// Match root package.json with root-level packages
 	if len(packagesWithoutKnownLocationIndices) > 0 {
-		err = m.matchFileWithIndices(sourceFile, packages, packagesWithoutKnownLocationIndices, content)
+		err = m.matchFileWithIndices(sourceFile, packages, packagesWithoutKnownLocationIndices, content, context.Reporter)
 		if err != nil {
 			return err
 		}
@@ -149,7 +151,7 @@ func (m PackageJSONMatcher) Match(sourceFile extractor.DepFile, packages []extra
 	if err := json.Unmarshal(content, &workspacesJSON); err != nil {
 		// If no workspaces, try matching all packages against root
 		if len(packagesWithoutKnownLocationIndices) == 0 && len(packages) > 0 {
-			err = m.matchFile(sourceFile, packages, content)
+			err = m.matchFile(sourceFile, packages, content, context.Reporter)
 			if err != nil {
 				return err
 			}
@@ -167,7 +169,7 @@ func (m PackageJSONMatcher) Match(sourceFile extractor.DepFile, packages []extra
 			for _, match := range matches {
 				matchPath := filepath.Dir(match)
 				if matchPath == workspacePath {
-					m.matchWorkspaceFile(sourceFile, match, packages, indices)
+					m.matchWorkspaceFile(sourceFile, match, packages, indices, context.Reporter)
 				}
 			}
 		}
@@ -181,18 +183,18 @@ func (m PackageJSONMatcher) Match(sourceFile extractor.DepFile, packages []extra
 	return nil
 }
 
-func (m PackageJSONMatcher) matchFile(file extractor.DepFile, packages []extractor.PackageDetails, content []byte) error {
+func (m PackageJSONMatcher) matchFile(file extractor.DepFile, packages []extractor.PackageDetails, content []byte, r reporter.Reporter) error {
 	allIndices := make([]int, len(packages))
 	for i := range packages {
 		allIndices[i] = i
 	}
 
-	return m.matchFileWithIndices(file, packages, allIndices, content)
+	return m.matchFileWithIndices(file, packages, allIndices, content, r)
 }
 
-func (m PackageJSONMatcher) matchFileWithIndices(file extractor.DepFile, allPackages []extractor.PackageDetails, indices []int, content []byte) error {
+func (m PackageJSONMatcher) matchFileWithIndices(file extractor.DepFile, allPackages []extractor.PackageDetails, indices []int, content []byte, r reporter.Reporter) error {
 	contentStr := string(content)
-	jsonFile := m.createPackageJSONFile(file, contentStr)
+	jsonFile := m.createPackageJSONFile(file, contentStr, r)
 
 	// Create pointers only to the packages at specified indices
 	packagesPtr := make([]*extractor.PackageDetails, len(indices))
@@ -207,7 +209,7 @@ func (m PackageJSONMatcher) matchFileWithIndices(file extractor.DepFile, allPack
 	return json.Unmarshal(content, &jsonFile)
 }
 
-func (m PackageJSONMatcher) matchWorkspaceFile(sourcefile extractor.DepFile, match string, packages []extractor.PackageDetails, indices []int) {
+func (m PackageJSONMatcher) matchWorkspaceFile(sourcefile extractor.DepFile, match string, packages []extractor.PackageDetails, indices []int, r reporter.Reporter) {
 	workspacePkg, err := sourcefile.Open(match)
 	if err != nil {
 		return
@@ -219,7 +221,7 @@ func (m PackageJSONMatcher) matchWorkspaceFile(sourcefile extractor.DepFile, mat
 		return
 	}
 
-	_ = m.matchFileWithIndices(workspacePkg, packages, indices, workspaceContent)
+	_ = m.matchFileWithIndices(workspacePkg, packages, indices, workspaceContent, r)
 }
 
 func (m PackageJSONMatcher) matchPackagesWithoutKnownLocation(sourcefile extractor.DepFile, matches []string, packages []extractor.PackageDetails, packagesWithoutKnownLocationIndices []int, context extractor.ScanContext) {
@@ -237,11 +239,11 @@ func (m PackageJSONMatcher) matchPackagesWithoutKnownLocation(sourcefile extract
 			continue
 		}
 
-		_ = m.matchFileWithIndices(workspacePkg, packages, packagesWithoutKnownLocationIndices, workspaceContent)
+		_ = m.matchFileWithIndices(workspacePkg, packages, packagesWithoutKnownLocationIndices, workspaceContent, context.Reporter)
 	}
 }
 
-func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, contentStr string) packageJSONFile {
+func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, contentStr string, r reporter.Reporter) packageJSONFile {
 	return packageJSONFile{
 		Dependencies: packageJSONDependencyMap{
 			MatcherDependencyMap: extractor.MatcherDependencyMap{
@@ -249,6 +251,7 @@ func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, conten
 				FilePath:   file.Path(),
 				LineOffset: jsonUtils.GetSectionOffset("dependencies", contentStr),
 			},
+			reporter: r,
 		},
 		DevDependencies: packageJSONDependencyMap{
 			MatcherDependencyMap: extractor.MatcherDependencyMap{
@@ -256,6 +259,7 @@ func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, conten
 				FilePath:   file.Path(),
 				LineOffset: jsonUtils.GetSectionOffset("devDependencies", contentStr),
 			},
+			reporter: r,
 		},
 		OptionalDependencies: packageJSONDependencyMap{
 			MatcherDependencyMap: extractor.MatcherDependencyMap{
@@ -263,6 +267,7 @@ func (m PackageJSONMatcher) createPackageJSONFile(file extractor.DepFile, conten
 				FilePath:   file.Path(),
 				LineOffset: jsonUtils.GetSectionOffset("optionalDependencies", contentStr),
 			},
+			reporter: r,
 		},
 	}
 }

--- a/pkg/extractor/javascript/match-package-json.go
+++ b/pkg/extractor/javascript/match-package-json.go
@@ -27,7 +27,7 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 	unmarshallErr := json.Unmarshal(data, &parsed)
 	if unmarshallErr != nil {
 		if depMap.reporter != nil {
-			depMap.reporter.Errorf("could not unmarshal %s, received error of %s", packageJSONContent, unmarshallErr)
+			depMap.reporter.Warnf("could not unmarshal %s, received error of %s", packageJSONContent, unmarshallErr)
 		}
 	}
 

--- a/pkg/extractor/javascript/types.go
+++ b/pkg/extractor/javascript/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 
 	"gopkg.in/yaml.v3"
 )
@@ -303,6 +304,7 @@ a different type to have a clear UnmarshallJSON method for the json decoder and 
 */
 type packageJSONDependencyMap struct {
 	extractor.MatcherDependencyMap
+	reporter reporter.Reporter
 }
 
 type packageJSONFile struct {

--- a/pkg/extractor/python/parse-pyproject-toml.go
+++ b/pkg/extractor/python/parse-pyproject-toml.go
@@ -150,6 +150,7 @@ func (e PyProjectTOMLExtractor) Extract(f extractor.DepFile, context extractor.S
 		lines:          lines,
 		path:           f.Path(),
 		packageManager: pm,
+		reporter:       context.Reporter,
 	}
 
 	for _, dep := range pyproject.Project.Dependencies {

--- a/pkg/extractor/python/parse-pyproject-toml.go
+++ b/pkg/extractor/python/parse-pyproject-toml.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 var pyprojectSiblingLockfiles = []string{
@@ -150,7 +151,7 @@ func (e PyProjectTOMLExtractor) Extract(f extractor.DepFile, context extractor.S
 		lines:          lines,
 		path:           f.Path(),
 		packageManager: pm,
-		reporter:       context.Reporter,
+		reporter:       reporter.Effective(context.Reporter),
 	}
 
 	for _, dep := range pyproject.Project.Dependencies {

--- a/pkg/extractor/python/parse-pyproject-toml_test.go
+++ b/pkg/extractor/python/parse-pyproject-toml_test.go
@@ -2,7 +2,6 @@ package python_test
 
 import (
 	"bytes"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor/python"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 func fixturePath(t *testing.T, rel string) string {
@@ -308,9 +308,7 @@ func TestParsePyProjectTOML_ConflictingRangesAreSourceOrderedAndLogged(t *testin
 	t.Parallel()
 
 	var logs bytes.Buffer
-	previousLogOutput := log.Writer()
-	log.SetOutput(&logs)
-	defer log.SetOutput(previousLogOutput)
+	r := reporter.NewCycloneDXReporterWithPretty(os.Stdout, &logs, reporter.WarnLevel, true)
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "pyproject.toml")
@@ -331,7 +329,8 @@ dev = [
 		t.Fatalf("could not write pyproject fixture: %v", err)
 	}
 
-	packages, err := python.ParsePyProjectTOML(path)
+	ctx := extractor.ScanContext{Reporter: r}
+	packages, err := extractor.ExtractFromFileWithContext(path, python.PyProjectExtractor, ctx)
 
 	expectNilErr(t, err)
 	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{

--- a/pkg/extractor/python/pyproject_package_collector.go
+++ b/pkg/extractor/python/pyproject_package_collector.go
@@ -2,7 +2,6 @@ package python
 
 import (
 	"cmp"
-	"log"
 	"maps"
 	"math"
 	"slices"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 type pyprojectPackageCollector struct {
@@ -17,12 +17,13 @@ type pyprojectPackageCollector struct {
 	lines          []string
 	path           string
 	packageManager models.PackageManager
+	reporter       reporter.Reporter
 }
 
 func (c *pyprojectPackageCollector) addDependency(dependency pep508Dependency, groups []string, isPoetry bool) {
 	if (dependency.Version == "") == (dependency.VersionRange == "") {
-		log.Printf(
-			"Invalid pyproject dependency state for %q from %s: expected exactly one of version or version range, got version=%q versionRange=%q\n",
+		c.reporter.Warnf(
+			"Invalid pyproject dependency state for %q from %s: expected exactly one of version or version range, got version=%q versionRange=%q",
 			dependency.Name,
 			c.path,
 			dependency.Version,
@@ -91,8 +92,8 @@ func (c *pyprojectPackageCollector) logVersionRangeConflict(pkg extractor.Packag
 			continue
 		}
 
-		log.Printf(
-			"Multiple pyproject version ranges for dependency %q from %s collapse to the same unversioned PURL; CycloneDX output will keep the earliest source declaration. Saw ranges %q and %q\n",
+		c.reporter.Warnf(
+			"Multiple pyproject version ranges for dependency %q from %s collapse to the same unversioned PURL; CycloneDX output will keep the earliest source declaration. Saw ranges %q and %q",
 			pkg.Name,
 			c.path,
 			existing.VersionRange,

--- a/pkg/extractor/ruby/match-gemfile.go
+++ b/pkg/extractor/ruby/match-gemfile.go
@@ -1,13 +1,13 @@
 package ruby
 
 import (
-	"log"
 	"path/filepath"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/utility/converter"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
@@ -32,13 +32,13 @@ func (matcher GemfileMatcher) Match(sourceFile extractor.DepFile, packages []ext
 	if err != nil {
 		return err
 	}
-	enrichPackagesWithLocation(sourceFile, rootGems, packagesByName)
+	enrichPackagesWithLocation(context.Reporter, sourceFile, rootGems, packagesByName)
 
 	remainingGems, err := findGroupedGems(treeResult.Node)
 	if err != nil {
 		return err
 	}
-	enrichPackagesWithLocation(sourceFile, remainingGems, packagesByName)
+	enrichPackagesWithLocation(context.Reporter, sourceFile, remainingGems, packagesByName)
 
 	return nil
 }
@@ -194,13 +194,13 @@ func indexPackages(packages []extractor.PackageDetails) map[string]*extractor.Pa
 	return result
 }
 
-func enrichPackagesWithLocation(sourceFile extractor.DepFile, gems []gemMetadata, packagesByName map[string]*extractor.PackageDetails) {
+func enrichPackagesWithLocation(r reporter.Reporter, sourceFile extractor.DepFile, gems []gemMetadata, packagesByName map[string]*extractor.PackageDetails) {
 	for _, gem := range gems {
 		pkg, ok := packagesByName[gem.name]
 		// If packages exist in the Gemfile but not in the Gemfile.lock, we skip the package as we treat the lockfile as
 		// the source of truth
 		if !ok {
-			log.Printf("Skipping package %q from Gemfile as it does not exist in the Gemfile.lock\n", gem.name)
+			r.Verbosef("Skipping package %q from Gemfile as it does not exist in the Gemfile.lock", gem.name)
 			continue
 		}
 

--- a/pkg/extractor/ruby/match-gemfile.go
+++ b/pkg/extractor/ruby/match-gemfile.go
@@ -32,13 +32,13 @@ func (matcher GemfileMatcher) Match(sourceFile extractor.DepFile, packages []ext
 	if err != nil {
 		return err
 	}
-	enrichPackagesWithLocation(context.Reporter, sourceFile, rootGems, packagesByName)
+	enrichPackagesWithLocation(reporter.Effective(context.Reporter), sourceFile, rootGems, packagesByName)
 
 	remainingGems, err := findGroupedGems(treeResult.Node)
 	if err != nil {
 		return err
 	}
-	enrichPackagesWithLocation(context.Reporter, sourceFile, remainingGems, packagesByName)
+	enrichPackagesWithLocation(reporter.Effective(context.Reporter), sourceFile, remainingGems, packagesByName)
 
 	return nil
 }

--- a/pkg/extractor/ruby/match-gemfile.go
+++ b/pkg/extractor/ruby/match-gemfile.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/DataDog/datadog-sbom-generator/internal/utility/converter"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
-	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 func (matcher GemfileMatcher) GetSourceFile(sourceFile extractor.DepFile) (extractor.DepFile, error) {

--- a/pkg/extractor/ruby/match-gemspec.go
+++ b/pkg/extractor/ruby/match-gemspec.go
@@ -1,7 +1,6 @@
 package ruby
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/internal/utility/converter"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
 func (matcher GemspecFileMatcher) GetSourceFile(sourceFile extractor.DepFile) (extractor.DepFile, error) {
@@ -44,7 +44,7 @@ func (matcher GemspecFileMatcher) Match(sourceFile extractor.DepFile, packages [
 	if err != nil {
 		return err
 	}
-	matcher.enrichPackagesWithLocation(sourceFile, gems, packagesByName)
+	matcher.enrichPackagesWithLocation(context.Reporter, sourceFile, gems, packagesByName)
 
 	return nil
 }
@@ -117,13 +117,13 @@ func (matcher GemspecFileMatcher) findGemspecs(node *extractor.Node) ([]gemspecM
 	return gems, nil
 }
 
-func (matcher GemspecFileMatcher) enrichPackagesWithLocation(sourceFile extractor.DepFile, gems []gemspecMetadata, packagesByName map[string]*extractor.PackageDetails) {
+func (matcher GemspecFileMatcher) enrichPackagesWithLocation(r reporter.Reporter, sourceFile extractor.DepFile, gems []gemspecMetadata, packagesByName map[string]*extractor.PackageDetails) {
 	for _, gem := range gems {
 		pkg, ok := packagesByName[gem.name]
 		// If packages exist in a .gemspec but not in the Gemfile.lock, we skip the package as we treat the lockfile as
 		// the source of truth
 		if !ok {
-			log.Printf("Skipping package %q from gemspec as it does not exist in the Gemfile.lock\n", gem.name)
+			r.Verbosef("Skipping package %q from gemspec as it does not exist in the Gemfile.lock", gem.name)
 			continue
 		}
 

--- a/pkg/extractor/ruby/match-gemspec.go
+++ b/pkg/extractor/ruby/match-gemspec.go
@@ -44,7 +44,7 @@ func (matcher GemspecFileMatcher) Match(sourceFile extractor.DepFile, packages [
 	if err != nil {
 		return err
 	}
-	matcher.enrichPackagesWithLocation(context.Reporter, sourceFile, gems, packagesByName)
+	matcher.enrichPackagesWithLocation(reporter.Effective(context.Reporter), sourceFile, gems, packagesByName)
 
 	return nil
 }

--- a/pkg/reachability/codefile/java.go
+++ b/pkg/reachability/codefile/java.go
@@ -3,13 +3,13 @@ package codefile
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/utility/converter"
 
 	"github.com/DataDog/datadog-sbom-generator/internal/utility/fileposition"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 
 	treesitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_java "github.com/tree-sitter/tree-sitter-java/bindings/go"
@@ -27,12 +27,13 @@ var symbolTypeToTSQuery = map[string]string{
 type ReachabilityJava struct {
 	tsParser               *treesitter.Parser
 	tsQueriesPerSymbolType map[string]*treesitter.Query
+	reporter               reporter.Reporter
 }
 
 // NewJavaReachableDetector creates a new JavaReachableDetector instance that once
 // instantiated can be used to parse Java files. You should call Close() on the
 // instance once you're finished parsing.
-func NewJavaReachableDetector() (*ReachabilityJava, error) {
+func NewJavaReachableDetector(r reporter.Reporter) (*ReachabilityJava, error) {
 	tsLanguage := treesitter.NewLanguage(tree_sitter_java.Language())
 
 	tsParser := treesitter.NewParser()
@@ -55,6 +56,7 @@ func NewJavaReachableDetector() (*ReachabilityJava, error) {
 	return &ReachabilityJava{
 		tsParser:               tsParser,
 		tsQueriesPerSymbolType: tsQueriesPerSymbolType,
+		reporter:               r,
 	}, nil
 }
 
@@ -102,7 +104,7 @@ func (r *ReachabilityJava) Detect(ctx context.Context, dir string, path string, 
 		for _, s := range advisoryToCheck.Symbols {
 			query := r.tsQueriesPerSymbolType[s.Type]
 			if query == nil {
-				log.Printf("No query found for symbol type %s\n", s.Type)
+				r.reporter.Warnf("No query found for symbol type %s", s.Type)
 				continue
 			}
 
@@ -170,12 +172,11 @@ func (r *ReachabilityJava) Detect(ctx context.Context, dir string, path string, 
 }
 
 // readFileContent is a thin wrapper over os.ReadFile that reads the content of a file
-// and returns it as a byte slice while logging any errors.
+// and returns it as a byte slice.
 // TODO(daniel.strong): find a better place for this function
 func readFileContent(filePath string) ([]byte, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Printf("Error reading file %s: %v", filePath, err)
 		return nil, err
 	}
 

--- a/pkg/reachability/codefile/java.go
+++ b/pkg/reachability/codefile/java.go
@@ -56,7 +56,7 @@ func NewJavaReachableDetector(r reporter.Reporter) (*ReachabilityJava, error) {
 	return &ReachabilityJava{
 		tsParser:               tsParser,
 		tsQueriesPerSymbolType: tsQueriesPerSymbolType,
-		reporter:               r,
+		reporter:               reporter.Effective(r),
 	}, nil
 }
 

--- a/pkg/reachability/codefile/java_test.go
+++ b/pkg/reachability/codefile/java_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ import (
 
 func Test_NewJavaReachableDetector(t *testing.T) {
 	t.Parallel()
-	detector, err := NewJavaReachableDetector()
+	detector, err := NewJavaReachableDetector(&reporter.VoidReporter{})
 	require.NoError(t, err)
 	defer detector.Close()
 
@@ -21,7 +22,7 @@ func Test_NewJavaReachableDetector(t *testing.T) {
 
 func Test_Detect_NoAdvisories(t *testing.T) {
 	t.Parallel()
-	detector, err := NewJavaReachableDetector()
+	detector, err := NewJavaReachableDetector(&reporter.VoidReporter{})
 	require.NoError(t, err)
 	defer detector.Close()
 
@@ -38,7 +39,7 @@ func Test_Detect_NoAdvisories(t *testing.T) {
 
 func Test_Detect_ClassSymbolsFound(t *testing.T) {
 	t.Parallel()
-	detector, err := NewJavaReachableDetector()
+	detector, err := NewJavaReachableDetector(&reporter.VoidReporter{})
 	require.NoError(t, err)
 	defer detector.Close()
 

--- a/pkg/reachability/reachability.go
+++ b/pkg/reachability/reachability.go
@@ -40,7 +40,7 @@ func PerformReachabilityAnalysis(r reporter.Reporter, purls []string, directoryP
 	eg.SetLimit(workerCount)
 
 	for range workerCount {
-		detector, err := codefile.NewJavaReachableDetector()
+		detector, err := codefile.NewJavaReachableDetector(r)
 		if err != nil {
 			r.Errorf("[reachability] Failed to create Java reachability detector: %v", err)
 			return models.ReachabilityAnalysis{}

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -5,6 +5,15 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// Effective returns r if non-nil, otherwise a VoidReporter that silently discards all output.
+// Use this when constructing structs that hold a Reporter to guarantee the field is never nil.
+func Effective(r Reporter) Reporter {
+	if r == nil {
+		return &VoidReporter{}
+	}
+	return r
+}
+
 type VoidReporter struct {
 	hasErrored bool
 }

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -11,6 +11,7 @@ func Effective(r Reporter) Reporter {
 	if r == nil {
 		return &VoidReporter{}
 	}
+
 	return r
 }
 

--- a/pkg/scanner/datadog_sbom_generator.go
+++ b/pkg/scanner/datadog_sbom_generator.go
@@ -3,7 +3,6 @@ package scanner
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -341,9 +340,9 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 
 	scannedPackages, droppedReasons := sanitizeScannedPackages(scannedPackages)
 	if len(droppedReasons) > 0 {
-		log.Println("Note that some scanned packages were dropped:")
+		r.Warnf("Note that some scanned packages were dropped:")
 		for _, reason := range droppedReasons {
-			log.Printf(" - %s\n", reason)
+			r.Warnf(" - %s", reason)
 		}
 	}
 

--- a/pkg/scanner/vulnerability_result.go
+++ b/pkg/scanner/vulnerability_result.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/reporter"
 )
 
-func exportMetadata(rawPkg extractor.PackageDetails, reachabilityAnalysisResults *models.ReachabilityAnalysisResults) map[models.PackageMetadataType]string {
+func exportMetadata(r reporter.Reporter, rawPkg extractor.PackageDetails, reachabilityAnalysisResults *models.ReachabilityAnalysisResults) map[models.PackageMetadataType]string {
 	metadata := make(map[models.PackageMetadataType]string)
 
 	if len(rawPkg.PackageManager) > 0 && rawPkg.PackageManager != models.Unknown {
@@ -50,13 +49,13 @@ func exportMetadata(rawPkg extractor.PackageDetails, reachabilityAnalysisResults
 	}
 	if reachabilityAnalysisResults != nil {
 		if !rawPkg.IsDirect && len(reachabilityAnalysisResults.ReachableVulnerabilities) > 0 {
-			log.Printf("transitive package (%s) with reachable symbols was dropped\n", rawPkg.PURL)
+			r.Warnf("transitive package (%s) with reachable symbols was dropped", rawPkg.PURL)
 		} else {
 			for _, vuln := range reachabilityAnalysisResults.ReachableVulnerabilities {
 				key := models.ReachableSymbolLocationMetadata.WithValue(vuln.AdvisoryID)
 				val, err := vuln.ReachableSymbolLocations.MarshalToJSONString()
 				if err != nil {
-					log.Printf("failed to marshal reachable symbol locations into a JSON string: %s\n", err)
+					r.Errorf("failed to marshal reachable symbol locations into a JSON string: %s", err)
 					continue
 				}
 				metadata[key] = val
@@ -86,7 +85,7 @@ func groupBySource(r reporter.Reporter, packages []extractor.PackageDetails, art
 					Ecosystem: string(p.Ecosystem),
 					Purl:      p.PURL,
 				},
-				Metadata: exportMetadata(p, reachabilityAnalysis.PurlToReachabilityAnalysisResults[p.PURL]),
+				Metadata: exportMetadata(r, p, reachabilityAnalysis.PurlToReachabilityAnalysisResults[p.PURL]),
 			}
 		case p.Commit != "":
 			pkg.Package.Version = p.Commit

--- a/pkg/scanner/vulnerability_result_test.go
+++ b/pkg/scanner/vulnerability_result_test.go
@@ -208,7 +208,7 @@ func Test_exportMetadata(t *testing.T) {
 			t.Parallel()
 
 			// Call the function
-			metadata := exportMetadata(tc.rawPkg, tc.reachabilityAnalysis)
+			metadata := exportMetadata(&reporter.VoidReporter{}, tc.rawPkg, tc.reachabilityAnalysis)
 
 			// Validate metadata
 			assert.Equal(t, tc.expectedMetadata, metadata)


### PR DESCRIPTION
## Summary

- Replaces all 11 `log.Printf`/`log.Println` calls in `pkg/` with the existing `reporter.Reporter` interface methods (`Warnf`, `Infof`, `Errorf`, `Verbosef`)
- Threads `Reporter` through to scanner, extractor matchers (Ruby, Python, JavaScript), and reachability layers where it wasn't previously available
- Library consumers can now use `VoidReporter` to fully silence all log output, eliminating noise in their service's logs

## Motivation

Downstream consumers using this library (e.g. `sci`) were seeing `log.Printf` output from the library appearing as noise in their service logs. The library already had the right abstraction (`reporter.Reporter` + `VoidReporter`) but 11 call sites bypassed it.

## Changes

- `pkg/scanner/datadog_sbom_generator.go` — use Reporter already in scope
- `pkg/scanner/vulnerability_result.go` — add Reporter parameter to `exportMetadata`
- `pkg/extractor/ruby/match-gemspec.go`, `match-gemfile.go` — thread Reporter through enrichment functions
- `pkg/extractor/python/pyproject_package_collector.go` — add `reporter` field to struct
- `pkg/extractor/javascript/match-package-json.go` — add `reporter` field to `packageJSONDependencyMap`
- `pkg/reachability/codefile/java.go` — add `reporter` field to `ReachabilityJava`, update `NewJavaReachableDetector` signature

## Test plan

- [ ] All existing tests pass unchanged
- [ ] Zero `log.Print*` calls remain in `pkg/` source files
- [ ] Linter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)