### PR TITLE
fix: protect against unsupported resolution element for pnpm

### DIFF
--- a/pkg/extractor/fixtures/pnpm/node-runtime.v9.yaml
+++ b/pkg/extractor/fixtures/pnpm/node-runtime.v9.yaml
@@ -1,0 +1,42 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      acorn:
+        specifier: ^8.11.3
+        version: 8.11.3
+
+packages:
+
+  acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  # pnpm self-managed node runtime: nested `resolution` with a variants list.
+  node@runtime:24.15.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-3UvHfctfTJoslkNzm7WTUAzLCUE+xCyqD47w5e8RYJU=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+
+snapshots:
+
+  acorn@8.11.3: {}
+
+  node@runtime:24.15.0: {}

--- a/pkg/extractor/javascript/parse-pnpm-lock-v9_test.go
+++ b/pkg/extractor/javascript/parse-pnpm-lock-v9_test.go
@@ -24,6 +24,29 @@ func TestParsePnpmLock_v9_NoPackages(t *testing.T) {
 	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{})
 }
 
+// A pnpm self-managed node runtime entry has a nested `resolution` shape that
+// used to abort the whole decode; the real packages must still be extracted.
+func TestParsePnpmLock_v9_NodeRuntime(t *testing.T) {
+	t.Parallel()
+
+	packages, err := javascript.ParsePnpmLock("../fixtures/pnpm/node-runtime.v9.yaml")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
+		{
+			Name:           "acorn",
+			Version:        "8.11.3",
+			PackageManager: models.Pnpm,
+			TargetVersions: []string{"^8.11.3"},
+			Ecosystem:      models.EcosystemNPM,
+			IsDirect:       true,
+			DepGroups:      []string{"prod"},
+		},
+	})
+}
+
 func TestParsePnpmLock_v9_OnePackage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/extractor/javascript/parse-pnpm-v9-lock.go
+++ b/pkg/extractor/javascript/parse-pnpm-v9-lock.go
@@ -358,7 +358,12 @@ func (e PnpmLockExtractor) Extract(f extractor.DepFile, context extractor.ScanCo
 
 	err = yaml.NewDecoder(bytes.NewReader(content)).Decode(&parsedLockfile)
 
-	if err != nil && !errors.Is(err, io.EOF) {
+	// A yaml.TypeError is partial: the rest of the lockfile still decoded, so we
+	// warn about the skipped entries instead of silently dropping every package.
+	var typeErr *yaml.TypeError
+	if errors.As(err, &typeErr) {
+		context.Reporter.Warnf("could not fully decode %s, some entries were skipped: %s\n", f.Path(), typeErr.Error())
+	} else if err != nil && !errors.Is(err, io.EOF) {
 		return []extractor.PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 

--- a/pkg/extractor/javascript/types.go
+++ b/pkg/extractor/javascript/types.go
@@ -115,8 +115,10 @@ type PnpmLockDependency struct {
 }
 
 type PnpmPackage struct {
-	Resolution map[string]string `yaml:"resolution"`
-	Version    string            `yaml:"version"`
+	// map[string]any (not map[string]string): some entries use a nested shape,
+	// e.g. pnpm's self-managed node runtime `resolution: {type: variations, variants: [...]}`.
+	Resolution map[string]any `yaml:"resolution"`
+	Version    string         `yaml:"version"`
 }
 
 type (


### PR DESCRIPTION
## 🚀 Motivation
A pnpm v9 lockfile that pins pnpm's self-managed node runtime caused the entire scan to return zero packages, so SCA silently skipped every dependency in the repository.

```yaml
  node@runtime:24.15.0:
    resolution:
      type: variations
      variants:
        - resolution: // <- generated an error during parsing, causing full ignore of the lock file
            archive: tarball
            bin:
```

## 📝 Summary
- The pnpm v9 parser now tolerates the nested `resolution` shape used by pnpm's self-managed node runtime, so these lockfiles parse fully instead of failing.
- A partial YAML decode is now surfaced as a warning while keeping the packages that did parse, instead of discarding the whole lockfile without a trace.

## 🧪 Testing
- [x] New tests were added for new logic.
- [ ] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🚧 Staging validation
- [x] Proof that it works as expected, including profiling or UX screenshots.

**before**
```bash
datadog-sbom-generator scan --output='sbom.json' --pretty --verbosity verbose .
Scanning directory '.', resolved absolute path '/<path>/pnpm'
Scanned /<path>/pnpm/pnpm-lock.yaml file and found 0 packages
No package sources found. Use the 'parsers list' command to view supported lockfiles, or use --help for usage information
```

**after**
```bash
~datadog-sbom-generator/datadog-sbom-generator scan --output='sbom.json' --pretty --verbosity verbose .
Scanning directory '.', resolved absolute path '<path>/pnpm'
Scanned <path>/pnpm/pnpm-lock.yaml file and found 2406 packages
[reachability] Reachability analysis is disabled
```
