### PR TITLE
Reapply "feat(lockfile): add BlockLocation + LocationRole=lockfile to npm-lock" (#141)

### DIFF
--- a/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
+++ b/cmd/datadog-sbom-generator/__snapshots__/main_test.snap
@@ -212,10 +212,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
             "location": "{/"block/":{/"file_name/":/"ignored/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":5,/"column_end/":31,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":24,/"column_end/":30,/"role/":/"manifest/"}}"
           },
           {
-            "location": "{/"block/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":5,/"column_end/":31,/"role/":/"manifest/"},/"name/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"package.json/",/"line_start/":4,/"line_end/":4,/"column_start/":24,/"column_end/":30,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"subdir/yarn.lock/",/"line_start/":4,/"line_end/":7,/"column_start/":1,/"column_end/":108,/"role/":/"lockfile/"}}"
           }
         ]
       }
@@ -1888,7 +1888,14 @@ Scanned <rootdir>/fixtures/integration-nuget/multiple-versions-with-lockfile/pac
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -2063,6 +2070,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":37,/"line_end/":50,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":48,/"line_end/":50,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
           },
           {
@@ -2085,6 +2095,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":57,/"line_end/":65,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":52,/"line_end/":54,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
           },
@@ -2109,6 +2122,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":75,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":56,/"line_end/":57,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
@@ -2131,6 +2147,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":76,/"line_end/":84,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":59,/"line_end/":61,/"column_start/":3,/"column_end/":31,/"role/":/"lockfile/"}}"
           },
@@ -2155,6 +2174,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":85,/"line_end/":94,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":63,/"line_end/":64,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
@@ -2177,6 +2199,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":95,/"line_end/":100,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":66,/"line_end/":67,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
@@ -2201,6 +2226,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":101,/"line_end/":110,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":69,/"line_end/":70,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
@@ -2223,6 +2251,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":111,/"line_end/":119,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":72,/"line_end/":73,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
@@ -2247,6 +2278,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":120,/"line_end/":131,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":75,/"line_end/":78,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
           },
           {
@@ -2269,6 +2303,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":132,/"line_end/":137,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":80,/"line_end/":81,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
@@ -2297,6 +2334,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":138,/"line_end/":147,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":83,/"line_end/":85,/"column_start/":3,/"column_end/":32,/"role/":/"lockfile/"}}"
           },
           {
@@ -2320,6 +2360,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":148,/"line_end/":153,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":87,/"line_end/":88,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
@@ -2342,6 +2385,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":168,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":90,/"line_end/":93,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
@@ -2391,6 +2437,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":182,/"line_end/":190,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":99,/"line_end/":101,/"column_start/":3,/"column_end/":27,/"role/":/"lockfile/"}}"
           },
           {
@@ -2413,6 +2462,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":191,/"line_end/":204,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":103,/"line_end/":105,/"column_start/":3,/"column_end/":34,/"role/":/"lockfile/"}}"
           },
@@ -2437,6 +2489,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":205,/"line_end/":210,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":107,/"line_end/":108,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
@@ -2459,6 +2514,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":211,/"line_end/":216,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":110,/"line_end/":111,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
@@ -2511,10 +2569,13 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":51,/"line_end/":56,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
           },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":116,/"line_end/":117,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
+          },
+          {
+            "location": "{/"block/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":5,/"column_end/":27,/"role/":/"manifest/"},/"name/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":6,/"column_end/":16,/"role/":/"manifest/"},/"version/":{/"file_name/":/"workspace-3/package.json/",/"line_start/":5,/"line_end/":5,/"column_start/":20,/"column_end/":26,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -2533,6 +2594,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":231,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":119,/"line_end/":120,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
@@ -2581,6 +2645,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":232,/"line_end/":247,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":128,/"line_end/":131,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
           }
         ]
@@ -2600,6 +2667,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":264,/"line_end/":283,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":133,/"line_end/":134,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
@@ -2720,6 +2790,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":293,/"line_end/":301,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":153,/"line_end/":154,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
           {
@@ -2742,6 +2815,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":311,/"line_end/":320,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":156,/"line_end/":157,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
@@ -2766,6 +2842,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":310,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":159,/"line_end/":161,/"column_start/":3,/"column_end/":32,/"role/":/"lockfile/"}}"
           },
           {
@@ -2788,6 +2867,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":321,/"line_end/":332,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":163,/"line_end/":165,/"column_start/":3,/"column_end/":27,/"role/":/"lockfile/"}}"
           },
@@ -2812,6 +2894,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       "evidence": {
         "occurrences": [
           {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":333,/"line_end/":350,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
+          {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":167,/"line_end/":170,/"column_start/":3,/"column_end/":17,/"role/":/"lockfile/"}}"
           },
           {
@@ -2834,6 +2919,9 @@ Skipping <rootdir>/fixtures/locks-many/yarn.lock with exclusion rule: *yarn.lock
       ],
       "evidence": {
         "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":356,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          },
           {
             "location": "{/"block/":{/"file_name/":/"pnpm-lock.yaml/",/"line_start/":172,/"line_end/":173,/"column_start/":3,/"column_end/":125,/"role/":/"lockfile/"}}"
           },
@@ -4405,7 +4493,14 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":5,/"line_end/":7,/"column_start/":5,/"column_end/":6,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -4654,7 +4749,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":7,/"line_end/":14,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -4667,7 +4769,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":15,/"line_end/":19,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -4680,7 +4789,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":20,/"line_end/":28,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -4693,7 +4809,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":29,/"line_end/":33,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -4706,7 +4829,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":34,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -4719,7 +4849,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":47,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -4732,7 +4869,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":48,/"line_end/":52,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -4745,7 +4889,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":53,/"line_end/":79,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -4758,7 +4909,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":80,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -4771,7 +4929,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":109,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -4784,7 +4949,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":110,/"line_end/":114,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -4797,7 +4969,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":115,/"line_end/":138,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -4810,7 +4989,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":139,/"line_end/":153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -4823,7 +5009,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":154,/"line_end/":162,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -4836,7 +5029,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":163,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -4849,7 +5049,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -4866,7 +5073,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@4.4.0",
@@ -4879,7 +5093,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":70,/"line_end/":77,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -4892,7 +5113,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -4905,7 +5133,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":201,/"line_end/":209,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -4918,7 +5153,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":210,/"line_end/":214,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -4931,7 +5173,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":215,/"line_end/":229,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -4944,7 +5193,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":230,/"line_end/":234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -4957,7 +5213,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":223,/"line_end/":227,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -4970,7 +5233,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":235,/"line_end/":246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -4983,7 +5253,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":247,/"line_end/":254,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -4996,7 +5273,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":255,/"line_end/":262,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -5009,7 +5293,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":263,/"line_end/":270,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -5022,7 +5313,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":283,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -5035,7 +5333,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":284,/"line_end/":288,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -5048,7 +5353,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":289,/"line_end/":293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -5061,7 +5373,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":294,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -5074,7 +5393,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":299,/"line_end/":306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -5087,7 +5413,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":307,/"line_end/":311,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -5100,7 +5433,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":312,/"line_end/":316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -5113,7 +5453,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":317,/"line_end/":325,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -5130,7 +5477,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":185,/"line_end/":190,/"column_start/":17,/"column_end/":18,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -5143,7 +5497,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":326,/"line_end/":330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -5156,7 +5517,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":331,/"line_end/":335,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -5169,7 +5537,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":336,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -5182,7 +5557,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":345,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -5195,7 +5577,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":346,/"line_end/":350,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -5208,7 +5597,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":351,/"line_end/":355,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -5221,7 +5617,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":356,/"line_end/":363,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -5234,7 +5637,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":364,/"line_end/":368,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -5247,7 +5657,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":369,/"line_end/":373,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -5260,7 +5677,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":374,/"line_end/":381,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -5273,7 +5697,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":382,/"line_end/":386,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -5286,7 +5717,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":387,/"line_end/":394,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -5327,7 +5765,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -5340,7 +5785,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -5353,7 +5805,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -5366,7 +5825,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -5379,7 +5845,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -5392,7 +5865,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -5405,7 +5885,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -5418,7 +5905,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -5431,7 +5925,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -5444,7 +5945,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -5457,7 +5965,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -5470,7 +5985,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -5507,7 +6029,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -5520,7 +6049,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -5533,7 +6069,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -5546,7 +6089,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -5559,7 +6109,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -5572,7 +6129,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -5585,7 +6149,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -5598,7 +6169,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -5611,7 +6189,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -5624,7 +6209,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -5637,7 +6229,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -5650,7 +6249,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -5663,7 +6269,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -5676,7 +6289,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -5689,7 +6309,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -5702,7 +6329,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -5715,7 +6349,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -5728,7 +6369,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -5741,7 +6389,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -5754,7 +6409,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -5767,7 +6429,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -5780,7 +6449,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -5793,7 +6469,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -5806,7 +6489,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -5847,7 +6537,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -5860,7 +6557,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -5873,7 +6577,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -5886,7 +6597,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -5899,7 +6617,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -5912,7 +6637,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -5925,7 +6657,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -5938,7 +6677,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -5951,7 +6697,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -5964,7 +6717,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -5977,7 +6737,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -5990,7 +6757,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -6003,7 +6777,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -6016,7 +6797,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -6029,7 +6817,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -6042,7 +6837,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -6055,7 +6857,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -6068,7 +6877,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -6081,7 +6897,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -6094,7 +6917,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -6107,7 +6937,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -6120,7 +6957,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -6133,7 +6977,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -6146,7 +6997,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -6159,7 +7017,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -6172,7 +7037,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -6185,7 +7057,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -6198,7 +7077,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -6211,7 +7097,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -6224,7 +7117,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -6237,7 +7137,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -6250,7 +7157,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -6263,7 +7177,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -6276,7 +7197,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -6289,7 +7217,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -6302,7 +7237,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -6315,7 +7257,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -6328,7 +7277,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -6341,7 +7297,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -6354,7 +7317,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -6367,7 +7337,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -6380,7 +7357,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -6393,7 +7377,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -6406,7 +7397,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -6419,7 +7417,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -6432,7 +7437,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -6445,7 +7457,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -6458,7 +7477,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -6471,7 +7497,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -6484,7 +7517,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -6497,7 +7537,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -6510,7 +7557,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -6523,7 +7577,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -6536,7 +7597,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -6553,7 +7621,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -6566,7 +7641,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -6579,7 +7661,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -6592,7 +7681,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -6605,7 +7701,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -6618,7 +7721,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -6631,7 +7741,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -6644,7 +7761,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -6657,7 +7781,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -6670,7 +7801,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -6683,7 +7821,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -6696,7 +7841,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -6709,7 +7861,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -6722,7 +7881,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -6735,7 +7901,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -6748,7 +7921,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -6761,7 +7941,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -6774,7 +7961,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -6787,7 +7981,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -6800,7 +8001,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -6813,7 +8021,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -6826,7 +8041,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -6839,7 +8061,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -6852,7 +8081,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -6865,7 +8101,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -6878,7 +8121,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -6891,7 +8141,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -6904,7 +8161,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -6917,7 +8181,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -6930,7 +8201,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -6943,7 +8221,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -6956,7 +8241,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -6969,7 +8261,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -6982,7 +8281,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -6995,7 +8301,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -7008,7 +8321,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -7021,7 +8341,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -7034,7 +8361,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -7047,7 +8381,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -7060,7 +8401,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -7101,7 +8449,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -7114,7 +8469,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -7127,7 +8489,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -7140,7 +8509,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -7153,7 +8529,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -7166,7 +8549,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -7179,7 +8569,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -7192,7 +8589,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -7205,7 +8609,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -7218,7 +8629,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -7231,7 +8649,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -7244,7 +8669,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -7281,7 +8713,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -7294,7 +8733,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -7307,7 +8753,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -7320,7 +8773,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -7333,7 +8793,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -7346,7 +8813,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -7359,7 +8833,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -7372,7 +8853,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -7385,7 +8873,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -7398,7 +8893,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -7411,7 +8913,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -7424,7 +8933,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -7437,7 +8953,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -7450,7 +8973,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -7463,7 +8993,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -7476,7 +9013,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -7489,7 +9033,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -7502,7 +9053,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -7515,7 +9073,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -7528,7 +9093,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -7541,7 +9113,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -7554,7 +9133,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -7567,7 +9153,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -7580,7 +9173,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -7621,7 +9221,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -7634,7 +9241,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -7647,7 +9261,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -7660,7 +9281,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -7673,7 +9301,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -7686,7 +9321,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -7699,7 +9341,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -7712,7 +9361,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -7725,7 +9381,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -7738,7 +9401,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -7751,7 +9421,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -7764,7 +9441,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -7777,7 +9461,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -7790,7 +9481,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -7803,7 +9501,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -7816,7 +9521,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -7829,7 +9541,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -7842,7 +9561,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -7855,7 +9581,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -7868,7 +9601,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -7881,7 +9621,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -7894,7 +9641,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -7907,7 +9661,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -7920,7 +9681,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -7933,7 +9701,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -7946,7 +9721,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -7959,7 +9741,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -7972,7 +9761,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -7985,7 +9781,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -7998,7 +9801,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -8011,7 +9821,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -8024,7 +9841,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -8037,7 +9861,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -8050,7 +9881,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -8063,7 +9901,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -8076,7 +9921,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -8089,7 +9941,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -8102,7 +9961,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -8115,7 +9981,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -8128,7 +10001,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -8141,7 +10021,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -8154,7 +10041,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -8167,7 +10061,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -8180,7 +10081,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -8193,7 +10101,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -8206,7 +10121,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -8219,7 +10141,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -8232,7 +10161,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -8245,7 +10181,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -8258,7 +10201,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -8271,7 +10221,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -8284,7 +10241,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -8297,7 +10261,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -8310,7 +10281,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -8327,7 +10305,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -8340,7 +10325,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -8353,7 +10345,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -8366,7 +10365,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -8379,7 +10385,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -8392,7 +10405,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -8405,7 +10425,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -8418,7 +10445,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -8431,7 +10465,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -8444,7 +10485,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -8457,7 +10505,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -8470,7 +10525,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -8483,7 +10545,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -8496,7 +10565,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -8509,7 +10585,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -8522,7 +10605,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -8535,7 +10625,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -8548,7 +10645,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -8561,7 +10665,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -8574,7 +10685,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -8587,7 +10705,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -8600,7 +10725,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -8613,7 +10745,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -8626,7 +10765,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -8639,7 +10785,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -8652,7 +10805,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -8665,7 +10825,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -8678,7 +10845,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -8691,7 +10865,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -8704,7 +10885,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -8717,7 +10905,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -8730,7 +10925,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -8743,7 +10945,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -8756,7 +10965,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -8769,7 +10985,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -8782,7 +11005,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -8795,7 +11025,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -8808,7 +11045,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -8821,7 +11065,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -8834,7 +11085,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -8875,7 +11133,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":43,/"line_end/":65,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -8888,7 +11153,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":89,/"line_end/":97,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -8901,7 +11173,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":34,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -8914,7 +11193,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":35,/"line_end/":42,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -8927,7 +11213,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":98,/"line_end/":112,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -8940,7 +11233,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":136,/"line_end/":148,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -8953,7 +11253,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":149,/"line_end/":155,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -8966,7 +11273,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":156,/"line_end/":167,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -8979,7 +11293,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":168,/"line_end/":175,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -8992,7 +11313,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":176,/"line_end/":187,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -9005,7 +11333,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":188,/"line_end/":192,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -9018,7 +11353,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":193,/"line_end/":197,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -9055,7 +11397,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":252,/"line_end/":278,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -9068,7 +11417,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":302,/"line_end/":317,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -9081,7 +11437,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":318,/"line_end/":343,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -9094,7 +11457,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":365,/"line_end/":376,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -9107,7 +11477,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":377,/"line_end/":402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -9120,7 +11497,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":424,/"line_end/":448,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -9133,7 +11517,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":449,/"line_end/":464,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -9146,7 +11537,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":465,/"line_end/":470,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -9159,7 +11557,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":483,/"line_end/":491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -9172,7 +11577,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":471,/"line_end/":482,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -9185,7 +11597,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":492,/"line_end/":507,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -9198,7 +11617,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":508,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -9211,7 +11637,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":531,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -9224,7 +11657,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":532,/"line_end/":537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -9237,7 +11677,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":538,/"line_end/":545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -9250,7 +11697,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":546,/"line_end/":551,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -9263,7 +11717,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":552,/"line_end/":561,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -9276,7 +11737,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":562,/"line_end/":572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -9289,7 +11757,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":573,/"line_end/":581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -9302,7 +11777,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":582,/"line_end/":597,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -9315,7 +11797,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":598,/"line_end/":609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -9328,7 +11817,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":610,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -9341,7 +11837,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":621,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -9354,7 +11857,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":622,/"line_end/":635,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -9395,7 +11905,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":66,/"line_end/":82,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -9408,7 +11925,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":645,/"line_end/":650,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -9421,7 +11945,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":651,/"line_end/":661,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -9434,7 +11965,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":662,/"line_end/":673,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -9447,7 +11985,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":674,/"line_end/":685,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -9460,7 +12005,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":742,/"line_end/":753,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -9473,7 +12025,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":782,/"line_end/":797,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -9486,7 +12045,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":754,/"line_end/":764,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -9499,7 +12065,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":686,/"line_end/":741,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -9512,7 +12085,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":813,/"line_end/":829,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -9525,7 +12105,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":830,/"line_end/":841,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -9538,7 +12125,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":851,/"line_end/":861,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -9551,7 +12145,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":870,/"line_end/":877,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -9564,7 +12165,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":798,/"line_end/":806,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -9577,7 +12185,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":878,/"line_end/":886,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -9590,7 +12205,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":887,/"line_end/":892,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -9603,7 +12225,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":893,/"line_end/":907,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -9616,7 +12245,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":919,/"line_end/":924,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -9629,7 +12265,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":925,/"line_end/":930,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -9642,7 +12285,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":931,/"line_end/":938,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -9655,7 +12305,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":939,/"line_end/":950,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -9668,7 +12325,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":951,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -9681,7 +12345,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -9694,7 +12365,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":991,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -9707,7 +12385,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":992,/"line_end/":997,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -9720,7 +12405,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":998,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -9733,7 +12425,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":908,/"line_end/":918,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -9746,7 +12445,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1025,/"line_end/":1036,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -9759,7 +12465,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1024,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -9772,7 +12485,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1037,/"line_end/":1051,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -9785,7 +12505,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1052,/"line_end/":1070,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -9798,7 +12525,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1071,/"line_end/":1075,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -9811,7 +12545,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1076,/"line_end/":1084,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -9824,7 +12565,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1085,/"line_end/":1092,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -9837,7 +12585,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1093,/"line_end/":1108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -9850,7 +12605,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1109,/"line_end/":1117,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -9863,7 +12625,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1118,/"line_end/":1128,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -9876,7 +12645,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1129,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -9889,7 +12665,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1142,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -9902,7 +12685,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1143,/"line_end/":1153,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -9915,7 +12705,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1154,/"line_end/":1161,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -9928,7 +12725,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1162,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -9941,7 +12745,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1176,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -9954,7 +12765,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1177,/"line_end/":1188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -9967,7 +12785,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1189,/"line_end/":1194,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -9980,7 +12805,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1195,/"line_end/":1200,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -9993,7 +12825,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1201,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -10006,7 +12845,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1215,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -10019,7 +12865,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1216,/"line_end/":1228,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -10032,7 +12885,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1229,/"line_end/":1243,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -10045,7 +12905,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1244,/"line_end/":1249,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -10058,7 +12925,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1250,/"line_end/":1257,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -10071,7 +12945,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1258,/"line_end/":1269,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -10084,7 +12965,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1270,/"line_end/":1281,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -10101,7 +12989,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1282,/"line_end/":1287,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -10114,7 +13009,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":83,/"line_end/":88,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -10127,7 +13029,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1294,/"line_end/":1298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -10140,7 +13049,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1288,/"line_end/":1293,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -10153,7 +13069,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1299,/"line_end/":1307,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -10166,7 +13089,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1308,/"line_end/":1324,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -10179,7 +13109,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1325,/"line_end/":1339,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -10192,7 +13129,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1340,/"line_end/":1354,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -10205,7 +13149,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1355,/"line_end/":1366,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -10218,7 +13169,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1367,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -10231,7 +13189,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1384,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -10244,7 +13209,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1385,/"line_end/":1393,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -10257,7 +13229,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1394,/"line_end/":1401,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -10270,7 +13249,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1402,/"line_end/":1412,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -10283,7 +13269,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1413,/"line_end/":1421,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -10296,7 +13289,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1422,/"line_end/":1430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -10309,7 +13309,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1431,/"line_end/":1449,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -10322,7 +13329,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1450,/"line_end/":1458,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -10335,7 +13349,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1459,/"line_end/":1467,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -10348,7 +13369,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1468,/"line_end/":1483,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -10361,7 +13389,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1484,/"line_end/":1505,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -10374,7 +13409,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1506,/"line_end/":1516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -10387,7 +13429,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1517,/"line_end/":1528,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -10400,7 +13449,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1529,/"line_end/":1537,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -10413,7 +13469,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1538,/"line_end/":1545,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -10426,7 +13489,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1546,/"line_end/":1557,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -10439,7 +13509,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1558,/"line_end/":1569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -10452,7 +13529,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1570,/"line_end/":1581,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -10465,7 +13549,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1582,/"line_end/":1587,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -10478,7 +13569,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1588,/"line_end/":1598,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -10491,7 +13589,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1599,/"line_end/":1603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -10504,7 +13609,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1604,/"line_end/":1617,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -10517,7 +13629,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1618,/"line_end/":1629,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -10530,7 +13649,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1630,/"line_end/":1641,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -10543,7 +13669,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1642,/"line_end/":1654,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -10556,7 +13689,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1655,/"line_end/":1663,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -10569,7 +13709,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1664,/"line_end/":1678,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -10582,7 +13729,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1679,/"line_end/":1687,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -10595,7 +13749,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1688,/"line_end/":1693,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -10608,7 +13769,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1694,/"line_end/":1705,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -10649,7 +13817,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":45,/"line_end/":68,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint%2Fjs@8.57.1",
@@ -10662,7 +13837,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":94,/"line_end/":103,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Feslint-utils@4.4.1",
@@ -10675,7 +13857,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":18,/"line_end/":35,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40eslint-community%2Fregexpp@4.12.1",
@@ -10688,7 +13877,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":36,/"line_end/":44,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fconfig-array@0.13.0",
@@ -10701,7 +13897,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":104,/"line_end/":119,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fmodule-importer@1.0.1",
@@ -10714,7 +13917,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":145,/"line_end/":158,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40humanwhocodes%2Fobject-schema@2.0.3",
@@ -10727,7 +13937,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":159,/"line_end/":166,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.scandir@2.1.5",
@@ -10740,7 +13957,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":167,/"line_end/":179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.stat@2.0.5",
@@ -10753,7 +13977,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":180,/"line_end/":188,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40nodelib%2Ffs.walk@1.2.8",
@@ -10766,7 +13997,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":189,/"line_end/":201,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fjson-schema@7.0.15",
@@ -10779,7 +14017,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":202,/"line_end/":207,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40types%2Fsemver@7.5.8",
@@ -10792,7 +14037,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":208,/"line_end/":213,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Feslint-plugin@5.62.0",
@@ -10829,7 +14081,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":271,/"line_end/":298,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fscope-manager@5.62.0",
@@ -10842,7 +14101,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":324,/"line_end/":340,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftype-utils@5.62.0",
@@ -10855,7 +14121,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":341,/"line_end/":367,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypes@5.62.0",
@@ -10868,7 +14141,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":391,/"line_end/":403,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Ftypescript-estree@5.62.0",
@@ -10881,7 +14161,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":404,/"line_end/":430,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Futils@5.62.0",
@@ -10894,7 +14181,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":454,/"line_end/":479,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40typescript-eslint%2Fvisitor-keys@5.62.0",
@@ -10907,7 +14201,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":480,/"line_end/":496,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/%40ungap%2Fstructured-clone@1.2.1",
@@ -10920,7 +14221,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":497,/"line_end/":503,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn-jsx@5.3.2",
@@ -10933,7 +14241,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":517,/"line_end/":526,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/acorn@8.14.0",
@@ -10946,7 +14261,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":504,/"line_end/":516,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ajv@6.12.6",
@@ -10959,7 +14281,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":527,/"line_end/":543,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-regex@5.0.1",
@@ -10972,7 +14301,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":544,/"line_end/":553,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ansi-styles@4.3.0",
@@ -10985,7 +14321,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":554,/"line_end/":569,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/argparse@2.0.1",
@@ -10998,7 +14341,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":570,/"line_end/":576,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/array-union@2.1.0",
@@ -11011,7 +14361,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":577,/"line_end/":585,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/balanced-match@1.0.2",
@@ -11024,7 +14381,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":586,/"line_end/":592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -11037,7 +14401,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":593,/"line_end/":603,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/braces@3.0.3",
@@ -11050,7 +14421,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":604,/"line_end/":615,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/callsites@3.1.0",
@@ -11063,7 +14441,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":616,/"line_end/":625,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/chalk@4.1.2",
@@ -11076,7 +14461,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":626,/"line_end/":642,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-convert@2.0.1",
@@ -11089,7 +14481,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":643,/"line_end/":655,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/color-name@1.1.4",
@@ -11102,7 +14501,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":656,/"line_end/":662,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/concat-map@0.0.1",
@@ -11115,7 +14521,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":663,/"line_end/":669,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/cross-spawn@7.0.6",
@@ -11128,7 +14541,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":670,/"line_end/":684,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/debug@2.5.2",
@@ -11169,7 +14589,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":69,/"line_end/":86,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/deep-is@0.1.4",
@@ -11182,7 +14609,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":695,/"line_end/":701,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/dir-glob@3.0.1",
@@ -11195,7 +14629,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":702,/"line_end/":713,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/doctrine@3.0.0",
@@ -11208,7 +14649,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":714,/"line_end/":726,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/escape-string-regexp@4.0.0",
@@ -11221,7 +14669,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":727,/"line_end/":739,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@5.1.1",
@@ -11234,7 +14689,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":797,/"line_end/":809,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-scope@7.2.2",
@@ -11247,7 +14709,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":840,/"line_end/":856,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint-visitor-keys@3.4.3",
@@ -11260,7 +14729,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":810,/"line_end/":821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/eslint@8.57.1",
@@ -11273,7 +14749,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":740,/"line_end/":796,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/espree@9.6.1",
@@ -11286,7 +14769,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":874,/"line_end/":891,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esquery@1.6.0",
@@ -11299,7 +14789,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":892,/"line_end/":904,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esrecurse@4.3.0",
@@ -11312,7 +14809,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":915,/"line_end/":926,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@4.3.0",
@@ -11325,7 +14829,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":936,/"line_end/":944,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/estraverse@5.3.0",
@@ -11338,7 +14849,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":857,/"line_end/":866,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/esutils@2.0.3",
@@ -11351,7 +14869,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":945,/"line_end/":954,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
@@ -11364,7 +14889,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":955,/"line_end/":961,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-glob@3.3.3",
@@ -11377,7 +14909,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":962,/"line_end/":977,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-json-stable-stringify@2.1.0",
@@ -11390,7 +14929,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":990,/"line_end/":996,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fast-levenshtein@2.0.6",
@@ -11403,7 +14949,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":997,/"line_end/":1003,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fastq@1.18.0",
@@ -11416,7 +14969,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1004,/"line_end/":1012,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/file-entry-cache@6.0.1",
@@ -11429,7 +14989,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1013,/"line_end/":1025,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fill-range@7.1.1",
@@ -11442,7 +15009,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1026,/"line_end/":1037,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/find-up@5.0.0",
@@ -11455,7 +15029,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1038,/"line_end/":1054,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flat-cache@3.2.0",
@@ -11468,7 +15049,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1055,/"line_end/":1069,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/flatted@3.3.2",
@@ -11481,7 +15069,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1070,/"line_end/":1076,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/fs.realpath@1.0.0",
@@ -11494,7 +15089,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1077,/"line_end/":1083,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@5.1.2",
@@ -11507,7 +15109,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":978,/"line_end/":989,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob-parent@6.0.2",
@@ -11520,7 +15129,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1106,/"line_end/":1118,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/glob@7.2.3",
@@ -11533,7 +15149,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1084,/"line_end/":1105,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globals@13.24.0",
@@ -11546,7 +15169,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1119,/"line_end/":1134,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/globby@11.1.0",
@@ -11559,7 +15189,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1135,/"line_end/":1154,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/graphemer@1.4.0",
@@ -11572,7 +15209,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1155,/"line_end/":1160,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/has-flag@4.0.0",
@@ -11585,7 +15229,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1161,/"line_end/":1170,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ignore@5.3.2",
@@ -11598,7 +15249,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1171,/"line_end/":1179,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/import-fresh@3.3.0",
@@ -11611,7 +15269,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1180,/"line_end/":1196,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/imurmurhash@0.1.4",
@@ -11624,7 +15289,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1197,/"line_end/":1206,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inflight@1.0.6",
@@ -11637,7 +15309,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1207,/"line_end/":1218,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/inherits@2.0.4",
@@ -11650,7 +15329,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1219,/"line_end/":1225,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-extglob@2.1.1",
@@ -11663,7 +15349,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1226,/"line_end/":1234,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-glob@4.0.3",
@@ -11676,7 +15369,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1235,/"line_end/":1246,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-number@7.0.0",
@@ -11689,7 +15389,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1247,/"line_end/":1255,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/is-path-inside@3.0.3",
@@ -11702,7 +15409,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1256,/"line_end/":1265,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/isexe@2.0.0",
@@ -11715,7 +15429,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1266,/"line_end/":1272,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/js-yaml@4.1.0",
@@ -11728,7 +15449,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1273,/"line_end/":1285,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-buffer@3.0.1",
@@ -11741,7 +15469,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1286,/"line_end/":1292,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-schema-traverse@0.4.1",
@@ -11754,7 +15489,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1293,/"line_end/":1299,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
@@ -11767,7 +15509,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1300,/"line_end/":1306,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/keyv@4.5.4",
@@ -11780,7 +15529,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1307,/"line_end/":1316,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/levn@0.4.1",
@@ -11793,7 +15549,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1317,/"line_end/":1330,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/locate-path@6.0.0",
@@ -11806,7 +15569,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1331,/"line_end/":1346,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/lodash.merge@4.6.2",
@@ -11819,7 +15589,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1347,/"line_end/":1353,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/merge2@1.4.1",
@@ -11832,7 +15609,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1354,/"line_end/":1362,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/micromatch@4.0.8",
@@ -11845,7 +15629,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1363,/"line_end/":1375,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/minimatch@3.1.2",
@@ -11858,7 +15649,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1376,/"line_end/":1388,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@0.7.2",
@@ -11875,7 +15673,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1389,/"line_end/":1395,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/ms@2.1.3",
@@ -11888,7 +15693,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":87,/"line_end/":93,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare-lite@1.4.0",
@@ -11901,7 +15713,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1403,/"line_end/":1408,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/natural-compare@1.4.0",
@@ -11914,7 +15733,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1396,/"line_end/":1402,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/once@1.4.0",
@@ -11927,7 +15753,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1409,/"line_end/":1418,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/optionator@0.9.4",
@@ -11940,7 +15773,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1419,/"line_end/":1436,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-limit@3.1.0",
@@ -11953,7 +15793,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1437,/"line_end/":1452,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/p-locate@5.0.0",
@@ -11966,7 +15813,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1453,/"line_end/":1468,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/parent-module@1.0.1",
@@ -11979,7 +15833,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1469,/"line_end/":1481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-exists@4.0.0",
@@ -11992,7 +15853,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1482,/"line_end/":1491,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
@@ -12005,7 +15873,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1492,/"line_end/":1501,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-key@3.1.1",
@@ -12018,7 +15893,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1502,/"line_end/":1511,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/path-type@4.0.0",
@@ -12031,7 +15913,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1512,/"line_end/":1520,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/picomatch@2.3.1",
@@ -12044,7 +15933,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1521,/"line_end/":1532,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/prelude-ls@1.2.1",
@@ -12057,7 +15953,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1533,/"line_end/":1542,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/punycode@2.3.1",
@@ -12070,7 +15973,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1543,/"line_end/":1552,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/queue-microtask@1.2.3",
@@ -12083,7 +15993,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1553,/"line_end/":1572,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/resolve-from@4.0.0",
@@ -12096,7 +16013,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1573,/"line_end/":1582,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/reusify@1.0.4",
@@ -12109,7 +16033,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1583,/"line_end/":1592,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/rimraf@3.0.2",
@@ -12122,7 +16053,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1593,/"line_end/":1609,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/run-parallel@1.2.0",
@@ -12135,7 +16073,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1610,/"line_end/":1632,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/semver@7.6.3",
@@ -12148,7 +16093,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1633,/"line_end/":1644,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-command@2.0.0",
@@ -12161,7 +16113,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1645,/"line_end/":1657,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/shebang-regex@3.0.0",
@@ -12174,7 +16133,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1658,/"line_end/":1667,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/slash@3.0.0",
@@ -12187,7 +16153,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1668,/"line_end/":1676,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-ansi@6.0.1",
@@ -12200,7 +16173,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1677,/"line_end/":1689,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/strip-json-comments@3.1.1",
@@ -12213,7 +16193,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1690,/"line_end/":1702,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/supports-color@7.2.0",
@@ -12226,7 +16213,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1703,/"line_end/":1715,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/text-table@0.2.0",
@@ -12239,7 +16233,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1716,/"line_end/":1722,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/to-regex-range@5.0.1",
@@ -12252,7 +16253,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1723,/"line_end/":1734,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tslib@1.14.1",
@@ -12265,7 +16273,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1735,/"line_end/":1740,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/tsutils@3.21.0",
@@ -12278,7 +16293,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1741,/"line_end/":1755,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-check@0.4.0",
@@ -12291,7 +16313,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1756,/"line_end/":1768,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/type-fest@0.20.2",
@@ -12304,7 +16333,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1769,/"line_end/":1781,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/typescript@5.7.3",
@@ -12317,7 +16353,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1782,/"line_end/":1795,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/uri-js@4.4.1",
@@ -12330,7 +16373,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1796,/"line_end/":1805,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/which@2.0.2",
@@ -12343,7 +16393,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1806,/"line_end/":1821,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/word-wrap@1.2.5",
@@ -12356,7 +16413,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1822,/"line_end/":1831,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/wrappy@1.0.2",
@@ -12369,7 +16433,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1832,/"line_end/":1838,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     },
     {
       "bom-ref": "pkg:npm/yocto-queue@0.1.0",
@@ -12382,7 +16453,14 @@ Warning: `scan` exists as both a subcommand of datadog-sbom-generator and as a f
           "name": "datadog:package-manager",
           "value": "NPM"
         }
-      ]
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"package-lock.json/",/"line_start/":1839,/"line_end/":1851,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+          }
+        ]
+      }
     }
   ]
 }
@@ -12771,6 +16849,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -12778,7 +16860,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5280,/"line_end/":5332,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -12819,6 +16901,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -12826,7 +16912,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5387,/"line_end/":5481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":25,/"column_end/":33,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -12999,6 +17085,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13006,7 +17096,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5482,/"line_end/":5544,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":24,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13351,6 +17441,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13358,7 +17452,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5679,/"line_end/":5733,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13399,6 +17493,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13406,7 +17504,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5783,/"line_end/":5828,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13423,6 +17521,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13430,7 +17532,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5829,/"line_end/":5875,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13495,6 +17597,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13502,7 +17608,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5932,/"line_end/":6014,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":25,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13703,6 +17809,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13710,7 +17820,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6199,/"line_end/":6276,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":5,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":6,/"column_end/":17,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":21,/"column_end/":25,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13727,6 +17837,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13734,7 +17848,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6277,/"line_end/":6342,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":5,/"column_end/":29,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":24,/"column_end/":28,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13819,6 +17933,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13826,7 +17944,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6461,/"line_end/":6518,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":5,/"column_end/":33,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":25,/"column_end/":32,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13963,6 +18081,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13970,7 +18092,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6842,/"line_end/":6941,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":5,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":25,/"column_end/":36,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -13987,6 +18109,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -13994,7 +18120,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6942,/"line_end/":7002,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":23,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -14271,6 +18397,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -14278,7 +18408,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7052,/"line_end/":7108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":71,/"line_end/":71,/"column_start/":5,/"column_end/":35,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":71,/"line_end/":71,/"column_start/":6,/"column_end/":23,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":71,/"line_end/":71,/"column_start/":27,/"column_end/":34,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -14703,6 +18833,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -14710,7 +18844,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8094,/"line_end/":8190,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":72,/"line_end/":72,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":72,/"line_end/":72,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":72,/"line_end/":72,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -14923,6 +19057,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -14930,7 +19068,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8267,/"line_end/":8360,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":73,/"line_end/":73,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":73,/"line_end/":73,/"column_start/":6,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":73,/"line_end/":73,/"column_start/":29,/"column_end/":33,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -15251,6 +19389,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -15258,7 +19400,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8439,/"line_end/":8521,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":74,/"line_end/":74,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":74,/"line_end/":74,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":74,/"line_end/":74,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -18745,6 +22887,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -18752,7 +22898,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5280,/"line_end/":5332,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -18793,6 +22939,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -18800,7 +22950,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5387,/"line_end/":5481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":25,/"column_end/":33,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -18973,6 +23123,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -18980,7 +23134,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5482,/"line_end/":5544,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":24,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19325,6 +23479,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19332,7 +23490,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5679,/"line_end/":5733,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19373,6 +23531,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19380,7 +23542,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5783,/"line_end/":5828,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19397,6 +23559,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19404,7 +23570,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5829,/"line_end/":5875,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19469,6 +23635,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19476,7 +23646,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5932,/"line_end/":6014,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":25,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19677,6 +23847,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19684,7 +23858,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6199,/"line_end/":6276,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":5,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":6,/"column_end/":17,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":21,/"column_end/":25,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19701,6 +23875,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19708,7 +23886,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6277,/"line_end/":6342,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":5,/"column_end/":29,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":24,/"column_end/":28,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19793,6 +23971,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19800,7 +23982,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6461,/"line_end/":6518,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":5,/"column_end/":33,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":25,/"column_end/":32,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19937,6 +24119,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19944,7 +24130,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6842,/"line_end/":6941,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":5,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":25,/"column_end/":36,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -19961,6 +24147,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -19968,7 +24158,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6942,/"line_end/":7002,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":23,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -20245,6 +24435,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -20252,7 +24446,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7052,/"line_end/":7108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":5,/"column_end/":35,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":6,/"column_end/":23,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":27,/"column_end/":34,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -20677,6 +24871,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -20684,7 +24882,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8094,/"line_end/":8190,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -20897,6 +25095,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -20904,7 +25106,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8267,/"line_end/":8360,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":6,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":29,/"column_end/":33,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -21225,6 +25427,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -21232,7 +25438,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8439,/"line_end/":8521,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -24644,6 +28850,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -24651,7 +28861,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5280,/"line_end/":5332,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":55,/"line_end/":55,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -24692,6 +28902,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -24699,7 +28913,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5387,/"line_end/":5481,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":56,/"line_end/":56,/"column_start/":25,/"column_end/":33,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -24872,6 +29086,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -24879,7 +29097,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5482,/"line_end/":5544,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":57,/"line_end/":57,/"column_start/":24,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25224,6 +29442,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25231,7 +29453,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5679,/"line_end/":5733,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":58,/"line_end/":58,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25272,6 +29494,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25279,7 +29505,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5783,/"line_end/":5828,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":59,/"line_end/":59,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25296,6 +29522,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25303,7 +29533,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5829,/"line_end/":5875,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":5,/"column_end/":41,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":6,/"column_end/":32,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":60,/"line_end/":60,/"column_start/":36,/"column_end/":40,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25368,6 +29598,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25375,7 +29609,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":5932,/"line_end/":6014,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":61,/"line_end/":61,/"column_start/":25,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25576,6 +29810,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25583,7 +29821,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6199,/"line_end/":6276,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":5,/"column_end/":26,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":6,/"column_end/":17,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":62,/"line_end/":62,/"column_start/":21,/"column_end/":25,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25600,6 +29838,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25607,7 +29849,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6277,/"line_end/":6342,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":5,/"column_end/":29,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":6,/"column_end/":20,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":63,/"line_end/":63,/"column_start/":24,/"column_end/":28,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25692,6 +29934,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25699,7 +29945,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6461,/"line_end/":6518,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":5,/"column_end/":33,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":64,/"line_end/":64,/"column_start/":25,/"column_end/":32,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25836,6 +30082,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25843,7 +30093,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6842,/"line_end/":6941,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":5,/"column_end/":37,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":6,/"column_end/":21,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":65,/"line_end/":65,/"column_start/":25,/"column_end/":36,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -25860,6 +30110,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -25867,7 +30121,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":6942,/"line_end/":7002,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":5,/"column_end/":30,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":66,/"line_end/":66,/"column_start/":23,/"column_end/":29,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -26144,6 +30398,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -26151,7 +30409,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":7052,/"line_end/":7108,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":5,/"column_end/":35,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":6,/"column_end/":23,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":67,/"line_end/":67,/"column_start/":27,/"column_end/":34,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -26576,6 +30834,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -26583,7 +30845,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8094,/"line_end/":8190,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":5,/"column_end/":28,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":6,/"column_end/":19,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":68,/"line_end/":68,/"column_start/":23,/"column_end/":27,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -26796,6 +31058,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -26803,7 +31069,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8267,/"line_end/":8360,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":5,/"column_end/":34,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":6,/"column_end/":25,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":69,/"line_end/":69,/"column_start/":29,/"column_end/":33,/"role/":/"manifest/"}}"
           }
         ]
       }
@@ -27124,6 +31390,10 @@ No package sources found. Use the 'parsers list' command to view supported lockf
           "value": "true"
         },
         {
+          "name": "datadog:is-direct",
+          "value": "true"
+        },
+        {
           "name": "datadog:package-manager",
           "value": "Composer"
         }
@@ -27131,7 +31401,7 @@ No package sources found. Use the 'parsers list' command to view supported lockf
       "evidence": {
         "occurrences": [
           {
-            "location": "{/"block/":{/"file_name/":/"composer/composer.lock/",/"line_start/":8439,/"line_end/":8521,/"column_start/":9,/"column_end/":10,/"role/":/"lockfile/"}}"
+            "location": "{/"block/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":5,/"column_end/":46,/"role/":/"manifest/"},/"name/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":6,/"column_end/":37,/"role/":/"manifest/"},/"version/":{/"file_name/":/"composer/composer.json/",/"line_start/":70,/"line_end/":70,/"column_start/":41,/"column_end/":45,/"role/":/"manifest/"}}"
           }
         ]
       }

--- a/internal/output/sbom/cyclonedx.go
+++ b/internal/output/sbom/cyclonedx.go
@@ -100,6 +100,9 @@ func addLocations(component *cyclonedx.Component, details models.PackageVulns) {
 		seenLocations[jsonLocation] = struct{}{}
 	}
 	if len(occurrences) > 0 {
+		slices.SortFunc(occurrences, func(a, b cyclonedx.EvidenceOccurrence) int {
+			return strings.Compare(a.Location, b.Location)
+		})
 		component.Evidence = &cyclonedx.Evidence{Occurrences: &occurrences}
 	}
 }

--- a/pkg/extractor/internal/testutil/helpers.go
+++ b/pkg/extractor/internal/testutil/helpers.go
@@ -84,7 +84,7 @@ func HasPackage(t *testing.T, expectedPkgs []extractor.PackageDetails, currentPk
 	for _, expectedPkg := range expectedPkgs {
 		var ignore []string
 		if ignoreLocations {
-			ignore = []string{"BlockLocation", "NameLocation", "VersionLocation"}
+			ignore = []string{"BlockLocation", "LocationRole", "NameLocation", "VersionLocation"}
 		}
 
 		if cmp.Equal(expectedPkg, currentPkg, cmpopts.IgnoreFields(extractor.PackageDetails{}, ignore...)) {

--- a/pkg/extractor/javascript/match-package-json.go
+++ b/pkg/extractor/javascript/match-package-json.go
@@ -65,8 +65,13 @@ func (depMap *packageJSONDependencyMap) UnmarshalJSON(data []byte) error {
 		}
 
 		if (depMap.RootType == typeDevDependencies || depMap.RootType == typeOptionalDependencies) && pkg.LocationRole == models.LocationRoleManifest {
-			// If it is a dev or optional dependency definition and we already found a manifest location,
-			// we skip it to prioritize non-dev dependencies
+			// If it is a dev or optional dependency definition and this package was already
+			// matched to a manifest location (e.g. the root package.json "dependencies" section,
+			// or an earlier workspace package.json), skip the overwrite to prioritize the
+			// non-dev/non-optional manifest location.
+			// We check LocationRole rather than BlockLocation.Filename so that cross-workspace
+			// matches are also guarded: a root prod-dep match sets LocationRole=manifest, and
+			// a subsequent workspace dev-dep section for the same package must not overwrite it.
 			pkgIndexes = []int{}
 		}
 		depMap.UpdatePackageDetails(pkg, packageJSONContent, pkgIndexes, depGroup)

--- a/pkg/extractor/javascript/node-modules-npm-v1_test.go
+++ b/pkg/extractor/javascript/node-modules-npm-v1_test.go
@@ -36,7 +36,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -55,7 +55,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -74,7 +74,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -100,7 +100,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -126,7 +126,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -178,29 +178,29 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 		t.Errorf("Expected to get 39 packages, but got %d", len(packages))
 	}
 
-	testutil.ExpectPackage(t, packages, extractor.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, extractor.PackageDetails{
 		Name:           "supports-color",
 		Version:        "6.1.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, extractor.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, extractor.PackageDetails{
 		Name:           "supports-color",
 		Version:        "5.5.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, extractor.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, extractor.PackageDetails{
 		Name:           "supports-color",
 		Version:        "2.0.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 }
 
 func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
@@ -211,7 +211,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "",

--- a/pkg/extractor/javascript/node-modules-npm-v2_test.go
+++ b/pkg/extractor/javascript/node-modules-npm-v2_test.go
@@ -14,7 +14,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_InvalidJson(t *testing.T) {
 	packages, err := testParsingNodeModules(t, "../fixtures/npm/not-json.txt")
 
 	testutil.ExpectErrContaining(t, err, "could not extract from")
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{})
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{})
 }
 
 func TestNodeModulesExtractor_Extract_npm_v2_NoPackages(t *testing.T) {
@@ -25,7 +25,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{})
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{})
 }
 
 func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
@@ -36,7 +36,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -56,7 +56,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -76,7 +76,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -104,7 +104,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -130,7 +130,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -177,7 +177,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "supports-color",
 			Version:        "6.1.0",
@@ -203,7 +203,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "2.4.1",
@@ -339,7 +339,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "etag",
 			Version:        "1.8.0",
@@ -376,7 +376,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.0.0",
@@ -412,7 +412,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",

--- a/pkg/extractor/javascript/parse-npm-lock-v1_test.go
+++ b/pkg/extractor/javascript/parse-npm-lock-v1_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor/internal/testutil"
 	"github.com/DataDog/datadog-sbom-generator/pkg/extractor/javascript"
 	"github.com/DataDog/datadog-sbom-generator/pkg/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseNpmLock_v1_FileDoesNotExist(t *testing.T) {
@@ -54,7 +56,7 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -63,6 +65,34 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 			DepGroups:      []string{"prod"},
 		},
 	})
+}
+
+func TestParseNpmLock_v1_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/npm/one-package.v1.json"))
+	packages, err := javascript.ParseNpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// Every package must have a valid BlockLocation from the lockfile
+	for _, pkg := range packages {
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Positive(t, pkg.BlockLocation.Line.End,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Positive(t, pkg.BlockLocation.Column.End,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
 }
 
 func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
@@ -78,7 +108,7 @@ func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -102,7 +132,7 @@ func TestParseNpmLock_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -133,7 +163,7 @@ func TestParseNpmLock_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
@@ -164,7 +194,7 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "postcss",
 			Version:        "6.0.23",
@@ -221,29 +251,29 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		t.Errorf("Expected to get 39 packages, but got %d", len(packages))
 	}
 
-	testutil.ExpectPackage(t, packages, extractor.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, extractor.PackageDetails{
 		Name:           "supports-color",
 		Version:        "6.1.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, extractor.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, extractor.PackageDetails{
 		Name:           "supports-color",
 		Version:        "5.5.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 
-	testutil.ExpectPackage(t, packages, extractor.PackageDetails{
+	testutil.InnerExpectPackage(t, packages, extractor.PackageDetails{
 		Name:           "supports-color",
 		Version:        "2.0.0",
 		PackageManager: models.NPM,
 		Ecosystem:      models.EcosystemNPM,
 		DepGroups:      []string{"prod"},
-	})
+	}, true)
 }
 
 func TestParseNpmLock_v1_Commits(t *testing.T) {
@@ -259,7 +289,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "",
@@ -396,7 +426,7 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "lodash",
 			Version:        "1.3.1",
@@ -429,7 +459,7 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.0.0",
@@ -467,7 +497,7 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	testutil.ExpectPackages(t, packages, []extractor.PackageDetails{
+	testutil.ExpectPackagesWithoutLocations(t, packages, []extractor.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",

--- a/pkg/extractor/javascript/parse-npm-lock-v2_test.go
+++ b/pkg/extractor/javascript/parse-npm-lock-v2_test.go
@@ -86,6 +86,34 @@ func TestParseNpmLock_v2_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseNpmLock_v2_OnePackage_BlockLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "../fixtures/npm/one-package.v2.json"))
+	packages, err := javascript.ParseNpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	// Every package must have a valid BlockLocation from the lockfile
+	for _, pkg := range packages {
+		assert.Positive(t, pkg.BlockLocation.Line.Start,
+			"package %s@%s should have BlockLocation.Line.Start > 0", pkg.Name, pkg.Version)
+		assert.Positive(t, pkg.BlockLocation.Line.End,
+			"package %s@%s should have BlockLocation.Line.End > 0", pkg.Name, pkg.Version)
+		assert.Positive(t, pkg.BlockLocation.Column.Start,
+			"package %s@%s should have BlockLocation.Column.Start > 0", pkg.Name, pkg.Version)
+		assert.Positive(t, pkg.BlockLocation.Column.End,
+			"package %s@%s should have BlockLocation.Column.End > 0", pkg.Name, pkg.Version)
+		assert.NotEmpty(t, pkg.BlockLocation.Filename,
+			"package %s@%s should have BlockLocation.Filename set", pkg.Name, pkg.Version)
+	}
+}
+
 //nolint:paralleltest
 func TestParseNpmLock_v2_OnePackage_MatcherFailed(t *testing.T) {
 	dir, err := os.Getwd()
@@ -959,9 +987,14 @@ func TestParseNpmLock_v2_WorkspacesComplex(t *testing.T) {
 			Version:        "1.4.0",
 			PackageManager: models.NPM,
 			Ecosystem:      models.EcosystemNPM,
-			BlockLocation:  models.FilePosition{},
-			IsDirect:       false, // is a dependency of group-dependencies@0.0.11
-			DepGroups:      []string{"dev"},
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 37, End: 46},
+				Column:   models.Position{Start: 5, End: 6},
+				Filename: path,
+			},
+			LocationRole: models.LocationRoleLockfile,
+			IsDirect:     false, // is a dependency of group-dependencies@0.0.11
+			DepGroups:    []string{"dev"},
 		},
 		{
 			Name:           "semver",

--- a/pkg/extractor/javascript/parse-npm-lock.go
+++ b/pkg/extractor/javascript/parse-npm-lock.go
@@ -54,6 +54,12 @@ func (pdm npmPackageDetailsMap) add(key string, details extractor.PackageDetails
 
 	if ok {
 		details.DepGroups = mergeNpmDepsGroups(existing, details)
+		// Keep the earlier lockfile location to ensure deterministic output
+		// (multiple node_modules paths may resolve to the same package key)
+		if existing.BlockLocation.Line.Start > 0 &&
+			(details.BlockLocation.Line.Start == 0 || existing.BlockLocation.Line.Start < details.BlockLocation.Line.Start) {
+			details.BlockLocation = existing.BlockLocation
+		}
 	}
 
 	pdm[key] = details
@@ -73,7 +79,7 @@ func (dep *NpmLockDependency) depGroups() []string {
 	return groups
 }
 
-func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[string]extractor.PackageDetails {
+func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency, sourceFile string) map[string]extractor.PackageDetails {
 	details := npmPackageDetailsMap{}
 
 	keys := reflect.ValueOf(dependencies).MapKeys()
@@ -84,7 +90,7 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 		name := key.Interface().(string)
 		detail := dependencies[name]
 		if detail.Dependencies != nil {
-			nestedDeps := parseNpmLockDependencies(detail.Dependencies)
+			nestedDeps := parseNpmLockDependencies(detail.Dependencies, sourceFile)
 			for k, v := range nestedDeps {
 				details.add(k, v)
 			}
@@ -118,6 +124,9 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 			}
 		}
 
+		blockLocation := detail.FilePosition
+		blockLocation.Filename = sourceFile
+
 		details.add(name+"@"+version, extractor.PackageDetails{
 			Name:           name,
 			Version:        finalVersion,
@@ -125,6 +134,8 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 			Ecosystem:      models.EcosystemNPM,
 			Commit:         commit,
 			DepGroups:      detail.depGroups(),
+			BlockLocation:  blockLocation,
+			LocationRole:   models.LocationRoleLockfile,
 		})
 	}
 
@@ -244,6 +255,7 @@ func processWorkspacePackages(
 	declaredWorkspacePackages map[string]*NpmLockPackage,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for workspacePath, workspacePkg := range declaredWorkspacePackages {
 		allDeps := make(map[string]string)
@@ -266,6 +278,7 @@ func processWorkspacePackages(
 				TargetVersion:     targetVersion,
 				DeclarationPath:   workspacePath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			}
 
 			if resolvedPkg, exists := resolvedPackages[workspaceNodeModulesPath]; exists {
@@ -295,6 +308,7 @@ func processRootPackages(
 	declaredRootPackages map[string]string,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for depName, targetVersion := range declaredRootPackages {
 		rootNodeModulesPath := getRootResolvedPath(depName)
@@ -307,6 +321,7 @@ func processRootPackages(
 				DeclarationPath:   "",
 				PhysicalPath:      rootNodeModulesPath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			})
 		}
 	}
@@ -317,6 +332,7 @@ func processLocalPackages(
 	localPackages map[string]*NpmLockPackage,
 	declaredRootPackages map[string]string,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for localPath, localPkg := range localPackages {
 		depName := path.Base(localPath)
@@ -335,6 +351,7 @@ func processLocalPackages(
 			DeclarationPath:   "",
 			PhysicalPath:      localPath,
 			ProcessedPackages: processedPackages,
+			SourceFile:        sourceFile,
 		})
 	}
 }
@@ -343,6 +360,7 @@ func processRemainingPackages(
 	details npmPackageDetailsMap,
 	resolvedPackages map[string]*NpmLockPackage,
 	processedPackages *map[string]bool,
+	sourceFile string,
 ) {
 	for physicalPath, pkg := range resolvedPackages {
 		if !(*processedPackages)[physicalPath] {
@@ -355,6 +373,7 @@ func processRemainingPackages(
 				DeclarationPath:   "",
 				PhysicalPath:      physicalPath,
 				ProcessedPackages: processedPackages,
+				SourceFile:        sourceFile,
 			})
 		}
 	}
@@ -368,6 +387,7 @@ type packageProcessingParams struct {
 	DeclarationPath   string
 	PhysicalPath      string
 	ProcessedPackages *map[string]bool
+	SourceFile        string
 }
 
 func processPackage(params packageProcessingParams) {
@@ -413,6 +433,9 @@ func processPackage(params packageProcessingParams) {
 		location = &models.FilePosition{Filename: params.DeclarationPath}
 	}
 
+	blockLocation := params.Pkg.FilePosition
+	blockLocation.Filename = params.SourceFile
+
 	packageUniqKey := getWorkspaceDependencyKey(finalName, finalVersion, params.DeclarationPath)
 	params.Details.add(packageUniqKey, extractor.PackageDetails{
 		Name:           finalName,
@@ -422,6 +445,8 @@ func processPackage(params packageProcessingParams) {
 		Ecosystem:      models.EcosystemNPM,
 		Commit:         commit,
 		DepGroups:      params.Pkg.depGroups(),
+		BlockLocation:  blockLocation,
+		LocationRole:   models.LocationRoleLockfile,
 		NameLocation:   location,
 	})
 
@@ -429,7 +454,7 @@ func processPackage(params packageProcessingParams) {
 	(*params.ProcessedPackages)[params.PhysicalPath] = true
 }
 
-func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]extractor.PackageDetails {
+func parseNpmLockPackages(packages map[string]*NpmLockPackage, sourceFile string) map[string]extractor.PackageDetails {
 	details := npmPackageDetailsMap{}
 
 	workspacePatterns := extractWorkspacePatterns(packages)
@@ -437,10 +462,10 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]extrac
 
 	processedPackages := make(map[string]bool) // makes sure we do not process the same package twice (meaningful with the support of workspaces)
 
-	processRootPackages(details, categorized.DeclaredRoot, categorized.Resolved, &processedPackages)
-	processWorkspacePackages(details, categorized.DeclaredWorkspace, categorized.Resolved, &processedPackages)
-	processLocalPackages(details, categorized.Local, categorized.DeclaredRoot, &processedPackages)
-	processRemainingPackages(details, categorized.Resolved, &processedPackages)
+	processRootPackages(details, categorized.DeclaredRoot, categorized.Resolved, &processedPackages, sourceFile)
+	processWorkspacePackages(details, categorized.DeclaredWorkspace, categorized.Resolved, &processedPackages, sourceFile)
+	processLocalPackages(details, categorized.Local, categorized.DeclaredRoot, &processedPackages, sourceFile)
+	processRemainingPackages(details, categorized.Resolved, &processedPackages, sourceFile)
 
 	return details
 }
@@ -449,12 +474,12 @@ func parseNpmLock(lockfile NpmLockfile, lines []string) map[string]extractor.Pac
 	if lockfile.Packages != nil {
 		fileposition.InJSON("packages", lockfile.Packages, lines, 0)
 
-		return parseNpmLockPackages(lockfile.Packages)
+		return parseNpmLockPackages(lockfile.Packages, lockfile.SourceFile)
 	}
 
 	fileposition.InJSON("dependencies", lockfile.Dependencies, lines, 0)
 
-	return parseNpmLockDependencies(lockfile.Dependencies)
+	return parseNpmLockDependencies(lockfile.Dependencies, lockfile.SourceFile)
 }
 
 func getWorkspaceDependencyKey(pkgName string, pkgVersion string, workspace string) string {
@@ -488,7 +513,7 @@ func (e NpmLockExtractor) Extract(f extractor.DepFile, context extractor.ScanCon
 		return []extractor.PackageDetails{}, fmt.Errorf("could not read from %s: %w", f.Path(), err)
 	}
 	contentString := string(contentBytes)
-	lines := strings.Split(contentString, "\n")
+	lines := strings.Split(strings.ReplaceAll(contentString, "\r\n", "\n"), "\n")
 	decoder := json.NewDecoder(strings.NewReader(contentString))
 
 	if err := decoder.Decode(&parsedLockfile); err != nil {

--- a/pkg/extractor/php/match-composer.go
+++ b/pkg/extractor/php/match-composer.go
@@ -35,9 +35,12 @@ func (depMap *ComposerMatcherDependencyMap) UnmarshalJSON(bytes []byte) error {
 	content := string(bytes)
 
 	for _, pkg := range depMap.Packages {
-		if depMap.RootType == typeRequireDev && pkg.BlockLocation.Line.Start != 0 {
-			// If it is dev dependency definition and we already found a package location,
-			// we skip it to prioritize non-dev dependencies
+		if depMap.RootType == typeRequireDev && pkg.BlockLocation.Filename == depMap.FilePath {
+			// If it is dev dependency definition and this package's BlockLocation already
+			// points to the current source file (meaning a prior section like "require"
+			// already set it), skip the location overwrite to prioritize non-dev dependencies.
+			// We compare Filename rather than checking Line.Start != 0 because extractors
+			// may now set BlockLocation from the lockfile for all packages.
 			continue
 		}
 		pkgIndexes := jsonUtils.ExtractPackageIndexes(pkg.Name, "", content)


### PR DESCRIPTION
What does this PR do?
---------------------

- Reapplies #141 (BlockLocation + LocationRole=lockfile support for npm), which was reverted in #152 due to concerns about SBOM size increase.
- The size-increase concern has since been resolved, so npm can now regain block location/role support, bringing it in line with the other lockfile-based ecosystems (Yarn, pnpm, Composer, etc.).

This is a `git revert` of the revert commit (`3ce0b13`), with merge conflicts resolved against the current `pkg/extractor` package layout (renamed from `pkg/lockfile` in #156 after the original revert), and snapshots regenerated via `UPDATE_SNAPS=true`.