### PR TITLE
Fix prettier formatting on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## What problem are you trying to solve?
 
 - TODO
-- [JIRA-TICKET]()
+- [JIRA-TICKET](<>)
 
 ## What is your solution?
 


### PR DESCRIPTION
## Summary
- Prettier reformats the empty markdown link `[JIRA-TICKET]()` to `[JIRA-TICKET](<>)`; `main` currently has the unformatted version, tripping the prettier CI check.

## Test plan
- [x] `npx prettier --check .github/PULL_REQUEST_TEMPLATE.md` passes locally.