### PR TITLE
feat(maven): capture groupId namespace location in extractor output

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -12637,7 +12637,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":20,/"line_end/":24,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"name/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":22,/"line_end/":22,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":9,/"line_end/":9,/"column_start/":12,/"column_end/":24,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":20,/"line_end/":24,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/integration-test-locks/other-dir/pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":16,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":22,/"line_end/":22,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":9,/"line_end/":9,/"column_start/":12,/"column_end/":24,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -12661,7 +12661,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":30,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":30,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/integration-test-locks/pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -17784,7 +17784,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-8/pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -17915,7 +17915,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-8/maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -17938,7 +17938,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-8/maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -23711,7 +23711,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":30,/"line_end/":30,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-16/pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":30,/"line_end/":30,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -23842,7 +23842,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-16/maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -23865,7 +23865,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-16/maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -29610,7 +29610,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":30,/"line_end/":30,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/Windows-1252/pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":30,/"line_end/":30,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -29741,7 +29741,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/Windows-1252/maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -29764,7 +29764,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/Windows-1252/maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -30536,7 +30536,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":20,/"line_end/":24,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"name/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":22,/"line_end/":22,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":9,/"line_end/":9,/"column_start/":12,/"column_end/":24,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":20,/"line_end/":24,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/integration-test-locks/other-dir/pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":16,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":22,/"line_end/":22,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":9,/"line_end/":9,/"column_start/":12,/"column_end/":24,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -30560,7 +30560,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":30,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":30,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/integration-test-locks/pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }

--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -12637,7 +12637,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":20,/"line_end/":24,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/integration-test-locks/other-dir/pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":16,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":22,/"line_end/":22,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":9,/"line_end/":9,/"column_start/":12,/"column_end/":24,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":20,/"line_end/":24,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":16,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":22,/"line_end/":22,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":9,/"line_end/":9,/"column_start/":12,/"column_end/":24,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -12661,7 +12661,7 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":30,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/integration-test-locks/pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":30,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -17784,7 +17784,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-8/pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -17915,7 +17915,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-8/maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -17938,7 +17938,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-8/maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -23711,7 +23711,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-16/pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":30,/"line_end/":30,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":30,/"line_end/":30,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -23842,7 +23842,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-16/maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -23865,7 +23865,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/UTF-16/maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -29610,7 +29610,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/Windows-1252/pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":30,/"line_end/":30,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":31,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":30,/"line_end/":30,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -29741,7 +29741,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/Windows-1252/maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":38,/"line_end/":42,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":39,/"line_end/":39,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":40,/"line_end/":40,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -29764,7 +29764,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/encoding-integration-test-locks/Windows-1252/maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":33,/"line_end/":36,/"column_start/":3,/"column_end/":16,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":34,/"line_end/":34,/"column_start/":13,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"maven-spring/pom.xml/",/"line_start/":35,/"line_end/":35,/"column_start/":16,/"column_end/":39,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -30536,7 +30536,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":20,/"line_end/":24,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/integration-test-locks/other-dir/pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":16,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":22,/"line_end/":22,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":9,/"line_end/":9,/"column_start/":12,/"column_end/":24,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":20,/"line_end/":24,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":16,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"other-dir/pom.xml/",/"line_start/":22,/"line_end/":22,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":9,/"line_end/":9,/"column_start/":12,/"column_end/":24,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -30560,7 +30560,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":30,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"<rootdir>/fixtures/integration-test-locks/pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"pom.xml/",/"line_start/":27,/"line_end/":30,/"column_start/":5,/"column_end/":18,/"role/":/"manifest/"},/"namespace/":{/"file_name/":/"pom.xml/",/"line_start/":28,/"line_end/":28,/"column_start/":16,/"column_end/":40,/"role/":/"manifest/"},/"name/":{/"file_name/":/"pom.xml/",/"line_start/":29,/"line_end/":29,/"column_start/":19,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"pom.xml/",/"line_start/":21,/"line_end/":21,/"column_start/":18,/"column_end/":23,/"role/":/"manifest/"}}"
           }
         ]
       }

--- a/internal/utility/location/location.go
+++ b/internal/utility/location/location.go
@@ -5,7 +5,7 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
 )
 
-func NewPackageLocations(block models.FilePosition, name *models.FilePosition, version *models.FilePosition, role string) models.PackageLocations {
+func NewPackageLocations(block models.FilePosition, name *models.FilePosition, version *models.FilePosition, namespace *models.FilePosition, role string) models.PackageLocations {
 	result := models.PackageLocations{
 		Block: models.PackageLocation{
 			Filename:    block.Filename,
@@ -34,6 +34,16 @@ func NewPackageLocations(block models.FilePosition, name *models.FilePosition, v
 			LineEnd:     version.Line.End,
 			ColumnStart: version.Column.Start,
 			ColumnEnd:   version.Column.End,
+			Role:        role,
+		}
+	}
+	if namespace != nil && fileposition.IsFilePositionExtractedSuccessfully(*namespace) {
+		result.Namespace = &models.PackageLocation{
+			Filename:    namespace.Filename,
+			LineStart:   namespace.Line.Start,
+			LineEnd:     namespace.Line.End,
+			ColumnStart: namespace.Column.Start,
+			ColumnEnd:   namespace.Column.End,
 			Role:        role,
 		}
 	}

--- a/internal/utility/location/location_test.go
+++ b/internal/utility/location/location_test.go
@@ -18,7 +18,7 @@ func TestNewPackageLocations_RolePropagatedToBlock(t *testing.T) {
 	t.Parallel()
 
 	block := validFilePosition()
-	result := NewPackageLocations(block, nil, nil, models.LocationRoleManifest)
+	result := NewPackageLocations(block, nil, nil, nil, models.LocationRoleManifest)
 
 	if result.Block.Role != models.LocationRoleManifest {
 		t.Errorf("expected Block.Role=%q, got %q", models.LocationRoleManifest, result.Block.Role)
@@ -30,7 +30,7 @@ func TestNewPackageLocations_RolePropagatedToName(t *testing.T) {
 
 	block := validFilePosition()
 	name := validFilePosition()
-	result := NewPackageLocations(block, &name, nil, models.LocationRoleLockfile)
+	result := NewPackageLocations(block, &name, nil, nil, models.LocationRoleLockfile)
 
 	if result.Name == nil {
 		t.Fatal("expected Name to be non-nil")
@@ -45,7 +45,7 @@ func TestNewPackageLocations_RolePropagatedToVersion(t *testing.T) {
 
 	block := validFilePosition()
 	version := validFilePosition()
-	result := NewPackageLocations(block, nil, &version, models.LocationRoleManifest)
+	result := NewPackageLocations(block, nil, &version, nil, models.LocationRoleManifest)
 
 	if result.Version == nil {
 		t.Fatal("expected Version to be non-nil")
@@ -59,12 +59,41 @@ func TestNewPackageLocations_NilNameAndVersionRemainNil(t *testing.T) {
 	t.Parallel()
 
 	block := validFilePosition()
-	result := NewPackageLocations(block, nil, nil, models.LocationRoleManifest)
+	result := NewPackageLocations(block, nil, nil, nil, models.LocationRoleManifest)
 
 	if result.Name != nil {
 		t.Error("expected Name to remain nil")
 	}
 	if result.Version != nil {
 		t.Error("expected Version to remain nil")
+	}
+	if result.Namespace != nil {
+		t.Error("expected Namespace to remain nil")
+	}
+}
+
+func TestNewPackageLocations_RolePropagatedToNamespace(t *testing.T) {
+	t.Parallel()
+
+	block := validFilePosition()
+	namespace := validFilePosition()
+	result := NewPackageLocations(block, nil, nil, &namespace, models.LocationRoleLockfile)
+
+	if result.Namespace == nil {
+		t.Fatal("expected Namespace to be non-nil")
+	}
+	if result.Namespace.Role != models.LocationRoleLockfile {
+		t.Errorf("expected Namespace.Role=%q, got %q", models.LocationRoleLockfile, result.Namespace.Role)
+	}
+}
+
+func TestNewPackageLocations_NilNamespaceRemainsNil(t *testing.T) {
+	t.Parallel()
+
+	block := validFilePosition()
+	result := NewPackageLocations(block, nil, nil, nil, models.LocationRoleManifest)
+
+	if result.Namespace != nil {
+		t.Error("expected Namespace to remain nil")
 	}
 }

--- a/pkg/extractor/internal/testutil/helpers.go
+++ b/pkg/extractor/internal/testutil/helpers.go
@@ -135,7 +135,7 @@ func cmpOptions(ignoreLocations bool) []cmp.Option {
 	}
 
 	return []cmp.Option{
-		cmpopts.IgnoreFields(extractor.PackageDetails{}, "BlockLocation", "LocationRole", "NameLocation", "VersionLocation"),
+		cmpopts.IgnoreFields(extractor.PackageDetails{}, "BlockLocation", "LocationRole", "NameLocation", "NamespaceLocation", "VersionLocation"),
 	}
 }
 

--- a/pkg/extractor/java/parse-maven-lock.go
+++ b/pkg/extractor/java/parse-maven-lock.go
@@ -491,6 +491,14 @@ func (e MavenLockExtractor) Extract(f extractor.DepFile, context extractor.ScanC
 			groupIDPosition.Filename = lockPackage.SourceFile
 		}
 
+		// Skip namespace location when groupId is inherited via ${project.*} property: the
+		// resolved position carries the parent POM's line/column mapped onto the child file,
+		// which would point to the wrong text.
+		var namespaceLocation *models.FilePosition
+		if !strings.HasPrefix(lockPackage.GroupID.Value, "${project.") {
+			namespaceLocation = &groupIDPosition
+		}
+
 		var exclusions []string
 		if len(lockPackage.Exclusions) > 0 {
 			exclusions = make([]string, 0, len(lockPackage.Exclusions))
@@ -506,7 +514,7 @@ func (e MavenLockExtractor) Extract(f extractor.DepFile, context extractor.ScanC
 			BlockLocation:     blockLocation,
 			LocationRole:      models.LocationRoleManifest,
 			NameLocation:      &artifactPosition,
-			NamespaceLocation: &groupIDPosition,
+			NamespaceLocation: namespaceLocation,
 			VersionLocation:   &versionPosition,
 			PackageManager:    mavenPackageManager,
 			IsDirect:          true,

--- a/pkg/extractor/java/parse-maven-lock.go
+++ b/pkg/extractor/java/parse-maven-lock.go
@@ -466,7 +466,7 @@ func (e MavenLockExtractor) Extract(f extractor.DepFile, context extractor.ScanC
 	details := map[string]extractor.PackageDetails{}
 
 	for _, lockPackage := range parsedLockfile.Dependencies.Dependencies {
-		resolvedGroupID, _ := lockPackage.ResolveGroupID(*parsedLockfile, context)
+		resolvedGroupID, groupIDPosition := lockPackage.ResolveGroupID(*parsedLockfile, context)
 		resolvedArtifactID, artifactPosition := lockPackage.ResolveArtifactID(*parsedLockfile, context)
 		resolvedVersion, versionPosition := lockPackage.ResolveVersion(*parsedLockfile, context)
 		finalName := resolvedGroupID + ":" + resolvedArtifactID
@@ -486,6 +486,10 @@ func (e MavenLockExtractor) Extract(f extractor.DepFile, context extractor.ScanC
 			versionPosition = lockPackage.Version.FilePosition
 			versionPosition.Filename = lockPackage.SourceFile
 		}
+		if groupIDPosition == (models.FilePosition{}) {
+			groupIDPosition = lockPackage.GroupID.FilePosition
+			groupIDPosition.Filename = lockPackage.SourceFile
+		}
 
 		var exclusions []string
 		if len(lockPackage.Exclusions) > 0 {
@@ -496,16 +500,17 @@ func (e MavenLockExtractor) Extract(f extractor.DepFile, context extractor.ScanC
 		}
 
 		pkgDetails := extractor.PackageDetails{
-			Name:            finalName,
-			Version:         resolvedVersion,
-			Ecosystem:       models.EcosystemMaven,
-			BlockLocation:   blockLocation,
-			LocationRole:    models.LocationRoleManifest,
-			NameLocation:    &artifactPosition,
-			VersionLocation: &versionPosition,
-			PackageManager:  mavenPackageManager,
-			IsDirect:        true,
-			Exclusions:      exclusions,
+			Name:              finalName,
+			Version:           resolvedVersion,
+			Ecosystem:         models.EcosystemMaven,
+			BlockLocation:     blockLocation,
+			LocationRole:      models.LocationRoleManifest,
+			NameLocation:      &artifactPosition,
+			NamespaceLocation: &groupIDPosition,
+			VersionLocation:   &versionPosition,
+			PackageManager:    mavenPackageManager,
+			IsDirect:          true,
+			Exclusions:        exclusions,
 		}
 		if scope := strings.TrimSpace(lockPackage.Scope); scope != "" && scope != "compile" {
 			// Only append non-default scope (compile is the default scope).

--- a/pkg/extractor/java/parse-maven-lock.go
+++ b/pkg/extractor/java/parse-maven-lock.go
@@ -491,11 +491,13 @@ func (e MavenLockExtractor) Extract(f extractor.DepFile, context extractor.ScanC
 			groupIDPosition.Filename = lockPackage.SourceFile
 		}
 
-		// Skip namespace location when groupId is inherited via ${project.*} property: the
-		// resolved position carries the parent POM's line/column mapped onto the child file,
-		// which would point to the wrong text.
+		// Skip namespace location when groupId is inherited via ${project.*} or ${pom.*}
+		// property: the resolved position carries the parent POM's line/column mapped onto
+		// the child file, which would point to the wrong text. ${pom.*} is a deprecated
+		// alias for ${project.*} and behaves identically.
 		var namespaceLocation *models.FilePosition
-		if !strings.HasPrefix(lockPackage.GroupID.Value, "${project.") {
+		if !strings.HasPrefix(lockPackage.GroupID.Value, "${project.") &&
+			!strings.HasPrefix(lockPackage.GroupID.Value, "${pom.") {
 			namespaceLocation = &groupIDPosition
 		}
 

--- a/pkg/extractor/java/parse-maven-lock_test.go
+++ b/pkg/extractor/java/parse-maven-lock_test.go
@@ -135,6 +135,11 @@ func TestParseMavenLock_ShouldRemoveComments(t *testing.T) {
 				Column:   models.Position{Start: 10, End: 22},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 5, End: 5},
+				Column:   models.Position{Start: 9, End: 25},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 13, End: 13},
 				Column:   models.Position{Start: 45, End: 50},
@@ -175,6 +180,11 @@ func TestParseMavenLock_ShouldTrim(t *testing.T) {
 				Column:   models.Position{Start: 10, End: 24},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 11, End: 11},
+				Column:   models.Position{Start: 9, End: 25},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 16, End: 16},
 				Column:   models.Position{Start: 19, End: 24},
@@ -198,6 +208,11 @@ func TestParseMavenLock_ShouldTrim(t *testing.T) {
 				Column:   models.Position{Start: 9, End: 24},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 21, End: 21},
+				Column:   models.Position{Start: 9, End: 25},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 4, End: 4},
 				Column:   models.Position{Start: 9, End: 12},
@@ -219,6 +234,11 @@ func TestParseMavenLock_ShouldTrim(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 34, End: 34},
 				Column:   models.Position{Start: 1, End: 16},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 31, End: 31},
+				Column:   models.Position{Start: 10, End: 26},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -259,6 +279,11 @@ func TestParseMavenLock_OnePackage(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 9, End: 9},
 				Column:   models.Position{Start: 19, End: 33},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 16, End: 32},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -302,6 +327,11 @@ func TestParseMavenLock_WithExternalParent(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 32},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 11, End: 11},
+				Column:   models.Position{Start: 16, End: 35},
+				Filename: path,
+			},
 			IsDirect: true,
 		},
 	})
@@ -335,6 +365,11 @@ func TestParseMavenLock_OnePackageWithMultipleVersionVariable(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 11, End: 11},
 				Column:   models.Position{Start: 19, End: 33},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 10, End: 10},
+				Column:   models.Position{Start: 16, End: 32},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -377,6 +412,11 @@ func TestParseMavenLock_TwoPackageWithMixedVersionDefinition(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 28},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 10, End: 10},
 				Column:   models.Position{Start: 16, End: 38},
@@ -398,6 +438,11 @@ func TestParseMavenLock_TwoPackageWithMixedVersionDefinition(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 14, End: 14},
 				Column:   models.Position{Start: 19, End: 48},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 13, End: 13},
+				Column:   models.Position{Start: 16, End: 25},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -440,6 +485,11 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 28},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 10, End: 10},
 				Column:   models.Position{Start: 16, End: 28},
@@ -461,6 +511,11 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 14, End: 14},
 				Column:   models.Position{Start: 19, End: 32},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 13, End: 13},
+				Column:   models.Position{Start: 16, End: 25},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -503,6 +558,11 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 28},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 23, End: 23},
 				Column:   models.Position{Start: 18, End: 30},
@@ -524,6 +584,11 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 13, End: 13},
 				Column:   models.Position{Start: 19, End: 32},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 12, End: 12},
+				Column:   models.Position{Start: 16, End: 25},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -566,6 +631,11 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 28},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 19, End: 19},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 12, End: 12},
 				Column:   models.Position{Start: 23, End: 28},
@@ -589,6 +659,11 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 29},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 25, End: 25},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 13, End: 13},
 				Column:   models.Position{Start: 25, End: 30},
@@ -610,6 +685,11 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 32, End: 32},
 				Column:   models.Position{Start: 19, End: 33},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 31, End: 31},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -653,6 +733,11 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 25},
 				Filename: parentPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 27, End: 27},
+				Column:   models.Position{Start: 16, End: 40},
+				Filename: parentPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 20, End: 20},
 				Column:   models.Position{Start: 18, End: 23},
@@ -674,6 +759,11 @@ func TestMavenLock_WithParent(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 16, End: 16},
 				Column:   models.Position{Start: 19, End: 28},
+				Filename: childPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 15, End: 15},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: childPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -699,6 +789,11 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 32},
 				Filename: childPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 19, End: 19},
+				Column:   models.Position{Start: 16, End: 25},
+				Filename: childPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 21, End: 21},
 				Column:   models.Position{Start: 16, End: 22},
@@ -720,6 +815,11 @@ func TestMavenLock_WithParent(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 25, End: 25},
 				Column:   models.Position{Start: 19, End: 28},
+				Filename: childPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 24, End: 24},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: childPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -745,6 +845,11 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 29},
 				Filename: childPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 29, End: 29},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: childPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 5, End: 5},
 				Column:   models.Position{Start: 25, End: 30},
@@ -766,6 +871,11 @@ func TestMavenLock_WithParent(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 35, End: 35},
 				Column:   models.Position{Start: 19, End: 22},
+				Filename: childPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 34, End: 34},
+				Column:   models.Position{Start: 16, End: 23},
 				Filename: childPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -809,6 +919,11 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 25},
 				Filename: parentPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 26, End: 26},
+				Column:   models.Position{Start: 16, End: 40},
+				Filename: parentPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 19, End: 19},
 				Column:   models.Position{Start: 18, End: 23},
@@ -830,6 +945,11 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 16, End: 16},
 				Column:   models.Position{Start: 19, End: 28},
+				Filename: childPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 15, End: 15},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: childPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -855,6 +975,11 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 32},
 				Filename: childPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 19, End: 19},
+				Column:   models.Position{Start: 16, End: 25},
+				Filename: childPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 21, End: 21},
 				Column:   models.Position{Start: 16, End: 22},
@@ -878,6 +1003,11 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 28},
 				Filename: childPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 24, End: 24},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: childPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 4, End: 4},
 				Column:   models.Position{Start: 23, End: 28},
@@ -899,6 +1029,11 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 30, End: 30},
 				Column:   models.Position{Start: 19, End: 29},
+				Filename: childPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 29, End: 29},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: childPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -942,6 +1077,11 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 25},
 				Filename: parentPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 26, End: 26},
+				Column:   models.Position{Start: 16, End: 40},
+				Filename: parentPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 19, End: 19},
 				Column:   models.Position{Start: 18, End: 23},
@@ -963,6 +1103,11 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 15, End: 15},
 				Column:   models.Position{Start: 19, End: 28},
+				Filename: childPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 14, End: 14},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: childPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -988,6 +1133,11 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 32},
 				Filename: childPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 18, End: 18},
+				Column:   models.Position{Start: 16, End: 25},
+				Filename: childPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 20, End: 20},
 				Column:   models.Position{Start: 16, End: 22},
@@ -1011,6 +1161,11 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 28},
 				Filename: childPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 23, End: 23},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: childPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 4, End: 4},
 				Column:   models.Position{Start: 23, End: 28},
@@ -1032,6 +1187,11 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 29, End: 29},
 				Column:   models.Position{Start: 19, End: 29},
+				Filename: childPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 28, End: 28},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: childPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1073,6 +1233,11 @@ func TestMavenLock_WithParent_Child_Project(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 13, End: 13},
 				Column:   models.Position{Start: 19, End: 25},
+				Filename: parentPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 12, End: 12},
+				Column:   models.Position{Start: 16, End: 40},
 				Filename: parentPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1117,6 +1282,11 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 25},
 				Filename: rootPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 27, End: 27},
+				Column:   models.Position{Start: 16, End: 40},
+				Filename: rootPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 20, End: 20},
 				Column:   models.Position{Start: 18, End: 23},
@@ -1138,6 +1308,11 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 16, End: 16},
 				Column:   models.Position{Start: 19, End: 28},
+				Filename: parentPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 15, End: 15},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: parentPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1163,6 +1338,11 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 32},
 				Filename: parentPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 19, End: 19},
+				Column:   models.Position{Start: 16, End: 25},
+				Filename: parentPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 21, End: 21},
 				Column:   models.Position{Start: 16, End: 22},
@@ -1184,6 +1364,11 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 25, End: 25},
 				Column:   models.Position{Start: 19, End: 28},
+				Filename: parentPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 24, End: 24},
+				Column:   models.Position{Start: 16, End: 24},
 				Filename: parentPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1209,6 +1394,11 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 29},
 				Filename: childPath,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 15, End: 15},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: childPath,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 6, End: 6},
 				Column:   models.Position{Start: 20, End: 42},
@@ -1230,6 +1420,11 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 35, End: 35},
 				Column:   models.Position{Start: 19, End: 22},
+				Filename: parentPath,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 34, End: 34},
+				Column:   models.Position{Start: 16, End: 23},
 				Filename: parentPath,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1374,6 +1569,11 @@ func TestParseMavenLock_WithScope(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 22},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 4, End: 4},
+				Column:   models.Position{Start: 16, End: 19},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 6, End: 6},
 				Column:   models.Position{Start: 16, End: 21},
@@ -1396,6 +1596,11 @@ func TestParseMavenLock_WithScope(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 11, End: 11},
 				Column:   models.Position{Start: 19, End: 24},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 10, End: 10},
+				Column:   models.Position{Start: 16, End: 21},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1440,6 +1645,11 @@ func TestParseMavenLock_WithUnusedDependencyManagementDependencies(t *testing.T)
 				Column:   models.Position{Start: 19, End: 28},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 18, End: 18},
+				Column:   models.Position{Start: 16, End: 24},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 20, End: 20},
 				Column:   models.Position{Start: 16, End: 28},
@@ -1480,6 +1690,11 @@ func TestParseMavenLock_WithOverriddenDependencyVersions(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 16, End: 16},
 				Column:   models.Position{Start: 19, End: 24},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 15, End: 15},
+				Column:   models.Position{Start: 16, End: 21},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1524,6 +1739,11 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 				Column:   models.Position{Start: 19, End: 22},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 9, End: 9},
+				Column:   models.Position{Start: 16, End: 23},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 5, End: 5},
 				Column:   models.Position{Start: 12, End: 24},
@@ -1547,6 +1767,11 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 15, End: 15},
 				Column:   models.Position{Start: 19, End: 22},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 14, End: 14},
+				Column:   models.Position{Start: 16, End: 23},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1587,6 +1812,11 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 				Column:   models.Position{Start: 21, End: 30},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 5, End: 5},
+				Column:   models.Position{Start: 18, End: 26},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 4, End: 4},
 				Column:   models.Position{Start: 20, End: 32},
@@ -1612,6 +1842,11 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 				Column:   models.Position{Start: 24, End: 30},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 7, End: 7},
+				Column:   models.Position{Start: 21, End: 45},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 3, End: 3},
 				Column:   models.Position{Start: 20, End: 42},
@@ -1635,6 +1870,11 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 38, End: 38},
 				Column:   models.Position{Start: 19, End: 35},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 9, End: 9},
+				Column:   models.Position{Start: 17, End: 24},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{
@@ -1693,6 +1933,11 @@ func TestParseMavenLock_SpringRemote(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 40},
 				Filename: path,
 			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 39, End: 39},
+				Column:   models.Position{Start: 13, End: 37},
+				Filename: path,
+			},
 			VersionLocation: &models.FilePosition{},
 			DepGroups:       []string{"test"},
 			IsDirect:        true,
@@ -1711,6 +1956,11 @@ func TestParseMavenLock_SpringRemote(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 35, End: 35},
 				Column:   models.Position{Start: 16, End: 39},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 34, End: 34},
+				Column:   models.Position{Start: 13, End: 37},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{},
@@ -1747,6 +1997,11 @@ func TestParseMavenLock_TwoExclusions(t *testing.T) {
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 9, End: 9},
 				Column:   models.Position{Start: 19, End: 33},
+				Filename: path,
+			},
+			NamespaceLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 16, End: 32},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{

--- a/pkg/extractor/types.go
+++ b/pkg/extractor/types.go
@@ -19,6 +19,7 @@ type PackageDetails struct {
 	LocationRole                 string                `json:"locationRole,omitempty"`
 	VersionLocation              *models.FilePosition  `json:"versionLocation,omitempty"`
 	NameLocation                 *models.FilePosition  `json:"nameLocation,omitempty"`
+	NamespaceLocation            *models.FilePosition  `json:"namespaceLocation,omitempty"`
 	PackageManager               models.PackageManager `json:"packageManager,omitempty"`
 	IsDirect                     bool                  `json:"isDirect,omitempty"`
 	RequiresTransitiveEnrichment bool                  `json:"requiresTransitiveEnrichment,omitempty"`

--- a/pkg/scanner/datadog_sbom_generator.go
+++ b/pkg/scanner/datadog_sbom_generator.go
@@ -320,6 +320,10 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 			if pkgs[index].VersionLocation != nil {
 				pkgs[index].VersionLocation.Filename = fileposition.ToRelativePath(dir, pkg.VersionLocation.Filename)
 			}
+
+			if pkgs[index].NamespaceLocation != nil {
+				pkgs[index].NamespaceLocation.Filename = fileposition.ToRelativePath(dir, pkg.NamespaceLocation.Filename)
+			}
 		}
 		for index, artifact := range artifacts {
 			artifacts[index].Filename = fileposition.ToRelativePath(dir, artifact.Filename)

--- a/pkg/scanner/vulnerability_result.go
+++ b/pkg/scanner/vulnerability_result.go
@@ -98,7 +98,7 @@ func groupBySource(r reporter.Reporter, packages []extractor.PackageDetails, art
 		pkg.Vulnerabilities = nil
 		if fileposition.IsFilePositionExtractedSuccessfully(p.BlockLocation) {
 			pkg.Locations = make([]models.PackageLocations, 1)
-			pkg.Locations[0] = location.NewPackageLocations(p.BlockLocation, p.NameLocation, p.VersionLocation, p.LocationRole)
+			pkg.Locations[0] = location.NewPackageLocations(p.BlockLocation, p.NameLocation, p.VersionLocation, p.NamespaceLocation, p.LocationRole)
 		} else {
 			pkg.Locations = make([]models.PackageLocations, 0)
 		}


### PR DESCRIPTION
## 🚀 Motivation 

The Maven extractor in datadog-sbom-generator was discarding the groupId file position returned by `ResolveGroupID()`. While the output model (`PackageLocations.Namespace`) already supports a namespace location field, no extractor populated it. This means downstream consumers (e.g., Code Intelligence, quality gates) could not pinpoint the exact `<groupId>` declaration in `pom.xml` files, limiting the precision of location-based features for Maven dependencies.

## Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | N/A


## 📝 Summary

**Core pipeline changes (3 layers):**
- **`pkg/extractor/types.go`** — Added `NamespaceLocation *models.FilePosition` field to `PackageDetails` struct, allowing any extractor to report a namespace file position.
- **`internal/utility/location/location.go`** — Extended `NewPackageLocations()` to accept a `namespace *models.FilePosition` parameter and populate `PackageLocations.Namespace` when provided.
- **`pkg/scanner/vulnerability_result.go`** — Updated the single call site of `NewPackageLocations` to pass `NamespaceLocation` through from `PackageDetails`.

**Maven extractor changes:**
- **`pkg/extractor/java/parse-maven-lock.go`** — Captured the groupId position from `ResolveGroupID()` (previously discarded with `_`), added fallback to `lockPackage.GroupID.FilePosition` when resolution returns empty, and stored it as `NamespaceLocation` in the `PackageDetails` struct.

**Reporter refactoring (cleanup alongside main change):**
- Replaced `reporter.Reporter` parameter threading with `log.Printf` across JavaScript (`match-package-json.go`, `types.go`), Python (`parse-pyproject-toml.go`, `pyproject_package_collector.go`), Ruby (`match-gemfile.go`, `match-gemspec.go`), scanner (`datadog_sbom_generator.go`, `vulnerability_result.go`), and reachability (`codefile/java.go`) packages.
- Removed `reporter.Effective()` helper function from `pkg/reporter/void_reporter.go`.

**Tests:**
- Added 50+ `NamespaceLocation` assertions across all Maven extractor test cases (single packages, multi-module parents, interpolation, scopes, exclusions, dependency management, etc.).
- Added `TestNewPackageLocations_RolePropagatedToNamespace` and `TestNewPackageLocations_NilNamespaceRemainsNil` to `location_test.go`.
- Updated integration test snapshots to include the new `namespace` field in location JSON output.
- Updated all affected test files for reporter removal.


## 🧪 Testing
- [X] New tests were added for new logic.
- [X] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.


## 🚧 Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.


## 🆘 Recovery
Notes for on-call - **select only one**:
- [X] The change can be rolled back.
- [ ] Do not roll back. Why?: