### PR TITLE
[SCI] Minor final improvements for Go/.NET artifact identity

### DIFF
--- a/pkg/extractor/dotnet/csproj-project-refs.go
+++ b/pkg/extractor/dotnet/csproj-project-refs.go
@@ -27,16 +27,40 @@ func (e NuGetCsprojExtractor) GetArtifact(f extractor.DepFile, ctx extractor.Sca
 		return &models.ScannedArtifact{ArtifactDetail: models.ArtifactDetail{Filename: f.Path()}}, err
 	}
 
+	var csProj NugetCsProj
+	if xmlErr := xml.Unmarshal(content, &csProj); xmlErr != nil {
+		return &models.ScannedArtifact{ArtifactDetail: models.ArtifactDetail{Filename: f.Path()}}, xmlErr
+	}
+
 	artifact := &models.ScannedArtifact{
 		ArtifactDetail: models.ArtifactDetail{
-			Filename:  f.Path(),
-			Ecosystem: models.EcosystemNuGet,
+			PackageName: extractCsprojPackageName(csProj, f.Path()),
+			Filename:    f.Path(),
+			Ecosystem:   models.EcosystemNuGet,
 		},
 	}
 
 	artifact.ProjectDeps = extractCsprojInternalDeps(content, f.Path())
 
 	return artifact, nil
+}
+
+// extractCsprojPackageName returns the project's package identity from a parsed
+// csproj. It checks <PackageId> first (the canonical NuGet package identity),
+// then falls back to <AssemblyName>, then to the csproj filename stem
+// (e.g. "App" for "App.csproj").
+func extractCsprojPackageName(csProj NugetCsProj, csprojPath string) string {
+	for _, name := range []string{"PackageId", "AssemblyName"} {
+		for _, pg := range csProj.PropertyGroups {
+			for _, prop := range pg.Properties {
+				if prop.XMLName.Local == name && prop.Value != "" {
+					return prop.Value
+				}
+			}
+		}
+	}
+
+	return strings.TrimSuffix(filepath.Base(csprojPath), ".csproj")
 }
 
 // extractCsprojInternalDeps parses csproj XML content and returns ArtifactDetail
@@ -113,10 +137,16 @@ func (e NuGetLockExtractor) GetArtifact(f extractor.DepFile, _ extractor.ScanCon
 			continue
 		}
 
+		var csProj NugetCsProj
+		if xmlErr := xml.Unmarshal(content, &csProj); xmlErr != nil {
+			continue
+		}
+
 		return &models.ScannedArtifact{
 			ArtifactDetail: models.ArtifactDetail{
-				Filename:  csprojPath,
-				Ecosystem: models.EcosystemNuGet,
+				PackageName: extractCsprojPackageName(csProj, csprojPath),
+				Filename:    csprojPath,
+				Ecosystem:   models.EcosystemNuGet,
 			},
 			ProjectDeps: extractCsprojInternalDeps(content, csprojPath),
 		}, nil

--- a/pkg/extractor/dotnet/csproj-project-refs_test.go
+++ b/pkg/extractor/dotnet/csproj-project-refs_test.go
@@ -223,6 +223,126 @@ func TestNuGetCsprojExtractor_IsManifestParser(t *testing.T) {
 }
 
 // ============================================================================
+// GetArtifact PackageName Tests (PackageId / AssemblyName extraction)
+// ============================================================================
+
+func TestNuGetCsprojExtractor_GetArtifact_PackageNameFromPackageId(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "src", "App")
+	require.NoError(t, os.MkdirAll(appDir, 0700))
+
+	// PackageId should win over AssemblyName when both are present.
+	appCsproj := filepath.Join(appDir, "App.csproj")
+	require.NoError(t, os.WriteFile(appCsproj, []byte(`<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>My.NuGet.Package</PackageId>
+    <AssemblyName>MyService</AssemblyName>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>`), 0600))
+
+	f, err := extractor.OpenLocalDepFile(appCsproj)
+	require.NoError(t, err)
+	defer f.Close()
+
+	ext := NuGetCsprojExtractor{}
+	artifact, err := ext.GetArtifact(f, extractor.ScanContext{RootDir: root})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	assert.Equal(t, "My.NuGet.Package", artifact.PackageName, "PackageId takes priority over AssemblyName")
+	assert.Empty(t, artifact.Name, "Name must not be set — only PackageName")
+}
+
+func TestNuGetCsprojExtractor_GetArtifact_PackageNameFromAssemblyName(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "src", "App")
+	require.NoError(t, os.MkdirAll(appDir, 0700))
+
+	appCsproj := filepath.Join(appDir, "App.csproj")
+	require.NoError(t, os.WriteFile(appCsproj, []byte(`<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>MyService</AssemblyName>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>`), 0600))
+
+	f, err := extractor.OpenLocalDepFile(appCsproj)
+	require.NoError(t, err)
+	defer f.Close()
+
+	ext := NuGetCsprojExtractor{}
+	artifact, err := ext.GetArtifact(f, extractor.ScanContext{RootDir: root})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	assert.Equal(t, "MyService", artifact.PackageName)
+	assert.Empty(t, artifact.Name, "Name must not be set — only PackageName")
+}
+
+func TestNuGetCsprojExtractor_GetArtifact_PackageNameFallsToCsprojStem(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "src", "App")
+	require.NoError(t, os.MkdirAll(appDir, 0700))
+
+	appCsproj := filepath.Join(appDir, "App.csproj")
+	require.NoError(t, os.WriteFile(appCsproj, []byte(`<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>`), 0600))
+
+	f, err := extractor.OpenLocalDepFile(appCsproj)
+	require.NoError(t, err)
+	defer f.Close()
+
+	ext := NuGetCsprojExtractor{}
+	artifact, err := ext.GetArtifact(f, extractor.ScanContext{RootDir: root})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	assert.Equal(t, "App", artifact.PackageName)
+	assert.Empty(t, artifact.Name, "Name must not be set — only PackageName")
+}
+
+func TestNuGetLockExtractor_GetArtifact_PackageNameFromAssemblyName(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "src", "App")
+	require.NoError(t, os.MkdirAll(appDir, 0700))
+
+	// Create a csproj with AssemblyName
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "App.csproj"), []byte(`<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>MyService</AssemblyName>
+  </PropertyGroup>
+</Project>`), 0600))
+
+	// Create a packages.lock.json (minimal valid content)
+	lockPath := filepath.Join(appDir, "packages.lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte(`{"version": 1, "dependencies": {}}`), 0600))
+
+	f, err := extractor.OpenLocalDepFile(lockPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	ext := NuGetLockExtractor{}
+	artifact, err := ext.GetArtifact(f, extractor.ScanContext{RootDir: root})
+
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+	assert.Equal(t, "MyService", artifact.PackageName)
+	assert.Empty(t, artifact.Name, "Name must not be set — only PackageName")
+}
+
+// ============================================================================
 // Integration Test: Transitive Closure
 // ============================================================================
 

--- a/pkg/extractor/golang/go-mod-artifact_test.go
+++ b/pkg/extractor/golang/go-mod-artifact_test.go
@@ -34,7 +34,8 @@ go 1.21
 	require.NoError(t, err)
 	require.NotNil(t, artifact)
 
-	assert.Equal(t, "github.com/mycompany/svcA", artifact.Name)
+	assert.Equal(t, "github.com/mycompany/svcA", artifact.PackageName)
+	assert.Empty(t, artifact.Name)
 	assert.Equal(t, goModPath, artifact.Filename)
 	assert.Equal(t, models.EcosystemGo, artifact.Ecosystem)
 	assert.Empty(t, artifact.ProjectDeps)

--- a/pkg/extractor/golang/parse-go-lock.go
+++ b/pkg/extractor/golang/parse-go-lock.go
@@ -228,9 +228,9 @@ func (e GoLockExtractor) GetArtifact(f extractor.DepFile, ctx extractor.ScanCont
 
 	artifact := &models.ScannedArtifact{
 		ArtifactDetail: models.ArtifactDetail{
-			Name:      moduleName,
-			Filename:  f.Path(),
-			Ecosystem: models.EcosystemGo,
+			PackageName: moduleName,
+			Filename:    f.Path(),
+			Ecosystem:   models.EcosystemGo,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- **Go**: Change `GetArtifact()` to set `PackageName` instead of `Name` for the module path. This prevents `findArtifact()` from creating spurious cross-matching edges in Go monorepos where `replace` directives already establish correct `ProjectDeps` edges.
- **.NET**: Extract `<AssemblyName>` from csproj XML (falling back to csproj filename stem) and set it as `PackageName` on both `NuGetCsprojExtractor` and `NuGetLockExtractor` artifacts. This gives .NET build files a package identity in the SBOM without enabling incorrect `findArtifact` cross-matching.

## Context

`ArtifactDetail.Name` triggers `findArtifact()` cross-matching (lockfile entry -> build file edge), which is correct for Maven/Gradle/npm but incorrect for Go and .NET. `PackageName` provides identity via the `datadog:maven-package` purl property without cross-matching side effects.

## Test plan

- [x] Go: Updated existing test to assert `PackageName` is set and `Name` is empty
- [x] .NET: Added 3 new tests (TDD red-green):
  - `NuGetCsprojExtractor` with `<AssemblyName>` -> `PackageName == "MyService"`
  - `NuGetCsprojExtractor` without `AssemblyName` -> `PackageName == filename stem`
  - `NuGetLockExtractor` with adjacent csproj containing `AssemblyName` -> `PackageName == "MyService"`
- [x] Full test suite passes (`./scripts/run_tests.sh`)
- [x] Lints pass (`./scripts/run_lints.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)