### PR TITLE
[NOJIRA]: Optimize `isLineContinuation` for `requirements.txt`

### DIFF
--- a/pkg/extractor/python/parse-requirements-txt.go
+++ b/pkg/extractor/python/parse-requirements-txt.go
@@ -237,9 +237,12 @@ func isNotRequirementLine(line string) bool {
 func isLineContinuation(line string) bool {
 	// checks that the line ends with an odd number of back slashes,
 	// meaning the last one isn't escaped
-	re := cachedregexp.MustCompile(`([^\\]|^)(\\{2})*\\$`)
+	trailingBackslashes := 0
+	for i := len(line) - 1; i >= 0 && line[i] == '\\'; i-- {
+		trailingBackslashes++
+	}
 
-	return re.MatchString(line)
+	return trailingBackslashes%2 == 1
 }
 
 // Please note the whl filename has been standardized here :


### PR DESCRIPTION
## What

`isLineContinuation` (in the `requirements.txt` parser) ran a **backtracking regexp** on **every line** of **every `requirements*.txt`** file:

```go
re := cachedregexp.MustCompile(`([^\\]|^)(\\{2})*\\$`)
return re.MatchString(line)
```

The check is just *"does the line end in an odd number of backslashes?"*. This PR replaces the regexp with a trailing-backslash count done iteratively without regexes.

```go
trailingBackslashes := 0
for i := len(line) - 1; i >= 0 && line[i] == '\\'; i-- {
    trailingBackslashes++
}
return trailingBackslashes%2 == 1
```

## Why

I CPU-profiled a full scan of the `dd-source` monorepo (large, Python-heavy). `pprof -peek` showed `regexp.(*Regexp).MatchString` was driven **100% by `python.isLineContinuation`**, and it accounted for **~3.9s cumulative — ~16% of total scan CPU**, almost entirely regexp backtracking.

**Before** — top self-time, `dd-source` scan (24.2s CPU total):
```
   flat  flat%        cum   cum%
 15.93s 65.77%     15.93s 65.77%  syscall.rawsyscalln
  1.93s  7.97%      2.01s  8.30%  path/filepath.matchChunk
  1.77s  7.31%      3.82s 15.77%  regexp.(*Regexp).tryBacktrack      <- isLineContinuation
  0.82s  3.39%      0.82s  3.39%  regexp/syntax.(*Inst).MatchRunePos <- isLineContinuation
  0.57s  2.35%      0.57s  2.35%  regexp.(*bitState).shouldVisit     <- isLineContinuation
  0.31s  1.28%      0.36s  1.49%  regexp.(*inputString).step         <- isLineContinuation
  0.16s  0.66%      0.17s  0.70%  regexp.(*bitState).push            <- isLineContinuation
```

**After** — same scan (19.1s CPU total): **every `regexp.*` frame is gone.**
```
   flat  flat%        cum   cum%
 14.94s 78.06%     14.94s 78.06%  syscall.rawsyscalln
  2.25s 11.76%      2.32s 12.12%  path/filepath.matchChunk
  0.44s  2.30%      0.44s  2.30%  path/filepath.scanChunk
  0.22s  1.15%      2.98s 15.57%  path/filepath.Match
  0.03s  0.16%      2.71s 14.16%  go-git/.../gitignore.(*pattern).simpleNameMatch
```

## Results

| Metric | Before | After | Δ |
|---|--:|--:|--:|
| `dd-source` scan — CPU samples | 24.2s | 19.1s | **−21%** |
| `dd-source` scan — wall time | 26.1s | 20.5s | −21% |

| What | graph |
|---|--:|
| `dd-source` scan cpu profile before |<img width="1010" height="1606" alt="pprof_before_top" src="https://github.com/user-attachments/assets/62d16c05-20ab-4507-9c5d-6d40b52be1ac" /> |
| `dd-source` scan cpu profile after |<img width="1162" height="1651" alt="pprof_after_top" src="https://github.com/user-attachments/assets/fd480d48-987e-42f3-b9f5-f321e5f31285" /> |

## Correctness

The trailing-backslash count is behavior-identical to `([^\\]|^)(\\{2})*\\$` across all inputs (empty string, leading backslash, and odd/even runs of trailing backslashes). The existing `pkg/extractor/python/fixtures/pip/line-continuation.txt` fixture test passes unchanged; `go vet` and the full `pkg/extractor/python` suite are green.

